### PR TITLE
TSK-271: Add custom holiday support to the monitor

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/configuration/TaskanaEngineConfiguration.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/configuration/TaskanaEngineConfiguration.java
@@ -1,6 +1,8 @@
 package pro.taskana.configuration;
 
 import java.sql.SQLException;
+import java.time.LocalDate;
+import java.util.List;
 
 import javax.sql.DataSource;
 
@@ -35,6 +37,9 @@ public class TaskanaEngineConfiguration {
     // authorizations
     protected boolean securityEnabled = true;
     protected boolean useManagedTransactions;
+
+    private boolean germanPublicHolidaysEnabled;
+    private List<LocalDate> customHolidays;
 
     public TaskanaEngineConfiguration(boolean enableSecurity) {
         this.securityEnabled = enableSecurity;
@@ -132,6 +137,22 @@ public class TaskanaEngineConfiguration {
 
     public void setPropertiesSeparator(String propertiesSeparator) {
         this.propertiesSeparator = propertiesSeparator;
+    }
+
+    public boolean isGermanPublicHolidaysEnabled() {
+        return this.germanPublicHolidaysEnabled;
+    }
+
+    public void setGermanPublicHolidaysEnabled(boolean germanPublicHolidaysEnabled) {
+        this.germanPublicHolidaysEnabled = germanPublicHolidaysEnabled;
+    }
+
+    public List<LocalDate> getCustomHolidays() {
+        return customHolidays;
+    }
+
+    public void setCustomHolidays(List<LocalDate> customHolidays) {
+        this.customHolidays = customHolidays;
     }
 
     /**

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/TaskMonitorServiceImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/TaskMonitorServiceImpl.java
@@ -52,6 +52,8 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         try {
             taskanaEngineImpl.openConnection();
 
+            configureDaysToWorkingDaysConverter();
+
             Report report = new Report();
             List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
                 .getTaskCountOfWorkbasketsByWorkbasketsAndStates(workbasketIds, states, categories, domains);
@@ -61,7 +63,6 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         } finally {
             taskanaEngineImpl.returnConnection();
             LOGGER.debug("exit from getWorkbasketLevelReport().");
-
         }
     }
 
@@ -90,6 +91,8 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         }
         try {
             taskanaEngineImpl.openConnection();
+
+            configureDaysToWorkingDaysConverter();
 
             Report report = new Report();
             List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
@@ -129,6 +132,8 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         }
         try {
             taskanaEngineImpl.openConnection();
+
+            configureDaysToWorkingDaysConverter();
 
             ClassificationReport report = new ClassificationReport();
             List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
@@ -172,6 +177,8 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         }
         try {
             taskanaEngineImpl.openConnection();
+
+            configureDaysToWorkingDaysConverter();
 
             DetailedClassificationReport report = new DetailedClassificationReport();
             List<DetailedMonitorQueryItem> detailedMonitorQueryItems = taskMonitorMapper
@@ -217,6 +224,8 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         try {
             taskanaEngineImpl.openConnection();
 
+            configureDaysToWorkingDaysConverter();
+
             Report report = new Report();
             List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
                 .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(workbasketIds, states, categories,
@@ -228,6 +237,12 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
             taskanaEngineImpl.returnConnection();
             LOGGER.debug("exit from getCustomFieldValueReport().");
         }
+    }
+
+    private void configureDaysToWorkingDaysConverter() {
+        DaysToWorkingDaysConverter.setCustomHolidays(taskanaEngineImpl.getConfiguration().getCustomHolidays());
+        DaysToWorkingDaysConverter.setGermanPublicHolidaysEnabled(
+            this.taskanaEngineImpl.getConfiguration().isGermanPublicHolidaysEnabled());
     }
 
 }

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCategoryReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCategoryReportAccTest.java
@@ -51,6 +51,7 @@ public class ProvideCategoryReportAccTest {
         cleaner.clearDb(dataSource, true);
         dataSource = TaskanaEngineConfigurationTest.getDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngineConfiguration.setGermanPublicHolidaysEnabled(false);
         taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
         ((TaskanaEngineImpl) taskanaEngine).setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
         cleaner.clearDb(dataSource, false);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideClassificationReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideClassificationReportAccTest.java
@@ -51,6 +51,7 @@ public class ProvideClassificationReportAccTest {
         cleaner.clearDb(dataSource, true);
         dataSource = TaskanaEngineConfigurationTest.getDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngineConfiguration.setGermanPublicHolidaysEnabled(false);
         taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
         ((TaskanaEngineImpl) taskanaEngine).setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
         cleaner.clearDb(dataSource, false);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCustomFieldValueReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCustomFieldValueReportAccTest.java
@@ -52,6 +52,7 @@ public class ProvideCustomFieldValueReportAccTest {
         cleaner.clearDb(dataSource, true);
         dataSource = TaskanaEngineConfigurationTest.getDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngineConfiguration.setGermanPublicHolidaysEnabled(false);
         taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
         ((TaskanaEngineImpl) taskanaEngine).setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
         cleaner.clearDb(dataSource, false);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideDetailedClassificationReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideDetailedClassificationReportAccTest.java
@@ -54,6 +54,7 @@ public class ProvideDetailedClassificationReportAccTest {
         cleaner.clearDb(dataSource, true);
         dataSource = TaskanaEngineConfigurationTest.getDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngineConfiguration.setGermanPublicHolidaysEnabled(false);
         taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
         ((TaskanaEngineImpl) taskanaEngine).setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
         cleaner.clearDb(dataSource, false);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideWorkbasketLevelReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideWorkbasketLevelReportAccTest.java
@@ -51,6 +51,7 @@ public class ProvideWorkbasketLevelReportAccTest {
         cleaner.clearDb(dataSource, true);
         dataSource = TaskanaEngineConfigurationTest.getDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngineConfiguration.setGermanPublicHolidaysEnabled(false);
         taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
         ((TaskanaEngineImpl) taskanaEngine).setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
         cleaner.clearDb(dataSource, false);

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/DaysToWorkingDaysConverterTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/DaysToWorkingDaysConverterTest.java
@@ -4,15 +4,26 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
  * Test for the DaysToWorkingDaysConverter.
  */
 public class DaysToWorkingDaysConverterTest {
+
+    @BeforeClass
+    public static void setup() {
+        DaysToWorkingDaysConverter.setGermanPublicHolidaysEnabled(true);
+        LocalDate dayOfReformation = LocalDate.of(2018, 10, 31);
+        LocalDate allSaintsDays = LocalDate.of(2018, 11, 1);
+        DaysToWorkingDaysConverter.setCustomHolidays(Arrays.asList(dayOfReformation, allSaintsDays));
+    }
 
     @Test
     public void testInitializeForDifferentReportLineItemDefinitions() {
@@ -59,6 +70,146 @@ public class DaysToWorkingDaysConverterTest {
 
         assertEquals(11, instance.convertDaysToWorkingDays(15));
         assertEquals(16, instance.convertDaysToWorkingDays(16));
+    }
+
+    @Test
+    public void testEasterHolidays() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-03-28T00:00:00.000Z"));
+
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(1, instance.convertDaysToWorkingDays(1));
+        assertEquals(1, instance.convertDaysToWorkingDays(2));
+        assertEquals(1, instance.convertDaysToWorkingDays(3));
+        assertEquals(1, instance.convertDaysToWorkingDays(4));
+        assertEquals(1, instance.convertDaysToWorkingDays(5));
+        assertEquals(2, instance.convertDaysToWorkingDays(6));
+    }
+
+    @Test
+    public void testWhitsunHolidays() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-05-16T00:00:00.000Z"));
+
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(1, instance.convertDaysToWorkingDays(1));
+        assertEquals(2, instance.convertDaysToWorkingDays(2));
+        assertEquals(2, instance.convertDaysToWorkingDays(3));
+        assertEquals(2, instance.convertDaysToWorkingDays(4));
+        assertEquals(2, instance.convertDaysToWorkingDays(5));
+        assertEquals(3, instance.convertDaysToWorkingDays(6));
+    }
+
+    @Test
+    public void testLabourDayHoliday() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-04-26T00:00:00.000Z"));
+
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(1, instance.convertDaysToWorkingDays(1));
+        assertEquals(1, instance.convertDaysToWorkingDays(2));
+        assertEquals(1, instance.convertDaysToWorkingDays(3));
+        assertEquals(2, instance.convertDaysToWorkingDays(4));
+        assertEquals(2, instance.convertDaysToWorkingDays(5));
+        assertEquals(3, instance.convertDaysToWorkingDays(6));
+        assertEquals(4, instance.convertDaysToWorkingDays(7));
+    }
+
+    @Test
+    public void testAscensionDayHoliday() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-05-07T00:00:00.000Z"));
+
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(1, instance.convertDaysToWorkingDays(1));
+        assertEquals(2, instance.convertDaysToWorkingDays(2));
+        assertEquals(2, instance.convertDaysToWorkingDays(3));
+        assertEquals(3, instance.convertDaysToWorkingDays(4));
+        assertEquals(3, instance.convertDaysToWorkingDays(5));
+        assertEquals(3, instance.convertDaysToWorkingDays(6));
+        assertEquals(4, instance.convertDaysToWorkingDays(7));
+    }
+
+    @Test
+    public void testDayOfGermanUnityHoliday() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-10-01T00:00:00.000Z"));
+
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(1, instance.convertDaysToWorkingDays(1));
+        assertEquals(1, instance.convertDaysToWorkingDays(2));
+        assertEquals(2, instance.convertDaysToWorkingDays(3));
+        assertEquals(3, instance.convertDaysToWorkingDays(4));
+        assertEquals(3, instance.convertDaysToWorkingDays(5));
+        assertEquals(3, instance.convertDaysToWorkingDays(6));
+        assertEquals(4, instance.convertDaysToWorkingDays(7));
+    }
+
+    @Test
+    public void testChristmasAndNewYearHolidays() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-12-20T00:00:00.000Z"));
+
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(1, instance.convertDaysToWorkingDays(1));
+        assertEquals(1, instance.convertDaysToWorkingDays(2));
+        assertEquals(1, instance.convertDaysToWorkingDays(3));
+        assertEquals(2, instance.convertDaysToWorkingDays(4));
+        assertEquals(2, instance.convertDaysToWorkingDays(5));
+        assertEquals(2, instance.convertDaysToWorkingDays(6));
+        assertEquals(3, instance.convertDaysToWorkingDays(7));
+        assertEquals(4, instance.convertDaysToWorkingDays(8));
+        assertEquals(4, instance.convertDaysToWorkingDays(9));
+        assertEquals(4, instance.convertDaysToWorkingDays(10));
+        assertEquals(5, instance.convertDaysToWorkingDays(11));
+        assertEquals(5, instance.convertDaysToWorkingDays(12));
+        assertEquals(6, instance.convertDaysToWorkingDays(13));
+        assertEquals(7, instance.convertDaysToWorkingDays(14));
+    }
+
+    @Test
+    public void testCustomHolidaysWithDayOfReformationAndAllSaintsDay() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-10-26T00:00:00.000Z"));
+
+        assertEquals(0, instance.convertDaysToWorkingDays(0));
+        assertEquals(0, instance.convertDaysToWorkingDays(1));
+        assertEquals(0, instance.convertDaysToWorkingDays(2));
+        assertEquals(1, instance.convertDaysToWorkingDays(3));
+        assertEquals(2, instance.convertDaysToWorkingDays(4));
+        assertEquals(2, instance.convertDaysToWorkingDays(5));
+        assertEquals(2, instance.convertDaysToWorkingDays(6));
+        assertEquals(3, instance.convertDaysToWorkingDays(7));
+
+    }
+
+    @Test
+    public void testgetEasterSunday() {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getShortListOfReportLineItemDefinitions(), Instant.parse("2018-02-27T00:00:00.000Z"));
+
+        assertEquals(LocalDate.of(2018, 4, 1), instance.getEasterSunday(2018));
+        assertEquals(LocalDate.of(2019, 4, 21), instance.getEasterSunday(2019));
+        assertEquals(LocalDate.of(2020, 4, 12), instance.getEasterSunday(2020));
+        assertEquals(LocalDate.of(2021, 4, 4), instance.getEasterSunday(2021));
+        assertEquals(LocalDate.of(2022, 4, 17), instance.getEasterSunday(2022));
+        assertEquals(LocalDate.of(2023, 4, 9), instance.getEasterSunday(2023));
+        assertEquals(LocalDate.of(2024, 3, 31), instance.getEasterSunday(2024));
+        assertEquals(LocalDate.of(2025, 4, 20), instance.getEasterSunday(2025));
+        assertEquals(LocalDate.of(2026, 4, 5), instance.getEasterSunday(2026));
+        assertEquals(LocalDate.of(2027, 3, 28), instance.getEasterSunday(2027));
+        assertEquals(LocalDate.of(2028, 4, 16), instance.getEasterSunday(2028));
+        assertEquals(LocalDate.of(2029, 4, 1), instance.getEasterSunday(2029));
+        assertEquals(LocalDate.of(2030, 4, 21), instance.getEasterSunday(2030));
+        assertEquals(LocalDate.of(2031, 4, 13), instance.getEasterSunday(2031));
+        assertEquals(LocalDate.of(2032, 3, 28), instance.getEasterSunday(2032));
+        assertEquals(LocalDate.of(2033, 4, 17), instance.getEasterSunday(2033));
+        assertEquals(LocalDate.of(2034, 4, 9), instance.getEasterSunday(2034));
+        assertEquals(LocalDate.of(2035, 3, 25), instance.getEasterSunday(2035));
+        assertEquals(LocalDate.of(2040, 4, 1), instance.getEasterSunday(2040));
+        assertEquals(LocalDate.of(2050, 4, 10), instance.getEasterSunday(2050));
+        assertEquals(LocalDate.of(2100, 3, 28), instance.getEasterSunday(2100));
+
     }
 
     private List<ReportLineItemDefinition> getShortListOfReportLineItemDefinitions() {

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/TaskMonitorServiceImplTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/TaskMonitorServiceImplTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.mappings.TaskMonitorMapper;
 
 /**
@@ -36,6 +37,9 @@ public class TaskMonitorServiceImplTest {
     private TaskanaEngineImpl taskanaEngineImplMock;
 
     @Mock
+    private TaskanaEngineConfiguration taskanaEngineConfiguration;
+
+    @Mock
     private TaskMonitorMapper taskMonitorMapperMock;
 
     @Before
@@ -43,6 +47,9 @@ public class TaskMonitorServiceImplTest {
         MockitoAnnotations.initMocks(this);
         Mockito.doNothing().when(taskanaEngineImplMock).openConnection();
         Mockito.doNothing().when(taskanaEngineImplMock).returnConnection();
+        doReturn(taskanaEngineConfiguration).when(taskanaEngineImplMock).getConfiguration();
+        doReturn(true).when(taskanaEngineConfiguration).isGermanPublicHolidaysEnabled();
+        doReturn(null).when(taskanaEngineConfiguration).getCustomHolidays();
     }
 
     @Test
@@ -63,10 +70,13 @@ public class TaskMonitorServiceImplTest {
         Report actualResult = cut.getWorkbasketLevelReport(workbasketIds, states, categories, domains);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfWorkbasketsByWorkbasketsAndStates(any(), any(), any(),
             any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(
@@ -96,10 +106,13 @@ public class TaskMonitorServiceImplTest {
             reportLineItemDefinitions);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfWorkbasketsByWorkbasketsAndStates(any(), any(), any(),
             any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(
@@ -132,10 +145,13 @@ public class TaskMonitorServiceImplTest {
         Report actualResult = cut.getCategoryReport(workbasketIds, states, categories, domains);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfCategoriesByWorkbasketsAndStates(any(), any(), any(),
             any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(actualResult.getReportLines().get("EXTERN").getTotalNumberOfTasks(), 1);
@@ -164,10 +180,13 @@ public class TaskMonitorServiceImplTest {
             reportLineItemDefinitions);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfCategoriesByWorkbasketsAndStates(any(), any(), any(),
             any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(actualResult.getReportLines().get("EXTERN").getTotalNumberOfTasks(), 1);
@@ -193,10 +212,13 @@ public class TaskMonitorServiceImplTest {
         ClassificationReport actualResult = cut.getClassificationReport(workbasketIds, states, categories, domains);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfClassificationsByWorkbasketsAndStates(any(), any(), any(),
             any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(
@@ -226,10 +248,13 @@ public class TaskMonitorServiceImplTest {
             reportLineItemDefinitions);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfClassificationsByWorkbasketsAndStates(any(), any(), any(),
             any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(
@@ -262,10 +287,13 @@ public class TaskMonitorServiceImplTest {
             categories, domains);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(any(),
             any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         DetailedReportLine line = (DetailedReportLine) actualResult.getReportLines()
             .get("CLI:000000000000000000000000000000000001");
@@ -295,14 +323,16 @@ public class TaskMonitorServiceImplTest {
             .getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(workbasketIds, states, categories, domains);
 
         DetailedClassificationReport actualResult = cut.getDetailedClassificationReport(workbasketIds, states,
-            categories,
-            domains, reportLineItemDefinitions);
+            categories, domains, reportLineItemDefinitions);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1)).getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(any(),
             any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         DetailedReportLine line = (DetailedReportLine) actualResult.getReportLines()
             .get("CLI:000000000000000000000000000000000001");
@@ -339,10 +369,13 @@ public class TaskMonitorServiceImplTest {
             CustomField.CUSTOM_1);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1))
             .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(any(), any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(actualResult.getReportLines().get("Geschaeftsstelle A").getTotalNumberOfTasks(), 1);
@@ -372,10 +405,13 @@ public class TaskMonitorServiceImplTest {
             CustomField.CUSTOM_1, reportLineItemDefinitions);
 
         verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1))
             .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(any(), any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
-        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock);
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
         assertNotNull(actualResult);
         assertEquals(actualResult.getReportLines().get("Geschaeftsstelle A").getTotalNumberOfTasks(), 1);


### PR DESCRIPTION
- Consider fix holidays like Christmas and movable holidays like Easter
- Calculate Easter Sunday with Gauss' formula and determine the other movable holidays with this day
- Make holidays configurable
- Add tests for all holidays
- Adapt existing acceptance and unit tests