### PR TITLE
TSK-341: No Exception when Classification-parent for ID does not exist

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/ClassificationService.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/ClassificationService.java
@@ -65,20 +65,22 @@ public interface ClassificationService {
      *             when the classification does already exists at the given domain.
      * @throws NotAuthorizedException
      *             if the current user is not member of role BUSINESS_ADMIN or ADMIN
+     * @throws ClassificationNotFoundException
+     *             if the current parentId is not NULL/EMPTY and can not be found.
      */
     Classification createClassification(Classification classification)
-        throws ClassificationAlreadyExistException, NotAuthorizedException;
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException;
 
     /**
-     * Update a Classification.
+     * Updates a Classification.
      *
      * @param classification
      *            the Classification to update
      * @return the updated Classification.
      * @throws ClassificationNotFoundException
-     *             when the classification does not exist already.
+     *             when the classification OR it´s parent does not exist.
      * @throws NotAuthorizedException
-     *             when a user got no permissions for WB content tasks.
+     *             when the caller got no ADMIN or BUSINESS_ADMIN permissions.
      * @throws ConcurrencyException
      *             when the Classification was modified meanwhile and is not latest anymore.
      */

--- a/lib/taskana-core/src/test/java/acceptance/classification/CreateClassificationAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/classification/CreateClassificationAccTest.java
@@ -98,7 +98,7 @@ public class CreateClassificationAccTest extends AbstractAccTest {
         groupNames = {"group_1", "businessadmin"})
     @Test
     public void testCreateClassificationWithInvalidValues()
-        throws ClassificationAlreadyExistException, NotAuthorizedException {
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException {
         long amountOfClassificationsBefore = classificationService.createClassificationQuery().count();
 
         // Check key NULL
@@ -135,9 +135,20 @@ public class CreateClassificationAccTest extends AbstractAccTest {
         groupNames = {"group_1", "businessadmin"})
     @Test(expected = ClassificationAlreadyExistException.class)
     public void testCreateClassificationAlreadyExisting()
-        throws ClassificationAlreadyExistException, NotAuthorizedException {
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException {
         Classification classification = classificationService.newClassification("Key3", "", "TASK");
         classification = classificationService.createClassification(classification);
+        classification = classificationService.createClassification(classification);
+    }
+
+    @WithAccessId(
+        userName = "teamlead_1",
+        groupNames = {"group_1", "businessadmin"})
+    @Test(expected = ClassificationNotFoundException.class)
+    public void testCreateClassificationWithInvalidParent()
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException {
+        Classification classification = classificationService.newClassification("Key4", "", "TASK");
+        classification.setParentId("ID WHICH CANT BE FOUND");
         classification = classificationService.createClassification(classification);
     }
 

--- a/lib/taskana-core/src/test/java/acceptance/classification/UpdateClassificationAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/classification/UpdateClassificationAccTest.java
@@ -62,7 +62,7 @@ public class UpdateClassificationAccTest extends AbstractAccTest {
         classification.setDescription("newDescription");
         classification.setIsValidInDomain(false);
         classification.setName(newName);
-        classification.setParentId("T2000");
+        classification.setParentId("CLI:100000000000000000000000000000000004");
         classification.setPriority(1000);
         classification.setServiceLevel("P2DT3H4M");
 
@@ -154,6 +154,19 @@ public class UpdateClassificationAccTest extends AbstractAccTest {
         classification.setDescription("IT SHOULD BE TO LATE...");
         classificationService.updateClassification(classification);
         fail("The Classification should not be updated, because it was modified while editing.");
+    }
+
+    @WithAccessId(
+        userName = "teamlead_1",
+        groupNames = {"group_1", "businessadmin"})
+    @Test(expected = ClassificationNotFoundException.class)
+    public void testUpdateClassificationParentToInvalid()
+        throws NotAuthorizedException, ClassificationNotFoundException,
+        ConcurrencyException {
+        ClassificationService classificationService = taskanaEngine.getClassificationService();
+        Classification classification = classificationService.getClassification("T2100", "DOMAIN_A");
+        classification.setParentId("ID WHICH CANT BE FOUND");
+        classification = classificationService.updateClassification(classification);
     }
 
     @AfterClass

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/integration/ClassificationServiceImplIntAutoCommitTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/integration/ClassificationServiceImplIntAutoCommitTest.java
@@ -160,7 +160,8 @@ public class ClassificationServiceImplIntAutoCommitTest {
     }
 
     @Test
-    public void testFindAllClassifications() throws ClassificationAlreadyExistException, NotAuthorizedException {
+    public void testFindAllClassifications()
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException {
         Classification classification0 = this.createDummyClassificationWithUniqueKey("", "type1");
         classificationService.createClassification(classification0);
         Classification classification1 = this.createDummyClassificationWithUniqueKey("", "type1");
@@ -227,7 +228,7 @@ public class ClassificationServiceImplIntAutoCommitTest {
 
     @Test
     public void testFindWithClassificationMapperDomainAndCategory()
-        throws ClassificationAlreadyExistException, NotAuthorizedException {
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException {
         Classification classification1 = this.createDummyClassificationWithUniqueKey("domain1", "type1");
         classification1.setCategory("category1");
         classificationService.createClassification(classification1);
@@ -249,7 +250,7 @@ public class ClassificationServiceImplIntAutoCommitTest {
 
     @Test
     public void testFindWithClassificationMapperCustomAndCategory()
-        throws ClassificationAlreadyExistException, NotAuthorizedException {
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException {
         Classification classification1 = this.createDummyClassificationWithUniqueKey("", "type1");
         classification1.setDescription("DESC1");
         classification1.setCategory("category1");
@@ -286,26 +287,27 @@ public class ClassificationServiceImplIntAutoCommitTest {
 
     @Test
     public void testFindWithClassificationMapperPriorityTypeAndParent()
-        throws ClassificationAlreadyExistException, NumberFormatException, NotAuthorizedException {
+        throws ClassificationAlreadyExistException, NumberFormatException, NotAuthorizedException,
+        ClassificationNotFoundException {
         Classification classification = this.createDummyClassificationWithUniqueKey("", "type1");
         classification.setPriority(Integer.decode("5"));
         classificationService.createClassification(classification);
         Classification classification1 = this.createDummyClassificationWithUniqueKey("", "type1");
         classification1.setPriority(Integer.decode("3"));
-        classification1.setParentId(classification.getKey());
+        classification1.setParentId(classification.getId());
         classificationService.createClassification(classification1);
         Classification classification2 = this.createDummyClassificationWithUniqueKey("", "type2");
         classification2.setPriority(Integer.decode("5"));
-        classification2.setParentId(classification.getKey());
+        classification2.setParentId(classification.getId());
         classificationService.createClassification(classification2);
 
         Classification classification3 = this.createDummyClassificationWithUniqueKey("", "type1");
         classification3.setPriority(Integer.decode("5"));
-        classification3.setParentId(classification1.getKey());
+        classification3.setParentId(classification1.getId());
         classificationService.createClassification(classification3);
 
         List<ClassificationSummary> list = classificationService.createClassificationQuery()
-            .parentIdIn(classification.getKey())
+            .parentIdIn(classification.getId())
             .list();
         Assert.assertEquals(2, list.size());
         list = classificationService.createClassificationQuery().typeIn("type1").priorityIn(Integer.decode("5")).list();
@@ -313,14 +315,14 @@ public class ClassificationServiceImplIntAutoCommitTest {
         list = classificationService.createClassificationQuery()
             .priorityIn(Integer.decode("5"))
             .typeIn("type1")
-            .parentIdIn(classification1.getKey())
+            .parentIdIn(classification1.getId())
             .list();
         Assert.assertEquals(1, list.size());
     }
 
     @Test
     public void testFindWithClassificationMapperServiceLevelNameAndDescription()
-        throws ClassificationAlreadyExistException, NotAuthorizedException {
+        throws ClassificationAlreadyExistException, NotAuthorizedException, ClassificationNotFoundException {
         int all = 0;
         Classification classification = this.createDummyClassificationWithUniqueKey("", "type1");
         classification.setServiceLevel("P1D");
@@ -366,7 +368,7 @@ public class ClassificationServiceImplIntAutoCommitTest {
         Classification classification1 = this.createDummyClassificationWithUniqueKey("UNIQUE-DOMAIN", "type1");
         classification1 = classificationService.createClassification(classification1);
 
-        classification1.setParentId(classification.getKey());
+        classification1.setParentId(classification.getId());
         classification1 = classificationService.updateClassification(classification1);
 
         List<ClassificationSummary> list = classificationService.createClassificationQuery()

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/integration/ClassificationServiceImplIntExplicitTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/integration/ClassificationServiceImplIntExplicitTest.java
@@ -171,7 +171,8 @@ public class ClassificationServiceImplIntExplicitTest {
 
     @Test
     public void testFindAllClassifications()
-        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException {
+        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException,
+        ClassificationNotFoundException {
         Connection connection = dataSource.getConnection();
         taskanaEngineImpl.setConnection(connection);
         Classification classification0 = this.createNewClassificationWithUniqueKey("", "t1");
@@ -208,7 +209,8 @@ public class ClassificationServiceImplIntExplicitTest {
 
     @Test
     public void testInsertAndClassificationQuery()
-        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException {
+        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException,
+        ClassificationNotFoundException {
         Connection connection = dataSource.getConnection();
         taskanaEngineImpl.setConnection(connection);
         Classification classification = this.createNewClassificationWithUniqueKey("UNIQUE-DOMAIN", "t1");
@@ -251,7 +253,8 @@ public class ClassificationServiceImplIntExplicitTest {
 
     @Test
     public void testFindWithClassificationMapperDomainAndCategory()
-        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException {
+        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException,
+        ClassificationNotFoundException {
         Connection connection = dataSource.getConnection();
         taskanaEngineImpl.setConnection(connection);
         Classification classification1 = this.createNewClassificationWithUniqueKey("domain1", "t1");
@@ -277,7 +280,8 @@ public class ClassificationServiceImplIntExplicitTest {
 
     @Test
     public void testFindWithClassificationMapperCustomAndCategory()
-        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException {
+        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException,
+        ClassificationNotFoundException {
         Connection connection = dataSource.getConnection();
         taskanaEngineImpl.setConnection(connection);
         Classification classification1 = this.createNewClassificationWithUniqueKey("", "t1");
@@ -317,7 +321,8 @@ public class ClassificationServiceImplIntExplicitTest {
 
     @Test
     public void testFindWithClassificationMapperPriorityTypeAndParent()
-        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException {
+        throws SQLException, ClassificationAlreadyExistException, NotAuthorizedException,
+        ClassificationNotFoundException {
         Connection connection = dataSource.getConnection();
         taskanaEngineImpl.setConnection(connection);
         Classification classification = this.createNewClassificationWithUniqueKey("", "type1");

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/rest/ClassificationController.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/rest/ClassificationController.java
@@ -90,6 +90,9 @@ public class ClassificationController {
         } catch (NotAuthorizedException e) {
             TransactionInterceptor.currentTransactionStatus().setRollbackOnly();
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        } catch (ClassificationNotFoundException e) {
+            TransactionInterceptor.currentTransactionStatus().setRollbackOnly();
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         }
     }
 


### PR DESCRIPTION
Changed ClassificationService.create() and update():
--> Throwing an Exception when no matching classification for the ParentClassificationId can be found.

update()
- removed insert, when classificationToUpdate does not ExistAlready (throwing notFoundException)
- removed getClassification in the end because it´s getting the same current classification again. Tests should approve that mapper.update() does work.