### PR TITLE
TSK-141: Get Classification by Key+Domain in extra Query.

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/Attachment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/Attachment.java
@@ -25,6 +25,14 @@ public interface Attachment {
     String getTaskId();
 
     /**
+     * Sets the taskId of the attachment where it should be appended to.
+     *
+     * @param taskId
+     *            id of the reference task
+     */
+    void setTaskId(String taskId);
+
+    /**
      * Returns the time when the attachment was created.
      *
      * @return the created time as {@link Timestamp}
@@ -39,19 +47,26 @@ public interface Attachment {
     Timestamp getModified();
 
     /**
-     * Returns the classification of the attachment.
+     * Returns the classificationKey for the mapping.
      *
-     * @return the {@link Classification} of this attachment
+     * @return classificationKey key for the correct mapping.
      */
-    Classification getClassification();
+    String getClassificationKey();
 
     /**
-     * Set the classification for this attachment.
+     * Sets the classificationKey for the mapping.
      *
-     * @param classification
-     *            the {@link Classification} for this attachment
+     * @param classificationKey
+     *            key for the correct mapping.
      */
-    void setClassification(Classification classification);
+    void setClassificationKey(String classificationKey);
+
+    /**
+     * Returns the classificationsummary of the attachment.
+     *
+     * @return the {@link ClassificationSummary} of this attachment
+     */
+    ClassificationSummary getClassificationSummary();
 
     /**
      * Returns the {@link ObjectReference primaryObjectReference} of the attachment.
@@ -112,5 +127,4 @@ public interface Attachment {
      *            a {@link Map} that contains the custom attributes of the attachment as key, value pairs
      */
     void setCustomAttributes(Map<String, Object> customAttributes);
-
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/TaskService.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/TaskService.java
@@ -174,9 +174,11 @@ public interface TaskService {
      *             if the workbasketId can´t be resolved to a existing work basket.
      * @throws NotAuthorizedException
      *             if the current user got no rights for reading on this work basket.
+     * @throws ClassificationNotFoundException
+     *             if a single Classification can not be found for a task which is returned
      */
     List<Task> getTasksByWorkbasketKeyAndState(String workbasketKey, TaskState taskState)
-        throws WorkbasketNotFoundException, NotAuthorizedException;
+        throws WorkbasketNotFoundException, NotAuthorizedException, ClassificationNotFoundException;
 
     /**
      * Getting a short summary of all tasks in a specific work basket.

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/AttachmentImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/AttachmentImpl.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import pro.taskana.Attachment;
-import pro.taskana.Classification;
+import pro.taskana.ClassificationSummary;
 import pro.taskana.model.ObjectReference;
 
 /**
@@ -19,7 +19,8 @@ public class AttachmentImpl implements Attachment {
     private String taskId;
     private Timestamp created;
     private Timestamp modified;
-    private Classification classification;
+    private String classificationKey;
+    private ClassificationSummary classificationSummary;
     private ObjectReference objectReference;
     private String channel;
     private Timestamp received;
@@ -42,6 +43,7 @@ public class AttachmentImpl implements Attachment {
         return taskId;
     }
 
+    @Override
     public void setTaskId(String taskId) {
         this.taskId = taskId;
     }
@@ -65,13 +67,22 @@ public class AttachmentImpl implements Attachment {
     }
 
     @Override
-    public Classification getClassification() {
-        return classification;
+    public String getClassificationKey() {
+        return classificationKey;
     }
 
     @Override
-    public void setClassification(Classification classification) {
-        this.classification = classification;
+    public void setClassificationKey(String classificationKey) {
+        this.classificationKey = classificationKey;
+    }
+
+    @Override
+    public ClassificationSummary getClassificationSummary() {
+        return classificationSummary;
+    }
+
+    public void setClassificationSummary(ClassificationSummary classificationSummary) {
+        this.classificationSummary = classificationSummary;
     }
 
     @Override
@@ -125,8 +136,8 @@ public class AttachmentImpl implements Attachment {
         builder.append(created);
         builder.append(", modified=");
         builder.append(modified);
-        builder.append(", classification=");
-        builder.append(classification);
+        builder.append(", classificationKey=");
+        builder.append(classificationKey);
         builder.append(", objectReference=");
         builder.append(objectReference);
         builder.append(", channel=");
@@ -138,5 +149,4 @@ public class AttachmentImpl implements Attachment {
         builder.append("]");
         return builder.toString();
     }
-
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/model/mappings/AttachmentMapper.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/mappings/AttachmentMapper.java
@@ -4,14 +4,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.One;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
 import org.apache.ibatis.annotations.Results;
 import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.type.JdbcType;
 
-import pro.taskana.Classification;
 import pro.taskana.impl.AttachmentImpl;
 import pro.taskana.impl.persistence.MapTypeHandler;
 
@@ -20,10 +18,8 @@ import pro.taskana.impl.persistence.MapTypeHandler;
  */
 public interface AttachmentMapper {
 
-    String CLASSIFICATION_FINDBYID = "pro.taskana.model.mappings.ClassificationMapper.findById";
-
     @Insert("INSERT INTO ATTACHMENT (ID, TASK_ID, CREATED, MODIFIED, CLASSIFICATION_KEY, REF_COMPANY, REF_SYSTEM, REF_INSTANCE, REF_TYPE, REF_VALUE, CHANNEL, RECEIVED, CUSTOM_ATTRIBUTES) "
-        + "VALUES (#{att.id}, #{att.taskId}, #{att.created}, #{att.modified}, #{att.classification.key}, #{att.objectReference.company}, #{att.objectReference.system}, #{att.objectReference.systemInstance}, "
+        + "VALUES (#{att.id}, #{att.taskId}, #{att.created}, #{att.modified}, #{att.classificationSummary.key}, #{att.objectReference.company}, #{att.objectReference.system}, #{att.objectReference.systemInstance}, "
         + " #{att.objectReference.type}, #{att.objectReference.value}, #{att.channel}, #{att.received}, #{att.customAttributes,jdbcType=BLOB,javaType=java.util.Map,typeHandler=pro.taskana.impl.persistence.MapTypeHandler} )")
     void insert(@Param("att") AttachmentImpl att);
 
@@ -35,8 +31,7 @@ public interface AttachmentMapper {
         @Result(property = "taskId", column = "TASK_ID"),
         @Result(property = "created", column = "CREATED"),
         @Result(property = "modified", column = "MODIFIED"),
-        @Result(property = "classification", column = "CLASSIFICATION_KEY", javaType = Classification.class,
-            one = @One(select = CLASSIFICATION_FINDBYID)),
+        @Result(property = "classificationKey", column = "CLASSIFICATION_KEY"),
         @Result(property = "objectReference.company", column = "REF_COMPANY"),
         @Result(property = "objectReference.system", column = "REF_SYSTEM"),
         @Result(property = "objectReference.systemInstance", column = "REF_INSTANCE"),

--- a/lib/taskana-core/src/main/java/pro/taskana/model/mappings/ClassificationMapper.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/mappings/ClassificationMapper.java
@@ -18,7 +18,7 @@ import pro.taskana.impl.ClassificationSummaryImpl;
  */
 public interface ClassificationMapper {
 
-    String VALID_UNTIL = "9999-12-31";
+    String VALID_UNTIL_MAX = "9999-12-31";
 
     @Select("SELECT ID, KEY, PARENT_CLASSIFICATION_KEY, CATEGORY, TYPE, DOMAIN, VALID_IN_DOMAIN, CREATED, NAME, DESCRIPTION, PRIORITY, SERVICE_LEVEL, APPLICATION_ENTRY_POINT, CUSTOM_1, CUSTOM_2, CUSTOM_3, CUSTOM_4, CUSTOM_5, CUSTOM_6, CUSTOM_7, CUSTOM_8, VALID_FROM, VALID_UNTIL "
         + "FROM CLASSIFICATION "
@@ -50,34 +50,6 @@ public interface ClassificationMapper {
         @Result(property = "validUntil", column = "VALID_UNTIL") })
     ClassificationImpl findByKeyAndDomain(@Param("key") String key, @Param("domain") String domain,
         @Param("valid_until") Date validUntil);
-
-    @Select("SELECT ID, KEY, PARENT_CLASSIFICATION_KEY, CATEGORY, TYPE, DOMAIN, VALID_IN_DOMAIN, CREATED, NAME, DESCRIPTION, PRIORITY, SERVICE_LEVEL, APPLICATION_ENTRY_POINT, CUSTOM_1, CUSTOM_2, CUSTOM_3, CUSTOM_4, CUSTOM_5, CUSTOM_6, CUSTOM_7, CUSTOM_8, VALID_FROM, VALID_UNTIL "
-        + "FROM CLASSIFICATION "
-        + "WHERE ID = #{id} ")
-    @Results({ @Result(property = "id", column = "ID"),
-        @Result(property = "key", column = "KEY"),
-        @Result(property = "parentClassificationKey", column = "PARENT_CLASSIFICATION_KEY"),
-        @Result(property = "category", column = "CATEGORY"),
-        @Result(property = "type", column = "TYPE"),
-        @Result(property = "domain", column = "DOMAIN"),
-        @Result(property = "isValidInDomain", column = "VALID_IN_DOMAIN"),
-        @Result(property = "created", column = "CREATED"),
-        @Result(property = "name", column = "NAME"),
-        @Result(property = "description", column = "DESCRIPTION"),
-        @Result(property = "priority", column = "PRIORITY"),
-        @Result(property = "serviceLevel", column = "SERVICE_LEVEL"),
-        @Result(property = "applicationEntryPoint", column = "APPLICATION_ENTRY_POINT"),
-        @Result(property = "custom1", column = "CUSTOM_1"),
-        @Result(property = "custom2", column = "CUSTOM_2"),
-        @Result(property = "custom3", column = "CUSTOM_3"),
-        @Result(property = "custom4", column = "CUSTOM_4"),
-        @Result(property = "custom5", column = "CUSTOM_5"),
-        @Result(property = "custom6", column = "CUSTOM_6"),
-        @Result(property = "custom7", column = "CUSTOM_7"),
-        @Result(property = "custom8", column = "CUSTOM_8"),
-        @Result(property = "validFrom", column = "VALID_FROM"),
-        @Result(property = "validUntil", column = "VALID_UNTIL") })
-    ClassificationImpl findById(@Param("id") String id);
 
     @Insert("INSERT INTO CLASSIFICATION (ID, KEY, PARENT_CLASSIFICATION_KEY, CATEGORY, TYPE, DOMAIN, VALID_IN_DOMAIN, CREATED, NAME, DESCRIPTION, PRIORITY, SERVICE_LEVEL, APPLICATION_ENTRY_POINT, CUSTOM_1, CUSTOM_2, CUSTOM_3, CUSTOM_4, CUSTOM_5, CUSTOM_6, CUSTOM_7, CUSTOM_8, VALID_FROM, VALID_UNTIL) VALUES (#{classification.id}, #{classification.key}, #{classification.parentClassificationKey}, #{classification.category}, #{classification.type}, #{classification.domain}, #{classification.isValidInDomain}, #{classification.created}, #{classification.name}, #{classification.description}, #{classification.priority}, #{classification.serviceLevel}, #{classification.applicationEntryPoint}, #{classification.custom1}, #{classification.custom2}, #{classification.custom3}, #{classification.custom4}, #{classification.custom5}, #{classification.custom6}, #{classification.custom7}, #{classification.custom8}, #{classification.validFrom}, #{classification.validUntil})")
     void insert(@Param("classification") ClassificationImpl classification);

--- a/lib/taskana-core/src/main/java/pro/taskana/model/mappings/TaskMapper.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/mappings/TaskMapper.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.One;
 import org.apache.ibatis.annotations.Options;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Result;
@@ -15,7 +14,6 @@ import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 import org.apache.ibatis.type.JdbcType;
 
-import pro.taskana.Classification;
 import pro.taskana.impl.TaskImpl;
 import pro.taskana.impl.persistence.MapTypeHandler;
 import pro.taskana.model.DueWorkbasketCounter;
@@ -26,10 +24,6 @@ import pro.taskana.model.TaskSummary;
  * This class is the mybatis mapping of task.
  */
 public interface TaskMapper {
-
-    String OBJECTREFERENCEMAPPER_FINDBYID = "pro.taskana.model.mappings.ObjectReferenceMapper.findById";
-    String CLASSIFICATION_FINDBYKEYANDDOMAIN = "pro.taskana.model.mappings.ClassificationMapper.findByKeyAndDomain";
-    String CLASSIFICATION_FINDBYID = "pro.taskana.model.mappings.ClassificationMapper.findById";
 
     @Select("SELECT ID, CREATED, CLAIMED, COMPLETED, MODIFIED, PLANNED, DUE, NAME, DESCRIPTION, NOTE, PRIORITY, STATE, CLASSIFICATION_KEY, WORKBASKET_KEY, DOMAIN, BUSINESS_PROCESS_ID, PARENT_BUSINESS_PROCESS_ID, OWNER, POR_COMPANY, POR_SYSTEM, POR_INSTANCE, POR_TYPE, POR_VALUE, IS_READ, IS_TRANSFERRED, CUSTOM_ATTRIBUTES, CUSTOM_1, CUSTOM_2, CUSTOM_3, CUSTOM_4, CUSTOM_5, CUSTOM_6, CUSTOM_7, CUSTOM_8, CUSTOM_9, CUSTOM_10 "
         + "FROM TASK "
@@ -75,9 +69,9 @@ public interface TaskMapper {
     })
     TaskImpl findById(@Param("id") String id);
 
-    @Results({@Result(column = "DUE_DATE", property = "due"),
+    @Results({ @Result(column = "DUE_DATE", property = "due"),
         @Result(column = "WORKBASKET_KEY", property = "workbasketKey"),
-        @Result(column = "counter", property = "taskCounter")})
+        @Result(column = "counter", property = "taskCounter") })
     List<DueWorkbasketCounter> getTaskCountByWorkbasketIdAndDaysInPastAndState(@Param("fromDate") Date fromDate,
         @Param("status") List<TaskState> states);
 
@@ -111,8 +105,6 @@ public interface TaskMapper {
         @Result(property = "priority", column = "PRIORITY"),
         @Result(property = "state", column = "STATE"),
         @Result(property = "workbasketKey", column = "WORKBASKET_KEY"),
-        @Result(property = "classification", column = "CLASSIFICATION_KEY", javaType = Classification.class,
-            one = @One(select = CLASSIFICATION_FINDBYKEYANDDOMAIN)),
         @Result(property = "domain", column = "DOMAIN"),
         @Result(property = "owner", column = "OWNER"),
         @Result(property = "primaryObjRef.company", column = "POR_COMPANY"),
@@ -133,7 +125,7 @@ public interface TaskMapper {
         @Result(property = "custom7", column = "CUSTOM_7"),
         @Result(property = "custom8", column = "CUSTOM_8"),
         @Result(property = "custom9", column = "CUSTOM_9"),
-        @Result(property = "custom10", column = "CUSTOM_10")})
+        @Result(property = "custom10", column = "CUSTOM_10") })
     List<TaskImpl> findTasksByWorkbasketIdAndState(@Param("workbasketKey") String workbasketKey,
         @Param("taskState") TaskState taskState);
 

--- a/lib/taskana-core/src/main/java/pro/taskana/model/mappings/WorkbasketMapper.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/mappings/WorkbasketMapper.java
@@ -41,7 +41,7 @@ public interface WorkbasketMapper {
         @Result(property = "orgLevel1", column = "ORG_LEVEL_1"),
         @Result(property = "orgLevel2", column = "ORG_LEVEL_2"),
         @Result(property = "orgLevel3", column = "ORG_LEVEL_3"),
-        @Result(property = "orgLevel4", column = "ORG_LEVEL_4")})
+        @Result(property = "orgLevel4", column = "ORG_LEVEL_4") })
     WorkbasketImpl findById(@Param("id") String id);
 
     @Select("SELECT ID, KEY, CREATED, MODIFIED, NAME, DOMAIN, TYPE, DESCRIPTION, OWNER, CUSTOM_1 ,CUSTOM_2 ,CUSTOM_3 ,CUSTOM_4 ,ORG_LEVEL_1 ,ORG_LEVEL_2 ,ORG_LEVEL_3 ,ORG_LEVEL_4 FROM WORKBASKET WHERE KEY = #{key}")
@@ -64,7 +64,7 @@ public interface WorkbasketMapper {
         @Result(property = "orgLevel1", column = "ORG_LEVEL_1"),
         @Result(property = "orgLevel2", column = "ORG_LEVEL_2"),
         @Result(property = "orgLevel3", column = "ORG_LEVEL_3"),
-        @Result(property = "orgLevel4", column = "ORG_LEVEL_4")})
+        @Result(property = "orgLevel4", column = "ORG_LEVEL_4") })
     WorkbasketImpl findByKey(@Param("key") String key);
 
     @Select("SELECT * FROM WORKBASKET WHERE id IN (SELECT TARGET_ID FROM DISTRIBUTION_TARGETS WHERE SOURCE_ID = #{id})")
@@ -80,8 +80,7 @@ public interface WorkbasketMapper {
         @Result(property = "orgLevel1", column = "ORG_LEVEL_1"),
         @Result(property = "orgLevel2", column = "ORG_LEVEL_2"),
         @Result(property = "orgLevel3", column = "ORG_LEVEL_3"),
-        @Result(property = "orgLevel4", column = "ORG_LEVEL_4")})
-
+        @Result(property = "orgLevel4", column = "ORG_LEVEL_4") })
     List<WorkbasketSummary> findByDistributionTargets(@Param("id") String id);
 
     @Select("SELECT * FROM WORKBASKET ORDER BY id")
@@ -96,7 +95,7 @@ public interface WorkbasketMapper {
         @Result(property = "orgLevel1", column = "ORG_LEVEL_1"),
         @Result(property = "orgLevel2", column = "ORG_LEVEL_2"),
         @Result(property = "orgLevel3", column = "ORG_LEVEL_3"),
-        @Result(property = "orgLevel4", column = "ORG_LEVEL_4")})
+        @Result(property = "orgLevel4", column = "ORG_LEVEL_4") })
     List<WorkbasketSummary> findAll();
 
     @Select("<script>SELECT W.ID, W.KEY, W.NAME, W.DESCRIPTION, W.OWNER, W.DOMAIN, W.TYPE, W.ORG_LEVEL_1, W.ORG_LEVEL_2,  W.ORG_LEVEL_3, W.ORG_LEVEL_4 FROM WORKBASKET AS W "
@@ -130,7 +129,7 @@ public interface WorkbasketMapper {
         @Result(property = "orgLevel1", column = "ORG_LEVEL_1"),
         @Result(property = "orgLevel2", column = "ORG_LEVEL_2"),
         @Result(property = "orgLevel3", column = "ORG_LEVEL_3"),
-        @Result(property = "orgLevel4", column = "ORG_LEVEL_4")})
+        @Result(property = "orgLevel4", column = "ORG_LEVEL_4") })
     List<WorkbasketSummary> findByPermission(@Param("authorizations") List<WorkbasketAuthorization> authorizations,
         @Param("accessId") String accessId);
 
@@ -143,5 +142,4 @@ public interface WorkbasketMapper {
 
     @Delete("DELETE FROM WORKBASKET where id = #{id}")
     void delete(@Param("id") String id);
-
 }

--- a/lib/taskana-core/src/test/java/acceptance/AbstractAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/AbstractAccTest.java
@@ -15,6 +15,8 @@ import pro.taskana.TaskanaEngine.ConnectionManagementMode;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.database.TestDataGenerator;
 import pro.taskana.exceptions.ClassificationNotFoundException;
+import pro.taskana.exceptions.NotAuthorizedException;
+import pro.taskana.impl.AttachmentImpl;
 import pro.taskana.impl.TaskanaEngineImpl;
 import pro.taskana.impl.configuration.DBCleaner;
 import pro.taskana.impl.configuration.TaskanaEngineConfigurationTest;
@@ -68,10 +70,15 @@ public abstract class AbstractAccTest {
 
     protected Attachment createAttachment(String classificationKey, ObjectReference objRef,
         String channel, String receivedDate, Map<String, Object> customAttributes)
-        throws ClassificationNotFoundException {
+        throws ClassificationNotFoundException, NotAuthorizedException {
         Attachment attachment = taskanaEngine.getTaskService().newAttachment();
-        attachment.setClassification(
-            taskanaEngine.getClassificationService().getClassification(classificationKey, "DOMAIN_A"));
+        ((AttachmentImpl) attachment).setClassificationSummary(
+            taskanaEngine.getClassificationService()
+                .createClassificationQuery()
+                .key(classificationKey)
+                .domain("DOMAIN_A")
+                .single());
+        attachment.setClassificationKey(classificationKey);
         attachment.setObjectReference(objRef);
         attachment.setChannel(channel);
         Timestamp receivedTimestamp = null;

--- a/lib/taskana-core/src/test/java/acceptance/task/CreateTaskAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/task/CreateTaskAccTest.java
@@ -16,6 +16,7 @@ import pro.taskana.TaskService;
 import pro.taskana.Workbasket;
 import pro.taskana.WorkbasketService;
 import pro.taskana.exceptions.ClassificationNotFoundException;
+import pro.taskana.exceptions.ConcurrencyException;
 import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.exceptions.InvalidWorkbasketException;
 import pro.taskana.exceptions.NotAuthorizedException;
@@ -38,7 +39,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testCreateSimpleManualTask()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -70,21 +71,22 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testCreateExternalTaskWithAttachment()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
-        WorkbasketNotFoundException, TaskAlreadyExistException, InvalidWorkbasketException, TaskNotFoundException {
+        WorkbasketNotFoundException, TaskAlreadyExistException, InvalidWorkbasketException, TaskNotFoundException,
+        ConcurrencyException {
 
         TaskService taskService = taskanaEngine.getTaskService();
         Task newTask = taskService.newTask();
         newTask.setClassificationKey("L12010");
-        newTask.setPrimaryObjRef(createObjectReference("COMPANY_A", "SYSTEM_A", "INSTANCE_A", "VNR", "1234567"));
-        newTask.setWorkbasketKey("USER_1_1");
         newTask.addAttachment(createAttachment("DOKTYP_DEFAULT",
             createObjectReference("COMPANY_A", "SYSTEM_B", "INSTANCE_B", "ArchiveId",
                 "12345678901234567890123456789012345678901234567890"),
             "E-MAIL", "2018-01-15", createSimpleCustomProperties(3)));
+        newTask.setPrimaryObjRef(createObjectReference("COMPANY_A", "SYSTEM_A", "INSTANCE_A", "VNR", "1234567"));
+        newTask.setWorkbasketKey("USER_1_1");
         Task createdTask = taskService.createTask(newTask);
 
         assertNotNull(createdTask.getId());
@@ -97,13 +99,13 @@ public class CreateTaskAccTest extends AbstractAccTest {
         assertNotNull(readTask.getAttachments().get(0).getCreated());
         assertNotNull(readTask.getAttachments().get(0).getModified());
         assertEquals(readTask.getAttachments().get(0).getCreated(), readTask.getAttachments().get(0).getModified());
-        // assertNotNull(readTask.getAttachments().get(0).getClassification());
+        assertNotNull(readTask.getAttachments().get(0).getClassificationSummary());
         assertNotNull(readTask.getAttachments().get(0).getObjectReference());
     }
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testCreateExternalTaskWithMultipleAttachments()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -140,7 +142,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testThrowsExceptionIfAttachmentIsInvalid()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -222,7 +224,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testUseCustomNameIfSetForNewTask()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -242,7 +244,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testUseClassificationMetadataFromCorrectDomainForNewTask()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -262,7 +264,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test(expected = WorkbasketNotFoundException.class)
     public void testGetExceptionIfWorkbasketDoesNotExist()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -278,7 +280,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test(expected = NotAuthorizedException.class)
     public void testGetExceptionIfAppendIsNotPermitted()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -294,7 +296,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testThrowsExceptionIfMandatoryPrimaryObjectReferenceIsNotSetOrIncomplete()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,
@@ -381,7 +383,7 @@ public class CreateTaskAccTest extends AbstractAccTest {
 
     @WithAccessId(
         userName = "user_1_1",
-        groupNames = {"group_1"})
+        groupNames = { "group_1" })
     @Test
     public void testSetDomainFromWorkbasket()
         throws SQLException, NotAuthorizedException, InvalidArgumentException, ClassificationNotFoundException,

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/TaskQueryImplTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/TaskQueryImplTest.java
@@ -11,6 +11,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
@@ -27,6 +28,7 @@ import pro.taskana.model.TaskState;
 @RunWith(MockitoJUnitRunner.class)
 public class TaskQueryImplTest {
 
+    @InjectMocks
     private TaskQueryImpl taskQueryImpl;
 
     @Mock


### PR DESCRIPTION
Task and Attachment load Classification afterwards and match them manually.
getClassificationById is not used anymore and attributes are matching the real properties now.