### PR TITLE
TSK-110: Generate workbasket level report for total count of tasks

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/TaskMonitorService.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/TaskMonitorService.java
@@ -3,6 +3,7 @@ package pro.taskana;
 import java.util.List;
 
 import pro.taskana.model.DueWorkbasketCounter;
+import pro.taskana.model.Report;
 import pro.taskana.model.TaskState;
 import pro.taskana.model.TaskStateCounter;
 
@@ -47,5 +48,17 @@ public interface TaskMonitorService {
      *         with appropriate due date exist in the various work baskets
      */
     List<DueWorkbasketCounter> getTaskCountByWorkbasketAndDaysInPastAndState(long daysInPast, List<TaskState> states);
+
+    /**
+     * Returns a {@link Report} for a given list of {@link Workbasket} objects and for a given list of {@link TaskState}
+     * objects.
+     *
+     * @param workbaskets
+     *            a list of {@link Workbasket} objects
+     * @param states
+     *            a list of {@link TaskState} objects
+     * @return a {@link Report} object
+     */
+    Report getWorkbasketLevelReport(List<Workbasket> workbaskets, List<TaskState> states);
 
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/model/Report.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/Report.java
@@ -1,0 +1,35 @@
+package pro.taskana.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A Report represents a table that consists of {@link ReportLine} objects.
+ */
+public class Report {
+
+    private List<ReportLine> detailLines;
+    private ReportLine sumLine;
+
+    public Report() {
+        this.detailLines = new ArrayList<>();
+        this.sumLine = new ReportLine();
+    }
+
+    public List<ReportLine> getDetailLines() {
+        return detailLines;
+    }
+
+    public void setDetailLines(List<ReportLine> detailLines) {
+        this.detailLines = detailLines;
+    }
+
+    public ReportLine getSumLine() {
+        return sumLine;
+    }
+
+    public void setSumLine(ReportLine sumLine) {
+        this.sumLine = sumLine;
+    }
+
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/model/ReportLine.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/ReportLine.java
@@ -1,0 +1,44 @@
+package pro.taskana.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Each ReportLine consists of a name, a list of {@link ReportLineItem} objects and a totalCount that represents the
+ * count of all tasks.
+ */
+public class ReportLine {
+
+    private String name;
+    private List<ReportLineItem> lineItems;
+    private int totalCount;
+
+    public ReportLine() {
+        this.lineItems = new ArrayList<>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<ReportLineItem> getLineItems() {
+        return lineItems;
+    }
+
+    public void setLineItems(List<ReportLineItem> lineItems) {
+        this.lineItems = lineItems;
+    }
+
+    public int getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(int totalCount) {
+        this.totalCount = totalCount;
+    }
+
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/model/ReportLineItem.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/ReportLineItem.java
@@ -1,0 +1,28 @@
+package pro.taskana.model;
+
+/**
+ * Each ReportLineItem consists of a {@link ReportLineItemDefinition} that defines the upper and lower limits of this
+ * item and a count value that represents the count of tasks of this item.
+ */
+public class ReportLineItem {
+
+    private ReportLineItemDefinition reportLineItemDefinition;
+    private int count;
+
+    public ReportLineItemDefinition getReportLineItemDefinition() {
+        return reportLineItemDefinition;
+    }
+
+    public void setReportLineItemDefinition(ReportLineItemDefinition reportLineItemDefinition) {
+        this.reportLineItemDefinition = reportLineItemDefinition;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public void setCount(int count) {
+        this.count = count;
+    }
+
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/model/ReportLineItemDefinition.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/ReportLineItemDefinition.java
@@ -1,0 +1,28 @@
+package pro.taskana.model;
+
+/**
+ * A ReportLineItemDefinition has a lower and an upper limit which subdivide the count of tasks in a workbasket into
+ * different sections.
+ */
+public class ReportLineItemDefinition {
+
+    private int lowerLimit;
+    private int upperLimit;
+
+    public int getLowerLimit() {
+        return lowerLimit;
+    }
+
+    public void setLowerLimit(int lowerLimit) {
+        this.lowerLimit = lowerLimit;
+    }
+
+    public int getUpperLimit() {
+        return upperLimit;
+    }
+
+    public void setUpperLimit(int upperLimit) {
+        this.upperLimit = upperLimit;
+    }
+
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/model/mappings/TaskMonitorMapper.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/mappings/TaskMonitorMapper.java
@@ -8,7 +8,9 @@ import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 
+import pro.taskana.Workbasket;
 import pro.taskana.model.DueWorkbasketCounter;
+import pro.taskana.model.ReportLine;
 import pro.taskana.model.TaskState;
 import pro.taskana.model.TaskStateCounter;
 
@@ -47,6 +49,18 @@ public interface TaskMonitorMapper {
         @Result(column = "WORKBASKETID", property = "workbasketId"),
         @Result(column = "counter", property = "taskCounter") })
     List<DueWorkbasketCounter> getTaskCountByWorkbasketIdAndDaysInPastAndState(@Param("fromDate") Date fromDate,
+        @Param("status") List<TaskState> states);
+
+    @Select("<script>"
+        + "SELECT WORKBASKET_KEY, COUNT(WORKBASKET_KEY) as counter "
+        + "FROM TASK "
+        + "WHERE WORKBASKET_KEY IN (<foreach collection='workbaskets' item='workbasket' separator=','>#{workbasket.key}</foreach>) "
+        + "AND STATE IN (<foreach collection='status' item='state' separator=','>#{state}</foreach>) "
+        + "GROUP BY WORKBASKET_KEY"
+        + "</script>")
+    @Results({ @Result(column = "WORKBASKET_KEY", property = "name"),
+        @Result(column = "counter", property = "totalCount") })
+    List<ReportLine> getDetailLinesByWorkbasketIdsAndStates(@Param("workbaskets") List<Workbasket> workbaskets,
         @Param("status") List<TaskState> states);
 
 }

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/TaskMonitorServiceImplTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/TaskMonitorServiceImplTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,9 +23,12 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import pro.taskana.Workbasket;
 import pro.taskana.WorkbasketService;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.model.DueWorkbasketCounter;
+import pro.taskana.model.Report;
+import pro.taskana.model.ReportLine;
 import pro.taskana.model.TaskState;
 import pro.taskana.model.TaskStateCounter;
 import pro.taskana.model.mappings.ObjectReferenceMapper;
@@ -117,6 +121,26 @@ public class TaskMonitorServiceImplTest {
         verifyNoMoreInteractions(taskanaEngineConfigurationMock, taskanaEngineMock, taskanaEngineImpl,
             taskMonitorMapperMock, objectReferenceMapperMock, workbasketServiceMock);
         assertThat(actualResult, equalTo(expectedResult));
+    }
+
+    @Test
+    public void testGetWorkbasketLevelReport() {
+        List<Workbasket> workbaskets = Arrays.asList(new WorkbasketImpl(), new WorkbasketImpl());
+        List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
+
+        Report expectedResult = new Report();
+        List<ReportLine> expectedDetailLines = new ArrayList<>();
+        doReturn(expectedDetailLines).when(taskMonitorMapperMock).getDetailLinesByWorkbasketIdsAndStates(any(), any());
+
+        Report actualResult = cut.getWorkbasketLevelReport(workbaskets, states);
+
+        verify(taskanaEngineImpl, times(1)).openConnection();
+        verify(taskMonitorMapperMock, times(1)).getDetailLinesByWorkbasketIdsAndStates(any(), any());
+        verify(taskanaEngineImpl, times(1)).returnConnection();
+        verifyNoMoreInteractions(taskanaEngineConfigurationMock, taskanaEngineMock, taskanaEngineImpl,
+            taskMonitorMapperMock, objectReferenceMapperMock, workbasketServiceMock);
+        Assert.assertNotNull(actualResult);
+        assertThat(actualResult.getDetailLines(), equalTo(expectedResult.getDetailLines()));
     }
 
 }

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskMonitorServiceImplIntAutocommitTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskMonitorServiceImplIntAutocommitTest.java
@@ -1,0 +1,179 @@
+package pro.taskana.impl.integration;
+
+import java.io.FileNotFoundException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.security.auth.login.LoginException;
+import javax.sql.DataSource;
+
+import org.h2.store.fs.FileUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import pro.taskana.Classification;
+import pro.taskana.ClassificationService;
+import pro.taskana.TaskMonitorService;
+import pro.taskana.TaskanaEngine;
+import pro.taskana.TaskanaEngine.ConnectionManagementMode;
+import pro.taskana.Workbasket;
+import pro.taskana.WorkbasketService;
+import pro.taskana.configuration.TaskanaEngineConfiguration;
+import pro.taskana.exceptions.ClassificationAlreadyExistException;
+import pro.taskana.exceptions.ClassificationNotFoundException;
+import pro.taskana.exceptions.InvalidArgumentException;
+import pro.taskana.exceptions.InvalidOwnerException;
+import pro.taskana.exceptions.InvalidStateException;
+import pro.taskana.exceptions.InvalidWorkbasketException;
+import pro.taskana.exceptions.NotAuthorizedException;
+import pro.taskana.exceptions.TaskAlreadyExistException;
+import pro.taskana.exceptions.TaskNotFoundException;
+import pro.taskana.exceptions.WorkbasketNotFoundException;
+import pro.taskana.impl.JunitHelper;
+import pro.taskana.impl.TaskImpl;
+import pro.taskana.impl.TaskServiceImpl;
+import pro.taskana.impl.TaskanaEngineImpl;
+import pro.taskana.impl.WorkbasketImpl;
+import pro.taskana.impl.configuration.DBCleaner;
+import pro.taskana.impl.configuration.TaskanaEngineConfigurationTest;
+import pro.taskana.impl.util.IdGenerator;
+import pro.taskana.model.Report;
+import pro.taskana.model.TaskState;
+import pro.taskana.model.WorkbasketAccessItem;
+import pro.taskana.model.WorkbasketType;
+import pro.taskana.security.JAASRunner;
+import pro.taskana.security.WithAccessId;
+
+/**
+ * Integration Test for TaskMonitorServiceImpl transactions with connection management mode AUTOCOMMIT.
+ */
+@RunWith(JAASRunner.class)
+public class TaskMonitorServiceImplIntAutocommitTest {
+
+    private DataSource dataSource;
+    private TaskServiceImpl taskServiceImpl;
+    private TaskanaEngineConfiguration taskanaEngineConfiguration;
+    private TaskanaEngine taskanaEngine;
+    private TaskanaEngineImpl taskanaEngineImpl;
+    private ClassificationService classificationService;
+    private WorkbasketService workBasketService;
+    private TaskMonitorService taskMonitorService;
+
+    @BeforeClass
+    public static void resetDb() throws SQLException {
+        DataSource ds = TaskanaEngineConfigurationTest.getDataSource();
+        DBCleaner cleaner = new DBCleaner();
+        cleaner.clearDb(ds, true);
+    }
+
+    @Before
+    public void setup() throws FileNotFoundException, SQLException, LoginException {
+        dataSource = TaskanaEngineConfigurationTest.getDataSource();
+        taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
+        taskServiceImpl = (TaskServiceImpl) taskanaEngine.getTaskService();
+        taskanaEngineImpl = (TaskanaEngineImpl) taskanaEngine;
+        classificationService = taskanaEngine.getClassificationService();
+        taskanaEngineImpl.setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
+        workBasketService = taskanaEngine.getWorkbasketService();
+        taskMonitorService = taskanaEngine.getTaskMonitorService();
+        DBCleaner cleaner = new DBCleaner();
+        cleaner.clearDb(dataSource, false);
+    }
+
+    @WithAccessId(userName = "Elena")
+    @Test
+    public void testGetWorkbasketLevelReport() throws ClassificationAlreadyExistException, WorkbasketNotFoundException,
+        ClassificationNotFoundException, NotAuthorizedException, TaskAlreadyExistException, InvalidWorkbasketException,
+        InvalidArgumentException, TaskNotFoundException, InvalidStateException, InvalidOwnerException {
+
+        generateSampleAccessItems();
+
+        WorkbasketImpl workbasket1 = (WorkbasketImpl) workBasketService.newWorkbasket();
+        workbasket1.setName("wb1");
+        workbasket1.setId("1");
+        workbasket1.setKey("1");
+        workbasket1.setDomain("novatec");
+        workbasket1.setType(WorkbasketType.GROUP);
+        workBasketService.createWorkbasket(workbasket1);
+
+        WorkbasketImpl workbasket2 = (WorkbasketImpl) workBasketService.newWorkbasket();
+        workbasket2.setName("wb2");
+        workbasket2.setId("2");
+        workbasket2.setKey("2");
+        workbasket2.setDomain("novatec");
+        workbasket2.setType(WorkbasketType.GROUP);
+        workBasketService.createWorkbasket(workbasket2);
+
+        Classification classification = classificationService.newClassification();
+        classification.setKey("TEST");
+        classification.setDomain("novatec");
+        classificationService.createClassification(classification);
+
+        TaskImpl task1 = (TaskImpl) taskServiceImpl.newTask();
+        task1.setWorkbasketKey(workbasket1.getKey());
+        task1.setClassificationKey(classification.getKey());
+        task1.setPrimaryObjRef(JunitHelper.createDefaultObjRef());
+        task1 = (TaskImpl) taskServiceImpl.createTask(task1);
+
+        TaskImpl task2 = (TaskImpl) taskServiceImpl.newTask();
+        task2.setWorkbasketKey(workbasket2.getKey());
+        task2.setClassificationKey(classification.getKey());
+        task2.setPrimaryObjRef(JunitHelper.createDefaultObjRef());
+        task2 = (TaskImpl) taskServiceImpl.createTask(task2);
+
+        TaskImpl task3 = (TaskImpl) taskServiceImpl.newTask();
+        task3.setWorkbasketKey(workbasket2.getKey());
+        task3.setClassificationKey(classification.getKey());
+        task3.setPrimaryObjRef(JunitHelper.createDefaultObjRef());
+        task3 = (TaskImpl) taskServiceImpl.createTask(task3);
+
+        List<Workbasket> workbaskets = Arrays.asList(workbasket1, workbasket2);
+        List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
+        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states);
+
+        int countWorkbasket1 = report.getDetailLines().get(0).getTotalCount();
+        int countWorkbasket2 = report.getDetailLines().get(1).getTotalCount();
+        int totalCount = report.getSumLine().getTotalCount();
+
+        Assert.assertNotNull(report);
+        Assert.assertEquals(countWorkbasket1, 1);
+        Assert.assertEquals(countWorkbasket2, 2);
+        Assert.assertEquals(countWorkbasket1 + countWorkbasket2, totalCount);
+    }
+
+    private void generateSampleAccessItems() {
+        WorkbasketAccessItem accessItem = new WorkbasketAccessItem();
+        accessItem.setId(IdGenerator.generateWithPrefix("WAI"));
+        accessItem.setWorkbasketKey("1");
+        accessItem.setAccessId("Elena");
+        accessItem.setPermAppend(true);
+        accessItem.setPermRead(true);
+        workBasketService.createWorkbasketAuthorization(accessItem);
+
+        WorkbasketAccessItem accessItem2 = new WorkbasketAccessItem();
+        accessItem2.setId(IdGenerator.generateWithPrefix("WAI"));
+        accessItem2.setWorkbasketKey("2");
+        accessItem2.setAccessId("Elena");
+        accessItem2.setPermAppend(true);
+        accessItem2.setPermRead(true);
+        workBasketService.createWorkbasketAuthorization(accessItem2);
+    }
+
+    @After
+    public void cleanUp() {
+        taskanaEngineImpl.setConnection(null);
+    }
+
+    @AfterClass
+    public static void cleanUpClass() {
+        FileUtils.deleteRecursive("~/data", true);
+    }
+
+}

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskMonitorServiceImplIntExplicitTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskMonitorServiceImplIntExplicitTest.java
@@ -1,0 +1,188 @@
+package pro.taskana.impl.integration;
+
+import java.io.FileNotFoundException;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.security.auth.login.LoginException;
+import javax.sql.DataSource;
+
+import org.h2.store.fs.FileUtils;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import pro.taskana.Classification;
+import pro.taskana.ClassificationService;
+import pro.taskana.TaskMonitorService;
+import pro.taskana.TaskanaEngine;
+import pro.taskana.TaskanaEngine.ConnectionManagementMode;
+import pro.taskana.Workbasket;
+import pro.taskana.WorkbasketService;
+import pro.taskana.configuration.TaskanaEngineConfiguration;
+import pro.taskana.exceptions.ClassificationAlreadyExistException;
+import pro.taskana.exceptions.ClassificationNotFoundException;
+import pro.taskana.exceptions.InvalidArgumentException;
+import pro.taskana.exceptions.InvalidOwnerException;
+import pro.taskana.exceptions.InvalidStateException;
+import pro.taskana.exceptions.InvalidWorkbasketException;
+import pro.taskana.exceptions.NotAuthorizedException;
+import pro.taskana.exceptions.TaskAlreadyExistException;
+import pro.taskana.exceptions.TaskNotFoundException;
+import pro.taskana.exceptions.WorkbasketNotFoundException;
+import pro.taskana.impl.JunitHelper;
+import pro.taskana.impl.TaskImpl;
+import pro.taskana.impl.TaskServiceImpl;
+import pro.taskana.impl.TaskanaEngineImpl;
+import pro.taskana.impl.WorkbasketImpl;
+import pro.taskana.impl.configuration.DBCleaner;
+import pro.taskana.impl.configuration.TaskanaEngineConfigurationTest;
+import pro.taskana.impl.util.IdGenerator;
+import pro.taskana.model.Report;
+import pro.taskana.model.TaskState;
+import pro.taskana.model.WorkbasketAccessItem;
+import pro.taskana.model.WorkbasketType;
+import pro.taskana.security.JAASRunner;
+import pro.taskana.security.WithAccessId;
+
+/**
+ * Integration Test for TaskMonitorServiceImpl transactions with connection management mode EXPLICIT.
+ */
+@RunWith(JAASRunner.class)
+public class TaskMonitorServiceImplIntExplicitTest {
+
+    private DataSource dataSource;
+    private TaskServiceImpl taskServiceImpl;
+    private TaskanaEngineConfiguration taskanaEngineConfiguration;
+    private TaskanaEngine taskanaEngine;
+    private TaskanaEngineImpl taskanaEngineImpl;
+    private ClassificationService classificationService;
+    private WorkbasketService workBasketService;
+    private TaskMonitorService taskMonitorService;
+
+    @BeforeClass
+    public static void resetDb() throws SQLException {
+        DataSource ds = TaskanaEngineConfigurationTest.getDataSource();
+        DBCleaner cleaner = new DBCleaner();
+        cleaner.clearDb(ds, true);
+    }
+
+    @Before
+    public void setup() throws FileNotFoundException, SQLException, LoginException {
+        dataSource = TaskanaEngineConfigurationTest.getDataSource();
+        taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
+        taskServiceImpl = (TaskServiceImpl) taskanaEngine.getTaskService();
+        taskanaEngineImpl = (TaskanaEngineImpl) taskanaEngine;
+        classificationService = taskanaEngine.getClassificationService();
+        taskanaEngineImpl.setConnectionManagementMode(ConnectionManagementMode.EXPLICIT);
+        workBasketService = taskanaEngine.getWorkbasketService();
+        DBCleaner cleaner = new DBCleaner();
+        cleaner.clearDb(dataSource, false);
+    }
+
+    @WithAccessId(userName = "Elena")
+    @Test
+    public void testGetWorkbasketLevelReport() throws SQLException, ClassificationAlreadyExistException,
+        WorkbasketNotFoundException, ClassificationNotFoundException, NotAuthorizedException, TaskNotFoundException,
+        TaskAlreadyExistException, InvalidWorkbasketException, InvalidArgumentException, InvalidOwnerException,
+        InvalidStateException {
+        Connection connection = dataSource.getConnection();
+        taskanaEngineImpl.setConnection(connection);
+
+        taskMonitorService = taskanaEngine.getTaskMonitorService();
+
+        generateSampleAccessItems();
+
+        WorkbasketImpl workbasket1 = (WorkbasketImpl) workBasketService.newWorkbasket();
+        workbasket1.setName("wb1");
+        workbasket1.setId("1");
+        workbasket1.setKey("1");
+        workbasket1.setDomain("novatec");
+        workbasket1.setType(WorkbasketType.GROUP);
+        workBasketService.createWorkbasket(workbasket1);
+
+        WorkbasketImpl workbasket2 = (WorkbasketImpl) workBasketService.newWorkbasket();
+        workbasket2.setName("wb2");
+        workbasket2.setId("2");
+        workbasket2.setKey("2");
+        workbasket2.setDomain("novatec");
+        workbasket2.setType(WorkbasketType.GROUP);
+        workBasketService.createWorkbasket(workbasket2);
+
+        Classification classification = classificationService.newClassification();
+        classification.setKey("TEST");
+        classification.setDomain("novatec");
+        classificationService.createClassification(classification);
+
+        TaskImpl task1 = (TaskImpl) taskServiceImpl.newTask();
+        task1.setWorkbasketKey(workbasket1.getKey());
+        task1.setClassificationKey(classification.getKey());
+        task1.setPrimaryObjRef(JunitHelper.createDefaultObjRef());
+        task1 = (TaskImpl) taskServiceImpl.createTask(task1);
+        connection.commit();
+
+        TaskImpl task2 = (TaskImpl) taskServiceImpl.newTask();
+        task2.setWorkbasketKey(workbasket2.getId());
+        task2.setClassificationKey(classification.getKey());
+        task2.setPrimaryObjRef(JunitHelper.createDefaultObjRef());
+        task2 = (TaskImpl) taskServiceImpl.createTask(task2);
+        connection.commit();
+
+        TaskImpl task3 = (TaskImpl) taskServiceImpl.newTask();
+        task3.setWorkbasketKey(workbasket2.getId());
+        task3.setClassificationKey(classification.getKey());
+        task3.setPrimaryObjRef(JunitHelper.createDefaultObjRef());
+        task3 = (TaskImpl) taskServiceImpl.createTask(task3);
+        connection.commit();
+
+        List<Workbasket> workbaskets = Arrays.asList(workbasket1, workbasket2);
+        List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
+        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states);
+
+        int countWorkbasket1 = report.getDetailLines().get(0).getTotalCount();
+        int countWorkbasket2 = report.getDetailLines().get(1).getTotalCount();
+        int totalCount = report.getSumLine().getTotalCount();
+
+        Assert.assertNotNull(report);
+        Assert.assertEquals(countWorkbasket1, 1);
+        Assert.assertEquals(countWorkbasket2, 2);
+        Assert.assertEquals(countWorkbasket1 + countWorkbasket2, totalCount);
+        connection.commit();
+    }
+
+    private void generateSampleAccessItems() {
+        WorkbasketAccessItem accessItem = new WorkbasketAccessItem();
+        accessItem.setId(IdGenerator.generateWithPrefix("WAI"));
+        accessItem.setWorkbasketKey("1");
+        accessItem.setAccessId("Elena");
+        accessItem.setPermAppend(true);
+        accessItem.setPermRead(true);
+        workBasketService.createWorkbasketAuthorization(accessItem);
+
+        WorkbasketAccessItem accessItem2 = new WorkbasketAccessItem();
+        accessItem2.setId(IdGenerator.generateWithPrefix("WAI"));
+        accessItem2.setWorkbasketKey("2");
+        accessItem2.setAccessId("Elena");
+        accessItem2.setPermAppend(true);
+        accessItem2.setPermRead(true);
+        workBasketService.createWorkbasketAuthorization(accessItem2);
+    }
+
+    @After
+    public void cleanUp() {
+        taskanaEngineImpl.setConnection(null);
+    }
+
+    @AfterClass
+    public static void cleanUpClass() {
+        FileUtils.deleteRecursive("~/data", true);
+    }
+
+}


### PR DESCRIPTION
- In this first step just the total counts of tasks are considered. The next step would be to subdivide the amount of tasks in different ages.
- New models:  Report, ReportLine, ReportLineItem and ReportLineItemDefintion.
- A Report is created in the TaskMonitorService with workbaskets and states as parameters. The count of tasks in the respective workbaskets are calculated by the TaskMonitorMapper. The total sum of all tasks is calculated in the TaskMonitorService.
- Unit and integration tests are updated.