### PR TITLE
TSK-228: Replace days by working days in the reports

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/TaskMonitorService.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/TaskMonitorService.java
@@ -68,8 +68,9 @@ public interface TaskMonitorService {
     /**
      * Returns a {@link Report} for a given list of {@link Workbasket}s, a given list of {@link TaskState}s and a given
      * list of {@link ReportLineItemDefinition}s. For each workbasket the report contains a list of ReportLineItems that
-     * subdivides the report in to different cluster grouped by the due date. Only tasks with a state in the list of
-     * TaskStates are provided. Tasks with Timestamp DUE = null are not considered.
+     * subdivides the report in to different cluster grouped by the due date. By default the age of the tasks is counted
+     * in working days. Only tasks with a state in the list of TaskStates are provided. Tasks with Timestamp DUE = null
+     * are not considered.
      *
      * @param workbaskets
      *            a list of {@link Workbasket} objects that should be listed in the report
@@ -85,6 +86,30 @@ public interface TaskMonitorService {
      */
     Report getWorkbasketLevelReport(List<Workbasket> workbaskets, List<TaskState> states,
         List<ReportLineItemDefinition> reportLineItemDefinitions);
+
+    /**
+     * Returns a {@link Report} for a given list of {@link Workbasket}s, a given list of {@link TaskState}s and a given
+     * list of {@link ReportLineItemDefinition}s. For each workbasket the report contains a list of ReportLineItems that
+     * subdivides the report in to different cluster grouped by the due date. Only tasks with a state in the list of
+     * TaskStates are provided. Tasks with Timestamp DUE = null are not considered.
+     *
+     * @param workbaskets
+     *            a list of {@link Workbasket} objects that should be listed in the report
+     * @param states
+     *            a list of {@link TaskState} objects that specify the states of the tasks that are provided
+     * @param reportLineItemDefinitions
+     *            a list of {@link ReportLineItemDefinition} objects that specify the subdivision into different cluster
+     *            of due dates. Days in past are represented as negative values and days in the future are represented
+     *            as positive values. To avoid tasks are counted multiple times or not be listed in the report, these
+     *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
+     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     * @param inWorkingDays
+     *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
+     *            working days.
+     * @return a {@link Report} object that represents an overview of all tasks in the
+     */
+    Report getWorkbasketLevelReport(List<Workbasket> workbaskets, List<TaskState> states,
+        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays);
 
     /**
      * Returns a {@link Report} with categories for a given list of {@link Workbasket}s and for a given list of
@@ -104,8 +129,9 @@ public interface TaskMonitorService {
     /**
      * Returns a {@link Report} with categories for a given list of {@link Workbasket}s, a given list of
      * {@link TaskState}s and a given list of {@link ReportLineItemDefinition}s. For each category the report contains a
-     * list of ReportLineItems that subdivides the report in to different cluster grouped by the due date. Only tasks
-     * with a state in the list of TaskStates are provided. Tasks with Timestamp DUE = null are not considered.
+     * list of ReportLineItems that subdivides the report in to different cluster grouped by the due date. By default
+     * the age of the tasks is counted in working days. Only tasks with a state in the list of TaskStates are provided.
+     * Tasks with Timestamp DUE = null are not considered.
      *
      * @param workbaskets
      *            a list of {@link Workbasket} objects that should be listed in the report
@@ -121,4 +147,28 @@ public interface TaskMonitorService {
      */
     Report getCategoryReport(List<Workbasket> workbaskets, List<TaskState> states,
         List<ReportLineItemDefinition> reportLineItemDefinitions);
+
+    /**
+     * Returns a {@link Report} with categories for a given list of {@link Workbasket}s, a given list of
+     * {@link TaskState}s and a given list of {@link ReportLineItemDefinition}s. For each category the report contains a
+     * list of ReportLineItems that subdivides the report in to different cluster grouped by the due date. Only tasks
+     * with a state in the list of TaskStates are provided. Tasks with Timestamp DUE = null are not considered.
+     *
+     * @param workbaskets
+     *            a list of {@link Workbasket} objects that should be listed in the report
+     * @param states
+     *            a list of {@link TaskState} objects that specify the states of the tasks that are provided
+     * @param reportLineItemDefinitions
+     *            a list of {@link ReportLineItemDefinition} objects that specify the subdivision into different cluster
+     *            of due dates. Days in past are represented as negative values and days in the future are represented
+     *            as positive values. To avoid tasks are counted multiple times or not be listed in the report, these
+     *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
+     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     * @param inWorkingDays
+     *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
+     *            working days.
+     * @return a {@link Report} object that represents an overview of all tasks of the respective category
+     */
+    Report getCategoryReport(List<Workbasket> workbaskets, List<TaskState> states,
+        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays);
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/DaysToWorkingDaysConverter.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/DaysToWorkingDaysConverter.java
@@ -1,0 +1,165 @@
+package pro.taskana.impl;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import pro.taskana.impl.util.LoggerUtils;
+import pro.taskana.model.ReportLineItemDefinition;
+
+/**
+ * The DaysToWorkingDaysConverter provides a method to convert an age in days into an age in working days. Before the
+ * method convertDaysToWorkingDays() can be used, the DaysToWorkingDaysConverter has to be initialized. For a list of
+ * {@link ReportLineItemDefinition}s the converter creates a "table" with integer that represents the age in days from
+ * the largest lower limit until the smallest upper limit of the reportLineItemDefinitions. This table is valid for a
+ * whole day until the converter is initialized with bigger limits.
+ */
+public final class DaysToWorkingDaysConverter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(TaskMonitorServiceImpl.class);
+    private static DaysToWorkingDaysConverter instance;
+    private static ArrayList<Integer> positiveDaysToWorkingDays;
+    private static ArrayList<Integer> negativeDaysToWorkingDays;
+    private static LocalDate dateCreated;
+
+    private DaysToWorkingDaysConverter(List<ReportLineItemDefinition> reportLineItemDefinitions,
+        LocalDate referenceDate) {
+        positiveDaysToWorkingDays = generatePositiveDaysToWorkingDays(reportLineItemDefinitions, referenceDate);
+        negativeDaysToWorkingDays = generateNegativeDaysToWorkingDays(reportLineItemDefinitions, referenceDate);
+        dateCreated = referenceDate;
+    }
+
+    /**
+     * Initializes the DaysToWorkingDaysConverter for a list of {@link ReportLineItemDefinition}s and the current day. A
+     * new table is only created if there are bigger limits or the date has changed.
+     *
+     * @param reportLineItemDefinitions
+     *            a list of {@link ReportLineItemDefinition}s that determines the size of the table
+     * @return an instance of the DaysToWorkingDaysConverter
+     */
+    public static DaysToWorkingDaysConverter initialize(List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        return initialize(reportLineItemDefinitions, LocalDate.now());
+    }
+
+    /**
+     * Initializes the DaysToWorkingDaysConverter for a list of {@link ReportLineItemDefinition}s and a referenceDate. A
+     * new table is only created if there are bigger limits or the date has changed.
+     *
+     * @param reportLineItemDefinitions
+     *            a list of {@link ReportLineItemDefinition}s that determines the size of the table
+     * @param referenceDate
+     *            a {@link LocalDate} that represents the current day of the table
+     * @return an instance of the DaysToWorkingDaysConverter
+     */
+    public static DaysToWorkingDaysConverter initialize(List<ReportLineItemDefinition> reportLineItemDefinitions,
+        LocalDate referenceDate) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Initialize DaysToWorkingDaysConverter with reportLineItemDefinitions: {}",
+                LoggerUtils.listToString(reportLineItemDefinitions));
+        }
+        int largesLowerLimit = getLargestLowerLimit(reportLineItemDefinitions);
+        int smallestUpperLimit = getSmallestUpperLimit(reportLineItemDefinitions);
+        if (instance == null
+            || !positiveDaysToWorkingDays.contains(largesLowerLimit)
+            || !negativeDaysToWorkingDays.contains(smallestUpperLimit)
+            || !dateCreated.isEqual(referenceDate)) {
+
+            instance = new DaysToWorkingDaysConverter(reportLineItemDefinitions, referenceDate);
+            LOGGER.debug("Create new converter for the values from {} until {} for the date: {}.", largesLowerLimit,
+                smallestUpperLimit, dateCreated);
+        }
+        return instance;
+    }
+
+    /**
+     * Converts an integer, that represents the age in days, to the age in working days by using the table that was
+     * created by initialization. If the age in days is beyond the limits of the table, the integer will be returned
+     * unchanged.
+     *
+     * @param ageInDays
+     *            represents the age in days
+     * @return the age in working days
+     */
+    public int convertDaysToWorkingDays(int ageInDays) {
+
+        int minWorkingDay = -(negativeDaysToWorkingDays.size() - 1);
+        int maxWorkingDay = positiveDaysToWorkingDays.size() - 1;
+
+        if (ageInDays >= minWorkingDay && ageInDays <= 0) {
+            return negativeDaysToWorkingDays.get(-ageInDays);
+        }
+        if (ageInDays > 0 && ageInDays <= maxWorkingDay) {
+            return positiveDaysToWorkingDays.get(ageInDays);
+        }
+
+        return ageInDays;
+    }
+
+    private ArrayList<Integer> generateNegativeDaysToWorkingDays(
+        List<ReportLineItemDefinition> reportLineItemDefinitions, LocalDate referenceDate) {
+        int minUpperLimit = getSmallestUpperLimit(reportLineItemDefinitions);
+        ArrayList<Integer> daysToWorkingDays = new ArrayList<>();
+        daysToWorkingDays.add(0);
+        int day = -1;
+        int workingDay = 0;
+        while (workingDay > minUpperLimit) {
+            if (isWorkingDay(day, referenceDate)) {
+                workingDay--;
+            }
+            daysToWorkingDays.add(workingDay);
+            day--;
+        }
+        return daysToWorkingDays;
+    }
+
+    private ArrayList<Integer> generatePositiveDaysToWorkingDays(
+        List<ReportLineItemDefinition> reportLineItemDefinitions, LocalDate referenceDate) {
+        int maxLowerLimit = getLargestLowerLimit(reportLineItemDefinitions);
+        ArrayList<Integer> daysToWorkingDays = new ArrayList<>();
+        daysToWorkingDays.add(0);
+
+        int day = 1;
+        int workingDay = 0;
+        while (workingDay < maxLowerLimit) {
+            if (isWorkingDay(day, referenceDate)) {
+                workingDay++;
+            }
+            daysToWorkingDays.add(workingDay);
+            day++;
+        }
+        return daysToWorkingDays;
+    }
+
+    private static int getSmallestUpperLimit(List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        int smallestUpperLimit = 0;
+        for (ReportLineItemDefinition reportLineItemDefinition : reportLineItemDefinitions) {
+            if (reportLineItemDefinition.getUpperAgeLimit() < smallestUpperLimit) {
+                smallestUpperLimit = reportLineItemDefinition.getUpperAgeLimit();
+            }
+        }
+        return smallestUpperLimit;
+    }
+
+    private static int getLargestLowerLimit(List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        int greatestLowerLimit = 0;
+        for (ReportLineItemDefinition reportLineItemDefinition : reportLineItemDefinitions) {
+            if (reportLineItemDefinition.getUpperAgeLimit() > greatestLowerLimit) {
+                greatestLowerLimit = reportLineItemDefinition.getLowerAgeLimit();
+            }
+        }
+        return greatestLowerLimit;
+    }
+
+    private boolean isWorkingDay(int day, LocalDate referenceDate) {
+        if (referenceDate.plusDays(day).getDayOfWeek().equals(DayOfWeek.SATURDAY)
+            || referenceDate.plusDays(day).getDayOfWeek().equals(DayOfWeek.SUNDAY)) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/model/Report.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/Report.java
@@ -36,7 +36,8 @@ public class Report {
         this.sumLine = sumLine;
     }
 
-    public void generateSumLine() {
+    public void generateSumLine(ReportLine sumLine) {
+        this.sumLine = sumLine;
         int totalNumberOfTasks = 0;
         for (ReportLine reportLine : this.getDetailLines().values()) {
             Iterator<ReportLineItem> reportLineItemIterator = reportLine.getLineItems().iterator();
@@ -48,7 +49,6 @@ public class Report {
             totalNumberOfTasks += reportLine.getTotalNumberOfTasks();
         }
         this.sumLine.setTotalNumberOfTasks(totalNumberOfTasks);
-
     }
 
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/model/ReportLine.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/ReportLine.java
@@ -42,6 +42,5 @@ public class ReportLine {
                 break;
             }
         }
-
     }
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/model/ReportLineItemDefinition.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/model/ReportLineItemDefinition.java
@@ -40,4 +40,9 @@ public class ReportLineItemDefinition {
     public void setUpperAgeLimit(int upperAgeLimit) {
         this.upperAgeLimit = upperAgeLimit;
     }
+
+    @Override
+    public String toString() {
+        return "(" + this.lowerAgeLimit + "," + this.upperAgeLimit + ")";
+    }
 }

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCategoryReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCategoryReportAccTest.java
@@ -1,4 +1,4 @@
-package acceptance.task;
+package acceptance.monitoring;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -13,7 +13,6 @@ import javax.sql.DataSource;
 
 import org.h2.store.fs.FileUtils;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,10 +37,10 @@ import pro.taskana.security.JAASRunner;
 import pro.taskana.security.WithAccessId;
 
 /**
- * Acceptance test for all "workbasket level report" scenarios.
+ * Acceptance test for all "category report" scenarios.
  */
 @RunWith(JAASRunner.class)
-public class ProvideWorkbasketLevelReportAccTest {
+public class ProvideCategoryReportAccTest {
 
     protected static TaskanaEngineConfiguration taskanaEngineConfiguration;
     protected static TaskanaEngine taskanaEngine;
@@ -66,36 +65,40 @@ public class ProvideWorkbasketLevelReportAccTest {
 
     @WithAccessId(userName = "monitor_user_1")
     @Test
-    public void testGetTotalNumbersOfTasksOfWorkbasketLevelReport()
+    public void testGetTotalNumbersOfTasksOfCategoryReport()
         throws WorkbasketNotFoundException, NotAuthorizedException {
 
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<Workbasket> workbaskets = getListOfWorkbaskets();
         List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
-        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states);
+        List<String> categories = Arrays.asList("EXTERN", "AUTOMATIC", "MANUAL");
+        Report report = taskMonitorService.getCategoryReport(workbaskets, states);
 
         assertNotNull(report);
-        assertEquals(20, report.getDetailLines().get(workbaskets.get(0).getKey()).getTotalNumberOfTasks());
-        assertEquals(20, report.getDetailLines().get(workbaskets.get(1).getKey()).getTotalNumberOfTasks());
-        assertEquals(10, report.getDetailLines().get(workbaskets.get(2).getKey()).getTotalNumberOfTasks());
-        assertEquals(0, report.getDetailLines().get(workbaskets.get(3).getKey()).getTotalNumberOfTasks());
+        assertEquals(33, report.getDetailLines().get(categories.get(0)).getTotalNumberOfTasks());
+        assertEquals(7, report.getDetailLines().get(categories.get(1)).getTotalNumberOfTasks());
+        assertEquals(10, report.getDetailLines().get(categories.get(2)).getTotalNumberOfTasks());
+        assertEquals(0, report.getDetailLines().get(categories.get(0)).getLineItems().size());
+        assertEquals(0, report.getDetailLines().get(categories.get(1)).getLineItems().size());
+        assertEquals(0, report.getDetailLines().get(categories.get(2)).getLineItems().size());
         assertEquals(50, report.getSumLine().getTotalNumberOfTasks());
 
     }
 
     @WithAccessId(userName = "monitor_user_1")
     @Test
-    public void testGetWorkbasketLevelReportWithReportLineItemDefinitions()
+    public void testGetCategoryReportWithReportLineItemDefinitions()
         throws WorkbasketNotFoundException, NotAuthorizedException {
 
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<Workbasket> workbaskets = getListOfWorkbaskets();
         List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
+        List<String> categories = Arrays.asList("EXTERN", "AUTOMATIC", "MANUAL");
         List<ReportLineItemDefinition> reportLineItemDefinitions = getListOfReportLineItemDefinitions();
 
-        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states, reportLineItemDefinitions);
+        Report report = taskMonitorService.getCategoryReport(workbaskets, states, reportLineItemDefinitions);
 
         int sumLineCount = report.getSumLine().getLineItems().get(0).getNumberOfTasks()
             + report.getSumLine().getLineItems().get(1).getNumberOfTasks()
@@ -103,23 +106,25 @@ public class ProvideWorkbasketLevelReportAccTest {
             + report.getSumLine().getLineItems().get(3).getNumberOfTasks()
             + report.getSumLine().getLineItems().get(4).getNumberOfTasks()
             + report.getSumLine().getLineItems().get(5).getNumberOfTasks()
-            + report.getSumLine().getLineItems().get(6).getNumberOfTasks();
+            + report.getSumLine().getLineItems().get(6).getNumberOfTasks()
+            + report.getSumLine().getLineItems().get(7).getNumberOfTasks()
+            + report.getSumLine().getLineItems().get(8).getNumberOfTasks();
 
-        Assert.assertNotNull(report);
+        assertNotNull(report);
 
-        assertEquals(20, report.getDetailLines().get(workbaskets.get(0).getKey()).getTotalNumberOfTasks());
-        assertEquals(20, report.getDetailLines().get(workbaskets.get(1).getKey()).getTotalNumberOfTasks());
-        assertEquals(10, report.getDetailLines().get(workbaskets.get(2).getKey()).getTotalNumberOfTasks());
-        assertEquals(0, report.getDetailLines().get(workbaskets.get(3).getKey()).getTotalNumberOfTasks());
+        assertEquals(33, report.getDetailLines().get(categories.get(0)).getTotalNumberOfTasks());
+        assertEquals(7, report.getDetailLines().get(categories.get(1)).getTotalNumberOfTasks());
+        assertEquals(10, report.getDetailLines().get(categories.get(2)).getTotalNumberOfTasks());
 
-        assertEquals(22, report.getSumLine().getLineItems().get(0).getNumberOfTasks());
-        assertEquals(5, report.getSumLine().getLineItems().get(1).getNumberOfTasks());
-        assertEquals(3, report.getSumLine().getLineItems().get(2).getNumberOfTasks());
-        assertEquals(4, report.getSumLine().getLineItems().get(3).getNumberOfTasks());
-        assertEquals(1, report.getSumLine().getLineItems().get(4).getNumberOfTasks());
-        assertEquals(4, report.getSumLine().getLineItems().get(5).getNumberOfTasks());
-        assertEquals(11, report.getSumLine().getLineItems().get(6).getNumberOfTasks());
-
+        assertEquals(11, report.getSumLine().getLineItems().get(0).getNumberOfTasks());
+        assertEquals(8, report.getSumLine().getLineItems().get(1).getNumberOfTasks());
+        assertEquals(11, report.getSumLine().getLineItems().get(2).getNumberOfTasks());
+        assertEquals(0, report.getSumLine().getLineItems().get(3).getNumberOfTasks());
+        assertEquals(4, report.getSumLine().getLineItems().get(4).getNumberOfTasks());
+        assertEquals(0, report.getSumLine().getLineItems().get(5).getNumberOfTasks());
+        assertEquals(7, report.getSumLine().getLineItems().get(6).getNumberOfTasks());
+        assertEquals(4, report.getSumLine().getLineItems().get(7).getNumberOfTasks());
+        assertEquals(5, report.getSumLine().getLineItems().get(8).getNumberOfTasks());
         assertEquals(50, report.getSumLine().getTotalNumberOfTasks());
         assertEquals(50, sumLineCount);
 
@@ -127,7 +132,7 @@ public class ProvideWorkbasketLevelReportAccTest {
 
     @WithAccessId(userName = "monitor_user_1")
     @Test
-    public void testGetWorkbasketLevelReportIfWorkbasketContainsNoTask()
+    public void testGetCategoryReportIfWorkbasketContainsNoTask()
         throws WorkbasketNotFoundException, NotAuthorizedException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
         WorkbasketService workbasketService = taskanaEngine.getWorkbasketService();
@@ -137,10 +142,10 @@ public class ProvideWorkbasketLevelReportAccTest {
             .getWorkbasket("WBI:000000000000000000000000000000000004");
         workbaskets.add(workbasket);
         List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
-        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states);
+        Report report = taskMonitorService.getCategoryReport(workbaskets, states);
 
         assertNotNull(report);
-        assertEquals(0, report.getDetailLines().get(workbaskets.get(0).getKey()).getTotalNumberOfTasks());
+        assertEquals(0, report.getDetailLines().size());
         assertEquals(0, report.getSumLine().getTotalNumberOfTasks());
     }
 
@@ -161,13 +166,15 @@ public class ProvideWorkbasketLevelReportAccTest {
 
     private List<ReportLineItemDefinition> getListOfReportLineItemDefinitions() {
         List<ReportLineItemDefinition> reportLineItemDefinitions = new ArrayList<>();
-        reportLineItemDefinitions.add(new ReportLineItemDefinition(Integer.MIN_VALUE, -6));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(Integer.MIN_VALUE, -11));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-10, -6));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(-5, -2));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(-1));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(0));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(1));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(2, 5));
-        reportLineItemDefinitions.add(new ReportLineItemDefinition(6, Integer.MAX_VALUE));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(6, 10));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(11, Integer.MAX_VALUE));
         return reportLineItemDefinitions;
     }
 

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideWorkbasketLevelReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideWorkbasketLevelReportAccTest.java
@@ -1,4 +1,4 @@
-package acceptance.task;
+package acceptance.monitoring;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -37,10 +37,10 @@ import pro.taskana.security.JAASRunner;
 import pro.taskana.security.WithAccessId;
 
 /**
- * Acceptance test for all "category report" scenarios.
+ * Acceptance test for all "workbasket level report" scenarios.
  */
 @RunWith(JAASRunner.class)
-public class ProvideCategoryReportAccTest {
+public class ProvideWorkbasketLevelReportAccTest {
 
     protected static TaskanaEngineConfiguration taskanaEngineConfiguration;
     protected static TaskanaEngine taskanaEngine;
@@ -65,40 +65,35 @@ public class ProvideCategoryReportAccTest {
 
     @WithAccessId(userName = "monitor_user_1")
     @Test
-    public void testGetTotalNumbersOfTasksOfCategoryReport()
+    public void testGetTotalNumbersOfTasksOfWorkbasketLevelReport()
         throws WorkbasketNotFoundException, NotAuthorizedException {
 
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<Workbasket> workbaskets = getListOfWorkbaskets();
         List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
-        List<String> categories = Arrays.asList("EXTERN", "AUTOMATIC", "MANUAL");
-        Report report = taskMonitorService.getCategoryReport(workbaskets, states);
+        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states);
 
         assertNotNull(report);
-        assertEquals(33, report.getDetailLines().get(categories.get(0)).getTotalNumberOfTasks());
-        assertEquals(7, report.getDetailLines().get(categories.get(1)).getTotalNumberOfTasks());
-        assertEquals(10, report.getDetailLines().get(categories.get(2)).getTotalNumberOfTasks());
-        assertEquals(0, report.getDetailLines().get(categories.get(0)).getLineItems().size());
-        assertEquals(0, report.getDetailLines().get(categories.get(1)).getLineItems().size());
-        assertEquals(0, report.getDetailLines().get(categories.get(2)).getLineItems().size());
+        assertEquals(20, report.getDetailLines().get(workbaskets.get(0).getKey()).getTotalNumberOfTasks());
+        assertEquals(20, report.getDetailLines().get(workbaskets.get(1).getKey()).getTotalNumberOfTasks());
+        assertEquals(10, report.getDetailLines().get(workbaskets.get(2).getKey()).getTotalNumberOfTasks());
         assertEquals(50, report.getSumLine().getTotalNumberOfTasks());
 
     }
 
     @WithAccessId(userName = "monitor_user_1")
     @Test
-    public void testGetCategoryReportWithReportLineItemDefinitions()
+    public void testGetWorkbasketLevelReportWithReportLineItemDefinitions()
         throws WorkbasketNotFoundException, NotAuthorizedException {
 
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<Workbasket> workbaskets = getListOfWorkbaskets();
         List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
-        List<String> categories = Arrays.asList("EXTERN", "AUTOMATIC", "MANUAL");
         List<ReportLineItemDefinition> reportLineItemDefinitions = getListOfReportLineItemDefinitions();
 
-        Report report = taskMonitorService.getCategoryReport(workbaskets, states, reportLineItemDefinitions);
+        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states, reportLineItemDefinitions);
 
         int sumLineCount = report.getSumLine().getLineItems().get(0).getNumberOfTasks()
             + report.getSumLine().getLineItems().get(1).getNumberOfTasks()
@@ -106,21 +101,25 @@ public class ProvideCategoryReportAccTest {
             + report.getSumLine().getLineItems().get(3).getNumberOfTasks()
             + report.getSumLine().getLineItems().get(4).getNumberOfTasks()
             + report.getSumLine().getLineItems().get(5).getNumberOfTasks()
-            + report.getSumLine().getLineItems().get(6).getNumberOfTasks();
+            + report.getSumLine().getLineItems().get(6).getNumberOfTasks()
+            + report.getSumLine().getLineItems().get(7).getNumberOfTasks()
+            + report.getSumLine().getLineItems().get(8).getNumberOfTasks();
 
         assertNotNull(report);
-        assertEquals(33, report.getDetailLines().get(categories.get(0)).getTotalNumberOfTasks());
-        assertEquals(7, report.getDetailLines().get(categories.get(1)).getTotalNumberOfTasks());
-        assertEquals(10, report.getDetailLines().get(categories.get(2)).getTotalNumberOfTasks());
 
-        assertEquals(22, report.getSumLine().getLineItems().get(0).getNumberOfTasks());
-        assertEquals(5, report.getSumLine().getLineItems().get(1).getNumberOfTasks());
-        assertEquals(3, report.getSumLine().getLineItems().get(2).getNumberOfTasks());
-        assertEquals(4, report.getSumLine().getLineItems().get(3).getNumberOfTasks());
-        assertEquals(1, report.getSumLine().getLineItems().get(4).getNumberOfTasks());
-        assertEquals(4, report.getSumLine().getLineItems().get(5).getNumberOfTasks());
-        assertEquals(11, report.getSumLine().getLineItems().get(6).getNumberOfTasks());
+        assertEquals(20, report.getDetailLines().get(workbaskets.get(0).getKey()).getTotalNumberOfTasks());
+        assertEquals(20, report.getDetailLines().get(workbaskets.get(1).getKey()).getTotalNumberOfTasks());
+        assertEquals(10, report.getDetailLines().get(workbaskets.get(2).getKey()).getTotalNumberOfTasks());
 
+        assertEquals(11, report.getSumLine().getLineItems().get(0).getNumberOfTasks());
+        assertEquals(8, report.getSumLine().getLineItems().get(1).getNumberOfTasks());
+        assertEquals(11, report.getSumLine().getLineItems().get(2).getNumberOfTasks());
+        assertEquals(0, report.getSumLine().getLineItems().get(3).getNumberOfTasks());
+        assertEquals(4, report.getSumLine().getLineItems().get(4).getNumberOfTasks());
+        assertEquals(0, report.getSumLine().getLineItems().get(5).getNumberOfTasks());
+        assertEquals(7, report.getSumLine().getLineItems().get(6).getNumberOfTasks());
+        assertEquals(4, report.getSumLine().getLineItems().get(7).getNumberOfTasks());
+        assertEquals(5, report.getSumLine().getLineItems().get(8).getNumberOfTasks());
         assertEquals(50, report.getSumLine().getTotalNumberOfTasks());
         assertEquals(50, sumLineCount);
 
@@ -128,7 +127,7 @@ public class ProvideCategoryReportAccTest {
 
     @WithAccessId(userName = "monitor_user_1")
     @Test
-    public void testGetCategoryReportIfWorkbasketContainsNoTask()
+    public void testGetWorkbasketLevelReportIfWorkbasketContainsNoTask()
         throws WorkbasketNotFoundException, NotAuthorizedException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
         WorkbasketService workbasketService = taskanaEngine.getWorkbasketService();
@@ -138,10 +137,9 @@ public class ProvideCategoryReportAccTest {
             .getWorkbasket("WBI:000000000000000000000000000000000004");
         workbaskets.add(workbasket);
         List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
-        Report report = taskMonitorService.getCategoryReport(workbaskets, states);
+        Report report = taskMonitorService.getWorkbasketLevelReport(workbaskets, states);
 
         assertNotNull(report);
-        assertEquals(0, report.getDetailLines().size());
         assertEquals(0, report.getSumLine().getTotalNumberOfTasks());
     }
 
@@ -162,13 +160,15 @@ public class ProvideCategoryReportAccTest {
 
     private List<ReportLineItemDefinition> getListOfReportLineItemDefinitions() {
         List<ReportLineItemDefinition> reportLineItemDefinitions = new ArrayList<>();
-        reportLineItemDefinitions.add(new ReportLineItemDefinition(Integer.MIN_VALUE, -6));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(Integer.MIN_VALUE, -11));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-10, -6));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(-5, -2));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(-1));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(0));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(1));
         reportLineItemDefinitions.add(new ReportLineItemDefinition(2, 5));
-        reportLineItemDefinitions.add(new ReportLineItemDefinition(6, Integer.MAX_VALUE));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(6, 10));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(11, Integer.MAX_VALUE));
         return reportLineItemDefinitions;
     }
 

--- a/lib/taskana-core/src/test/java/pro/taskana/database/TestDataGenerator.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/database/TestDataGenerator.java
@@ -105,9 +105,9 @@ public class TestDataGenerator {
         StringBuilder sql = new StringBuilder();
         String line;
 
-        List<Integer> ages = Arrays.asList(-1500, -1200, -1000, -1000, -1000, -500, -500, -300, -200, -100, -50, -20,
-            -15, -15, -14, -13, -12, -10, -8, -6, -6, -6, -5, -5, -5, -5, -2, -1, -1, -1, 0, 0, 0, 0, 1, 2, 3, 4, 5, 6,
-            7, 8, 9, 10, 100, 150, 150, 1000, 10000, 100000);
+        List<Integer> ages = Arrays.asList(-70000, -14000, -2800, -1400, -1400, -700, -700, -35, -28, -28, -15, -14,
+            -14, -14, -14, -14, -14, -14, -14, -7, -7, -7, -7, -7, -7, -7, -7, -7, -7, -7, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7,
+            7, 14, 14, 14, 14, 21, 210, 210, 28000, 700000);
         int i = 0;
         while ((line = bufferedReader.readLine()) != null) {
             if (line.contains("dueDate")) {

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/DaysToWorkingDaysConverterTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/DaysToWorkingDaysConverterTest.java
@@ -1,0 +1,89 @@
+package pro.taskana.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+
+import pro.taskana.model.ReportLineItemDefinition;
+
+/**
+ * Test for the DaysToWorkingDaysConverter.
+ */
+public class DaysToWorkingDaysConverterTest {
+
+    @Test
+    public void testInitializeForDifferentReportLineItemDefinitions() {
+        DaysToWorkingDaysConverter instance1 = DaysToWorkingDaysConverter
+            .initialize(getShortListOfReportLineItemDefinitions(), LocalDate.of(2018, 02, 03));
+        DaysToWorkingDaysConverter instance2 = DaysToWorkingDaysConverter
+            .initialize(getShortListOfReportLineItemDefinitions(), LocalDate.of(2018, 02, 03));
+        DaysToWorkingDaysConverter instance3 = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), LocalDate.of(2018, 02, 03));
+
+        assertEquals(instance1, instance2);
+        assertNotEquals(instance1, instance3);
+    }
+
+    @Test
+    public void testInitializeForDifferentDates() {
+        DaysToWorkingDaysConverter instance1 = DaysToWorkingDaysConverter
+            .initialize(getShortListOfReportLineItemDefinitions(), LocalDate.of(2018, 02, 04));
+        DaysToWorkingDaysConverter instance2 = DaysToWorkingDaysConverter
+            .initialize(getShortListOfReportLineItemDefinitions(), LocalDate.of(2018, 02, 05));
+
+        assertNotEquals(instance1, instance2);
+    }
+
+    @Test
+    public void testConvertDaysToWorkingDays() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), LocalDate.of(2018, 02, 06));
+
+        assertEquals(16, instance.convertDaysToWorkingDays(16));
+        assertEquals(11, instance.convertDaysToWorkingDays(15));
+
+        assertEquals(-2, instance.convertDaysToWorkingDays(-4));
+        assertEquals(-1, instance.convertDaysToWorkingDays(-3));
+        assertEquals(-1, instance.convertDaysToWorkingDays(-2));
+        assertEquals(-1, instance.convertDaysToWorkingDays(-1));
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(1, instance.convertDaysToWorkingDays(1));
+        assertEquals(2, instance.convertDaysToWorkingDays(2));
+        assertEquals(3, instance.convertDaysToWorkingDays(3));
+        assertEquals(3, instance.convertDaysToWorkingDays(4));
+        assertEquals(3, instance.convertDaysToWorkingDays(5));
+        assertEquals(4, instance.convertDaysToWorkingDays(6));
+
+        assertEquals(11, instance.convertDaysToWorkingDays(15));
+        assertEquals(16, instance.convertDaysToWorkingDays(16));
+    }
+
+    private List<ReportLineItemDefinition> getShortListOfReportLineItemDefinitions() {
+        List<ReportLineItemDefinition> reportLineItemDefinitions = new ArrayList<>();
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(Integer.MIN_VALUE, -3));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-1, -2));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(0));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(1, 2));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(3, Integer.MAX_VALUE));
+        return reportLineItemDefinitions;
+    }
+
+    private List<ReportLineItemDefinition> getLargeListOfReportLineItemDefinitions() {
+        List<ReportLineItemDefinition> reportLineItemDefinitions = new ArrayList<>();
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(Integer.MIN_VALUE, -11));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-10, -6));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-5, -2));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-1));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(0));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(1));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(2, 5));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(6, 10));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(11, Integer.MAX_VALUE));
+        return reportLineItemDefinitions;
+    }
+}


### PR DESCRIPTION
- Create a converter that converts days to working days by using a table
- The table should exist all day if no changes are required
- Create tests for this converter
- Modify the existing report functions to count the age in working days
- Update test and sample data
- Remove empty lines from the WorkbasketLevelReport