### PR TITLE
TSK-264: Determine task ids for report line items of category report

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/TaskMonitorService.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/TaskMonitorService.java
@@ -2,10 +2,12 @@ package pro.taskana;
 
 import java.util.List;
 
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.impl.ClassificationReport;
 import pro.taskana.impl.DetailedClassificationReport;
 import pro.taskana.impl.Report;
 import pro.taskana.impl.ReportLineItemDefinition;
+import pro.taskana.impl.SelectedItem;
 
 /**
  * The Task Monitor Service manages operations on tasks regarding the monitoring.
@@ -26,9 +28,11 @@ public interface TaskMonitorService {
      * @param domains
      *            a list of domains to filter by domains
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     Report getWorkbasketLevelReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains);
+        List<String> domains) throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by workbaskets. For each workbasket the report contains the total number of
@@ -51,11 +55,16 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     Report getWorkbasketLevelReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions);
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions)
+        throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by workbaskets. For each workbasket the report contains the total number of
@@ -78,15 +87,19 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @param inWorkingDays
      *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
      *            working days
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     Report getWorkbasketLevelReport(List<String> workbasketIds, List<TaskState> states,
         List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays);
+        boolean inWorkingDays) throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by categories. The report contains the total numbers of tasks of the respective
@@ -102,9 +115,11 @@ public interface TaskMonitorService {
      * @param domains
      *            a list of domains to filter by domains
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     Report getCategoryReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains);
+        List<String> domains) throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by categories. For each category the report contains the total number of tasks
@@ -127,11 +142,15 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     Report getCategoryReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions);
+        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions) throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by categories. For each category the report contains the total number of tasks
@@ -154,14 +173,19 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @param inWorkingDays
      *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
      *            working days
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     Report getCategoryReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays);
+        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays)
+        throws InvalidArgumentException;
 
     /**
      * Returns a {@link Classification} grouped by classifications. The report contains the total numbers of tasks of
@@ -177,9 +201,11 @@ public interface TaskMonitorService {
      * @param domains
      *            a list of domains to filter by domains
      * @return the ClassificationReport
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     ClassificationReport getClassificationReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains);
+        List<String> categories, List<String> domains) throws InvalidArgumentException;
 
     /**
      * Returns a {@link Classification} grouped by classifications. For each classification the report contains the
@@ -202,11 +228,16 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @return the ClassificationReport
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     ClassificationReport getClassificationReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions);
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions)
+        throws InvalidArgumentException;
 
     /**
      * Returns a {@link ClassificationReport} grouped by classification. For each classification the report contains the
@@ -229,15 +260,19 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @param inWorkingDays
      *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
      *            working days
      * @return the ClassificationReport
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     ClassificationReport getClassificationReport(List<String> workbasketIds, List<TaskState> states,
         List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays);
+        boolean inWorkingDays) throws InvalidArgumentException;
 
     /**
      * Returns a {@link DetailedClassificationReport}. The report contains the total numbers of tasks of the respective
@@ -254,9 +289,11 @@ public interface TaskMonitorService {
      * @param domains
      *            a list of domains to filter by domains
      * @return the DetailedClassificationReport
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     DetailedClassificationReport getDetailedClassificationReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains);
+        List<String> categories, List<String> domains) throws InvalidArgumentException;
 
     /**
      * Returns a {@link DetailedClassificationReport}. For each classification the report contains the total number of
@@ -280,11 +317,16 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @return the DetailedClassificationReport
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     DetailedClassificationReport getDetailedClassificationReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions);
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions)
+        throws InvalidArgumentException;
 
     /**
      * Returns a {@link DetailedClassificationReport}. For each classification the report contains the total number of
@@ -308,15 +350,19 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @param inWorkingDays
      *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
      *            working days
      * @return the DetailedClassificationReport
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories or domains is null
      */
     DetailedClassificationReport getDetailedClassificationReport(List<String> workbasketIds, List<TaskState> states,
         List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays);
+        boolean inWorkingDays) throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by the value of a certain {@link CustomField}. The report contains the total
@@ -334,9 +380,11 @@ public interface TaskMonitorService {
      * @param customField
      *            a custom field whose values should be listed in the report
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories, domains or customField is null
      */
     Report getCustomFieldValueReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains, CustomField customField);
+        List<String> domains, CustomField customField) throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by the value of a certain {@link CustomField}. For each value of the custom
@@ -361,11 +409,16 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories, domains or customField is null
      */
     Report getCustomFieldValueReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains, CustomField customField, List<ReportLineItemDefinition> reportLineItemDefinitions);
+        List<String> domains, CustomField customField, List<ReportLineItemDefinition> reportLineItemDefinitions)
+        throws InvalidArgumentException;
 
     /**
      * Returns a {@link Report} grouped by the value of a certain {@link CustomField}. For each value of the custom
@@ -390,13 +443,83 @@ public interface TaskMonitorService {
      *            Days in past are represented as negative values and days in the future are represented as positive
      *            values. To avoid tasks are counted multiple times or not be listed in the report, these
      *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
-     *            should represent a single day, lowerLimit and upperLimit have to be equal.
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
      * @param inWorkingDays
      *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
      *            working days
      * @return the report
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories, domains or customField is null
      */
     Report getCustomFieldValueReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
         List<String> domains, CustomField customField, List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays);
+        boolean inWorkingDays) throws InvalidArgumentException;
+
+    /**
+     * Returns a list of all task ids in the selected items of a {@link Report}. By default the age of the tasks is
+     * counted in working days.
+     *
+     * @param workbasketIds
+     *            a list of workbasket ids objects to filter by workbaskets
+     * @param states
+     *            a list of states objects to filter by states
+     * @param categories
+     *            a list of categories to filter by categories
+     * @param domains
+     *            a list of domains to filter by domains
+     * @param reportLineItemDefinitions
+     *            a list of reportLineItemDefinitions that specify the subdivision into different cluster of due dates.
+     *            Days in past are represented as negative values and days in the future are represented as positive
+     *            values. To avoid tasks are counted multiple times or not be listed in the report, these
+     *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
+     * @param selectedItems
+     *            a list of {@link SelectedItem}s that are selected from the report whose task ids should be determined.
+     * @return the list of task ids
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories, domains or reportLineItemDefinitions is null or if
+     *             selectedItems is empty or null
+     */
+    List<String> getTaskIdsOfCategoryReportLineItems(List<String> workbasketIds, List<TaskState> states,
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
+        List<SelectedItem> selectedItems) throws InvalidArgumentException;
+
+    /**
+     * Returns a list of all task ids in the selected items of a {@link Report}. By default the age of the tasks is
+     * counted in working days.
+     *
+     * @param workbasketIds
+     *            a list of workbasket ids objects to filter by workbaskets
+     * @param states
+     *            a list of states objects to filter by states
+     * @param categories
+     *            a list of categories to filter by categories
+     * @param domains
+     *            a list of domains to filter by domains
+     * @param reportLineItemDefinitions
+     *            a list of reportLineItemDefinitions that specify the subdivision into different cluster of due dates.
+     *            Days in past are represented as negative values and days in the future are represented as positive
+     *            values. To avoid tasks are counted multiple times or not be listed in the report, these
+     *            reportLineItemDefinitions should not overlap and should not have gaps. If the ReportLineDefinition
+     *            should represent a single day, lowerLimit and upperLimit have to be equal. The outer cluster of a
+     *            report should have open ends. These open ends are represented with Integer.MIN_VALUE and
+     *            Integer.MAX_VALUE.
+     * @param inWorkingDays
+     *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
+     *            working days
+     * @param selectedItems
+     *            a list of {@link SelectedItem}s that are selected from the report whose task ids should be determined.
+     * @return the list of task ids
+     * @throws InvalidArgumentException
+     *             thrown if workbasketIds, states, categories, domains or reportLineItemDefinitions is null or if
+     *             selectedItems is empty or null
+     */
+    List<String> getTaskIdsOfCategoryReportLineItems(List<String> workbasketIds, List<TaskState> states,
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
+        boolean inWorkingDays, List<SelectedItem> selectedItems) throws InvalidArgumentException;
+
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/DetailedClassificationReport.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/DetailedClassificationReport.java
@@ -2,6 +2,8 @@ package pro.taskana.impl;
 
 import java.util.List;
 
+import pro.taskana.exceptions.InvalidArgumentException;
+
 /**
  * The DetailedClassificationReport extends the {@link ClassificationReport}. In contrast to the ClassificationReport
  * there are DetailedReportLines instead of ReportLines. That means each ReportLine contains an additional list of
@@ -24,12 +26,15 @@ public class DetailedClassificationReport extends ClassificationReport {
      * @param inWorkingDays
      *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
      *            working days.
+     * @throws InvalidArgumentException
+     *             thrown if reportLineItemDefinitions is null and inWorkingDays is true
      */
     public void addDetailedMonitoringQueryItems(List<DetailedMonitorQueryItem> detailedMonitorQueryItems,
-        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays) {
+        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays)
+        throws InvalidArgumentException {
 
         DaysToWorkingDaysConverter instance = null;
-        if (reportLineItemDefinitions != null && inWorkingDays) {
+        if (inWorkingDays) {
             instance = DaysToWorkingDaysConverter.initialize(reportLineItemDefinitions);
         }
 

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/Report.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/Report.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import pro.taskana.exceptions.InvalidArgumentException;
+
 /**
  * A Report represents a table that consists of {@link ReportLine} objects. The detailLines are the rows of the table
  * that contains the total number of all tasks and could be optionally subdivided into different sections. The sumLine
@@ -46,11 +48,14 @@ public class Report {
      * @param inWorkingDays
      *            a boolean parameter that specifies whether the age of the tasks should be counted in days or in
      *            working days.
+     * @throws InvalidArgumentException
+     *             thrown if reportLineItemDefinitions is null and inWorkingDays is true
      */
     public void addMonitoringQueryItems(List<MonitorQueryItem> monitorQueryItems,
-        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays) {
+        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays)
+        throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = null;
-        if (reportLineItemDefinitions != null && inWorkingDays) {
+        if (inWorkingDays) {
             instance = DaysToWorkingDaysConverter.initialize(reportLineItemDefinitions);
         }
 

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/ReportLineItemDefinition.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/ReportLineItemDefinition.java
@@ -5,7 +5,8 @@ package pro.taskana.impl;
  * sections. Days in past are represented as negative values and days in the future are represented as positive values.
  * To avoid tasks are counted multiple times or not be listed in the report, these reportLineItemDefinitions should not
  * overlap and should not have gaps. If the ReportLineDefinition should represent a single day, lowerAgeLimit and
- * upperAgeLimit have to be equal.
+ * upperAgeLimit have to be equal. The outer cluster of a report should have open ends. These open ends are represented
+ * with Integer.MIN_VALUE and Integer.MAX_VALUE.
  */
 public class ReportLineItemDefinition {
 

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/SelectedItem.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/SelectedItem.java
@@ -1,0 +1,42 @@
+package pro.taskana.impl;
+
+/**
+ * An item that contains information of a selected item of a Report. It is used to get the task ids of the selected item
+ * of the Report.
+ */
+public class SelectedItem {
+
+    private String key;
+    private int upperAgeLimit;
+    private int lowerAgeLimit;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public int getUpperAgeLimit() {
+        return upperAgeLimit;
+    }
+
+    public void setUpperAgeLimit(int upperAgeLimit) {
+        this.upperAgeLimit = upperAgeLimit;
+    }
+
+    public int getLowerAgeLimit() {
+        return lowerAgeLimit;
+    }
+
+    public void setLowerAgeLimit(int lowerAgeLimit) {
+        this.lowerAgeLimit = lowerAgeLimit;
+    }
+
+    @Override
+    public String toString() {
+        return "Key: " + this.key + ", Limits: (" + this.lowerAgeLimit + "," + this.getUpperAgeLimit() + ")";
+    }
+
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/TaskMonitorServiceImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/TaskMonitorServiceImpl.java
@@ -9,6 +9,7 @@ import pro.taskana.CustomField;
 import pro.taskana.TaskMonitorService;
 import pro.taskana.TaskState;
 import pro.taskana.TaskanaEngine;
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.impl.util.LoggerUtils;
 import pro.taskana.mappings.TaskMonitorMapper;
 
@@ -29,24 +30,24 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
 
     @Override
     public Report getWorkbasketLevelReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains) {
+        List<String> categories, List<String> domains) throws InvalidArgumentException {
         return getWorkbasketLevelReport(workbasketIds, states, categories, domains, null, false);
     }
 
     @Override
     public Report getWorkbasketLevelReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions)
+        throws InvalidArgumentException {
         return getWorkbasketLevelReport(workbasketIds, states, categories, domains, reportLineItemDefinitions, true);
     }
 
     @Override
     public Report getWorkbasketLevelReport(List<String> workbasketIds, List<TaskState> states,
         List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays) {
+        boolean inWorkingDays) throws InvalidArgumentException {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                "entry to getWorkbasketLevelReport(workbasketIds = {}, states = {}, categories = {}, domains = {}, "
-                    + "reportLineItemDefinitions = {}, inWorkingDays = {})",
+            LOGGER.debug("entry to getWorkbasketLevelReport(workbasketIds = {}, states = {}, categories = {}, "
+                + "domains = {}, reportLineItemDefinitions = {}, inWorkingDays = {})",
                 LoggerUtils.listToString(workbasketIds), LoggerUtils.listToString(states),
                 LoggerUtils.listToString(categories), LoggerUtils.listToString(domains),
                 LoggerUtils.listToString(reportLineItemDefinitions), inWorkingDays);
@@ -54,11 +55,24 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         try {
             taskanaEngineImpl.openConnection();
 
+            if (workbasketIds == null) {
+                throw new InvalidArgumentException("WorkbasketIds can´t be used as NULL-Parameter");
+            }
+            if (states == null) {
+                throw new InvalidArgumentException("States can´t be used as NULL-Parameter");
+            }
+            if (categories == null) {
+                throw new InvalidArgumentException("Categories can´t be used as NULL-Parameter");
+            }
+            if (domains == null) {
+                throw new InvalidArgumentException("Domains can´t be used as NULL-Parameter");
+            }
+
             configureDaysToWorkingDaysConverter();
 
             Report report = new Report();
-            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
-                .getTaskCountOfWorkbasketsByWorkbasketsAndStates(workbasketIds, states, categories, domains);
+            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper.getTaskCountOfWorkbaskets(workbasketIds,
+                states, categories, domains);
             report.addMonitoringQueryItems(monitorQueryItems, reportLineItemDefinitions, inWorkingDays);
             return report;
 
@@ -70,23 +84,24 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
 
     @Override
     public Report getCategoryReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains) {
+        List<String> domains) throws InvalidArgumentException {
         return getCategoryReport(workbasketIds, states, categories, domains, null, false);
     }
 
     @Override
     public Report getCategoryReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions)
+        throws InvalidArgumentException {
         return getCategoryReport(workbasketIds, states, categories, domains, reportLineItemDefinitions, true);
     }
 
     @Override
     public Report getCategoryReport(List<String> workbasketIds, List<TaskState> states, List<String> categories,
-        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays) {
+        List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays)
+        throws InvalidArgumentException {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                "entry to getCategoryReport(workbasketIds = {}, states = {}, categories = {}, domains = {}, "
-                    + "reportLineItemDefinitions = {}, inWorkingDays = {})",
+            LOGGER.debug("entry to getCategoryReport(workbasketIds = {}, states = {}, categories = {}, "
+                + "domains = {},reportLineItemDefinitions = {}, inWorkingDays = {})",
                 LoggerUtils.listToString(workbasketIds), LoggerUtils.listToString(states),
                 LoggerUtils.listToString(categories), LoggerUtils.listToString(domains),
                 LoggerUtils.listToString(reportLineItemDefinitions), inWorkingDays);
@@ -94,11 +109,24 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         try {
             taskanaEngineImpl.openConnection();
 
+            if (workbasketIds == null) {
+                throw new InvalidArgumentException("WorkbasketIds can´t be used as NULL-Parameter");
+            }
+            if (states == null) {
+                throw new InvalidArgumentException("States can´t be used as NULL-Parameter");
+            }
+            if (categories == null) {
+                throw new InvalidArgumentException("Categories can´t be used as NULL-Parameter");
+            }
+            if (domains == null) {
+                throw new InvalidArgumentException("Domains can´t be used as NULL-Parameter");
+            }
+
             configureDaysToWorkingDaysConverter();
 
             Report report = new Report();
-            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
-                .getTaskCountOfCategoriesByWorkbasketsAndStates(workbasketIds, states, categories, domains);
+            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper.getTaskCountOfCategories(workbasketIds, states,
+                categories, domains);
             report.addMonitoringQueryItems(monitorQueryItems, reportLineItemDefinitions, inWorkingDays);
             return report;
 
@@ -110,24 +138,24 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
 
     @Override
     public ClassificationReport getClassificationReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains) {
+        List<String> categories, List<String> domains) throws InvalidArgumentException {
         return getClassificationReport(workbasketIds, states, categories, domains, null, false);
     }
 
     @Override
     public ClassificationReport getClassificationReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions)
+        throws InvalidArgumentException {
         return getClassificationReport(workbasketIds, states, categories, domains, reportLineItemDefinitions, true);
     }
 
     @Override
     public ClassificationReport getClassificationReport(List<String> workbasketIds, List<TaskState> states,
         List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays) {
+        boolean inWorkingDays) throws InvalidArgumentException {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                "entry to getClassificationReport(workbasketIds = {}, states = {}, categories = {}, domains = {}, "
-                    + "reportLineItemDefinitions = {}, inWorkingDays = {})",
+            LOGGER.debug("entry to getClassificationReport(workbasketIds = {}, states = {}, categories = {}, "
+                + "domains = {}, reportLineItemDefinitions = {}, inWorkingDays = {})",
                 LoggerUtils.listToString(workbasketIds), LoggerUtils.listToString(states),
                 LoggerUtils.listToString(categories), LoggerUtils.listToString(domains),
                 LoggerUtils.listToString(reportLineItemDefinitions), inWorkingDays);
@@ -135,11 +163,24 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         try {
             taskanaEngineImpl.openConnection();
 
+            if (workbasketIds == null) {
+                throw new InvalidArgumentException("WorkbasketIds can´t be used as NULL-Parameter");
+            }
+            if (states == null) {
+                throw new InvalidArgumentException("States can´t be used as NULL-Parameter");
+            }
+            if (categories == null) {
+                throw new InvalidArgumentException("Categories can´t be used as NULL-Parameter");
+            }
+            if (domains == null) {
+                throw new InvalidArgumentException("Domains can´t be used as NULL-Parameter");
+            }
+
             configureDaysToWorkingDaysConverter();
 
             ClassificationReport report = new ClassificationReport();
-            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
-                .getTaskCountOfClassificationsByWorkbasketsAndStates(workbasketIds, states, categories, domains);
+            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper.getTaskCountOfClassifications(workbasketIds,
+                states, categories, domains);
             report.addMonitoringQueryItems(monitorQueryItems, reportLineItemDefinitions, inWorkingDays);
             return report;
 
@@ -151,14 +192,14 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
 
     @Override
     public DetailedClassificationReport getDetailedClassificationReport(List<String> workbasketIds,
-        List<TaskState> states, List<String> categories, List<String> domains) {
+        List<TaskState> states, List<String> categories, List<String> domains) throws InvalidArgumentException {
         return getDetailedClassificationReport(workbasketIds, states, categories, domains, null, false);
     }
 
     @Override
     public DetailedClassificationReport getDetailedClassificationReport(List<String> workbasketIds,
         List<TaskState> states, List<String> categories, List<String> domains,
-        List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        List<ReportLineItemDefinition> reportLineItemDefinitions) throws InvalidArgumentException {
         return getDetailedClassificationReport(workbasketIds, states, categories, domains, reportLineItemDefinitions,
             true);
     }
@@ -166,13 +207,12 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
     @Override
     public DetailedClassificationReport getDetailedClassificationReport(List<String> workbasketIds,
         List<TaskState> states, List<String> categories, List<String> domains,
-        List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays) {
+        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays)
+        throws InvalidArgumentException {
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                "entry to getDetailedClassificationReport(workbasketIds = {}, states = {}, categories = {},"
-                    + " domains = {}, reportLineItemDefinitions = {}, inWorkingDays = {})",
+            LOGGER.debug("entry to getDetailedClassificationReport(workbasketIds = {}, states = {}, "
+                + "categories = {}, domains = {}, reportLineItemDefinitions = {}, inWorkingDays = {})",
                 LoggerUtils.listToString(workbasketIds), LoggerUtils.listToString(states),
                 LoggerUtils.listToString(categories), LoggerUtils.listToString(domains),
                 LoggerUtils.listToString(reportLineItemDefinitions), inWorkingDays);
@@ -180,12 +220,24 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         try {
             taskanaEngineImpl.openConnection();
 
+            if (workbasketIds == null) {
+                throw new InvalidArgumentException("WorkbasketIds can´t be used as NULL-Parameter");
+            }
+            if (states == null) {
+                throw new InvalidArgumentException("States can´t be used as NULL-Parameter");
+            }
+            if (categories == null) {
+                throw new InvalidArgumentException("Categories can´t be used as NULL-Parameter");
+            }
+            if (domains == null) {
+                throw new InvalidArgumentException("Domains can´t be used as NULL-Parameter");
+            }
+
             configureDaysToWorkingDaysConverter();
 
             DetailedClassificationReport report = new DetailedClassificationReport();
             List<DetailedMonitorQueryItem> detailedMonitorQueryItems = taskMonitorMapper
-                .getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(workbasketIds, states, categories,
-                    domains);
+                .getTaskCountOfDetailedClassifications(workbasketIds, states, categories, domains);
             report.addDetailedMonitoringQueryItems(detailedMonitorQueryItems, reportLineItemDefinitions,
                 inWorkingDays);
             return report;
@@ -198,14 +250,14 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
 
     @Override
     public Report getCustomFieldValueReport(List<String> workbasketIds, List<TaskState> states,
-        List<String> categories, List<String> domains, CustomField customField) {
+        List<String> categories, List<String> domains, CustomField customField) throws InvalidArgumentException {
         return getCustomFieldValueReport(workbasketIds, states, categories, domains, customField, null, false);
     }
 
     @Override
     public Report getCustomFieldValueReport(List<String> workbasketIds, List<TaskState> states,
         List<String> categories, List<String> domains, CustomField customField,
-        List<ReportLineItemDefinition> reportLineItemDefinitions) {
+        List<ReportLineItemDefinition> reportLineItemDefinitions) throws InvalidArgumentException {
         return getCustomFieldValueReport(workbasketIds, states, categories, domains, customField,
             reportLineItemDefinitions, true);
     }
@@ -213,12 +265,11 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
     @Override
     public Report getCustomFieldValueReport(List<String> workbasketIds, List<TaskState> states,
         List<String> categories, List<String> domains, CustomField customField,
-        List<ReportLineItemDefinition> reportLineItemDefinitions,
-        boolean inWorkingDays) {
+        List<ReportLineItemDefinition> reportLineItemDefinitions, boolean inWorkingDays)
+        throws InvalidArgumentException {
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug(
-                "entry to getCustomFieldValueReport(workbasketIds = {}, states = {}, categories = {}, domains = {},"
-                    + " customField = {}, reportLineItemDefinitions = {}, inWorkingDays = {})",
+            LOGGER.debug("entry to getCustomFieldValueReport(workbasketIds = {}, states = {}, categories = {}, "
+                + "domains = {}, customField = {}, reportLineItemDefinitions = {}, inWorkingDays = {})",
                 LoggerUtils.listToString(workbasketIds), LoggerUtils.listToString(states),
                 LoggerUtils.listToString(categories), LoggerUtils.listToString(domains), customField,
                 LoggerUtils.listToString(reportLineItemDefinitions), inWorkingDays);
@@ -226,12 +277,27 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
         try {
             taskanaEngineImpl.openConnection();
 
+            if (workbasketIds == null) {
+                throw new InvalidArgumentException("WorkbasketIds can´t be used as NULL-Parameter");
+            }
+            if (states == null) {
+                throw new InvalidArgumentException("States can´t be used as NULL-Parameter");
+            }
+            if (categories == null) {
+                throw new InvalidArgumentException("Categories can´t be used as NULL-Parameter");
+            }
+            if (domains == null) {
+                throw new InvalidArgumentException("Domains can´t be used as NULL-Parameter");
+            }
+            if (customField == null) {
+                throw new InvalidArgumentException("CustomField can´t be used as NULL-Parameter");
+            }
+
             configureDaysToWorkingDaysConverter();
 
             Report report = new Report();
-            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper
-                .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(workbasketIds, states, categories,
-                    domains, customField);
+            List<MonitorQueryItem> monitorQueryItems = taskMonitorMapper.getTaskCountOfCustomFieldValues(workbasketIds,
+                states, categories, domains, customField);
             report.addMonitoringQueryItems(monitorQueryItems, reportLineItemDefinitions, inWorkingDays);
             return report;
 
@@ -239,6 +305,77 @@ public class TaskMonitorServiceImpl implements TaskMonitorService {
             taskanaEngineImpl.returnConnection();
             LOGGER.debug("exit from getCustomFieldValueReport().");
         }
+    }
+
+    @Override
+    public List<String> getTaskIdsOfCategoryReportLineItems(List<String> workbasketIds, List<TaskState> states,
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
+        List<SelectedItem> selectedItems) throws InvalidArgumentException {
+        return getTaskIdsOfCategoryReportLineItems(workbasketIds, states, categories, domains,
+            reportLineItemDefinitions, true, selectedItems);
+    }
+
+    @Override
+    public List<String> getTaskIdsOfCategoryReportLineItems(List<String> workbasketIds, List<TaskState> states,
+        List<String> categories, List<String> domains, List<ReportLineItemDefinition> reportLineItemDefinitions,
+        boolean inWorkingDays, List<SelectedItem> selectedItems) throws InvalidArgumentException {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("entry to getTaskIdsOfCategoryReportLineItems(workbasketIds = {}, states = {}, "
+                + "categories = {}, domains = {}, reportLineItemDefinitions = {}, inWorkingDays = {}, "
+                + "selectedItems = {})", LoggerUtils.listToString(workbasketIds), LoggerUtils.listToString(states),
+                LoggerUtils.listToString(categories), LoggerUtils.listToString(domains),
+                LoggerUtils.listToString(reportLineItemDefinitions), inWorkingDays,
+                LoggerUtils.listToString(selectedItems));
+        }
+        try {
+            taskanaEngineImpl.openConnection();
+
+            if (workbasketIds == null) {
+                throw new InvalidArgumentException("WorkbasketIds can´t be used as NULL-Parameter");
+            }
+            if (states == null) {
+                throw new InvalidArgumentException("States can´t be used as NULL-Parameter");
+            }
+            if (categories == null) {
+                throw new InvalidArgumentException("Categories can´t be used as NULL-Parameter");
+            }
+            if (domains == null) {
+                throw new InvalidArgumentException("Domains can´t be used as NULL-Parameter");
+            }
+            if (reportLineItemDefinitions == null) {
+                throw new InvalidArgumentException("ReportLineItemDefinitions can´t be used as NULL-Parameter");
+            }
+            if (selectedItems == null || selectedItems.size() == 0) {
+                throw new InvalidArgumentException(
+                    "SelectedItems can´t be used as NULL-Parameter and should not be empty");
+            }
+
+            configureDaysToWorkingDaysConverter();
+
+            if (inWorkingDays) {
+                selectedItems = convertWorkingDaysToDays(selectedItems, reportLineItemDefinitions);
+            }
+
+            List<String> taskIds = taskMonitorMapper.getTaskIdsOfCategoriesBySelectedItems(workbasketIds, states,
+                categories, domains, selectedItems);
+
+            return taskIds;
+
+        } finally {
+            taskanaEngineImpl.returnConnection();
+            LOGGER.debug("exit from getTaskIdsOfCategoryReportLineItems().");
+        }
+    }
+
+    private List<SelectedItem> convertWorkingDaysToDays(List<SelectedItem> selectedItems,
+        List<ReportLineItemDefinition> reportLineItemDefinitions) throws InvalidArgumentException {
+
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter.initialize(reportLineItemDefinitions);
+        for (SelectedItem selectedItem : selectedItems) {
+            selectedItem.setLowerAgeLimit(instance.convertWorkingDaysToDays(selectedItem.getLowerAgeLimit()));
+            selectedItem.setUpperAgeLimit(instance.convertWorkingDaysToDays(selectedItem.getUpperAgeLimit()));
+        }
+        return selectedItems;
     }
 
     private void configureDaysToWorkingDaysConverter() {

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/GetTaskIdsOfCategoryReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/GetTaskIdsOfCategoryReportAccTest.java
@@ -1,0 +1,132 @@
+package acceptance.monitoring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.h2.store.fs.FileUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import pro.taskana.TaskMonitorService;
+import pro.taskana.TaskState;
+import pro.taskana.TaskanaEngine;
+import pro.taskana.TaskanaEngine.ConnectionManagementMode;
+import pro.taskana.configuration.TaskanaEngineConfiguration;
+import pro.taskana.database.TestDataGenerator;
+import pro.taskana.exceptions.InvalidArgumentException;
+import pro.taskana.impl.ReportLineItemDefinition;
+import pro.taskana.impl.SelectedItem;
+import pro.taskana.impl.TaskanaEngineImpl;
+import pro.taskana.impl.configuration.DBCleaner;
+import pro.taskana.impl.configuration.TaskanaEngineConfigurationTest;
+
+/**
+ * Acceptance test for all "category report" scenarios.
+ */
+public class GetTaskIdsOfCategoryReportAccTest {
+
+    protected static TaskanaEngineConfiguration taskanaEngineConfiguration;
+    protected static TaskanaEngine taskanaEngine;
+
+    @BeforeClass
+    public static void setupTest() throws Exception {
+        resetDb();
+    }
+
+    public static void resetDb() throws SQLException, IOException {
+        DataSource dataSource = TaskanaEngineConfigurationTest.getDataSource();
+        DBCleaner cleaner = new DBCleaner();
+        cleaner.clearDb(dataSource, true);
+        dataSource = TaskanaEngineConfigurationTest.getDataSource();
+        taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false);
+        taskanaEngineConfiguration.setGermanPublicHolidaysEnabled(false);
+        taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
+        ((TaskanaEngineImpl) taskanaEngine).setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
+        cleaner.clearDb(dataSource, false);
+        TestDataGenerator testDataGenerator = new TestDataGenerator();
+        testDataGenerator.generateMonitoringTestData(dataSource);
+    }
+
+    @Test
+    public void testGetTaskIdsOfCategoryReport() throws InvalidArgumentException {
+        TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
+
+        List<String> workbasketIds = generateWorkbasketIds(3, 1);
+        List<TaskState> states = Arrays.asList(TaskState.READY, TaskState.CLAIMED);
+        List<String> categories = Arrays.asList("EXTERN", "AUTOMATIC", "MANUAL");
+        List<String> domains = Arrays.asList("DOMAIN_A", "DOMAIN_B", "DOMAIN_C");
+        List<ReportLineItemDefinition> reportLineItemDefinitions = getListOfReportLineItemDefinitions();
+
+        List<SelectedItem> selectedItems = new ArrayList<>();
+
+        SelectedItem s1 = new SelectedItem();
+        s1.setKey("EXTERN");
+        s1.setLowerAgeLimit(-5);
+        s1.setUpperAgeLimit(-2);
+        selectedItems.add(s1);
+
+        SelectedItem s2 = new SelectedItem();
+        s2.setKey("AUTOMATIC");
+        s2.setLowerAgeLimit(Integer.MIN_VALUE);
+        s2.setUpperAgeLimit(-11);
+        selectedItems.add(s2);
+
+        SelectedItem s3 = new SelectedItem();
+        s3.setKey("MANUAL");
+        s3.setLowerAgeLimit(0);
+        s3.setUpperAgeLimit(0);
+        selectedItems.add(s3);
+
+        List<String> ids = taskMonitorService.getTaskIdsOfCategoryReportLineItems(workbasketIds, states, categories,
+            domains, reportLineItemDefinitions, selectedItems);
+
+        assertEquals(11, ids.size());
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000006"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000020"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000021"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000022"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000023"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000024"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000026"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000027"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000028"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000031"));
+        assertTrue(ids.contains("TKI:000000000000000000000000000000000032"));
+    }
+
+    private List<String> generateWorkbasketIds(int amount, int startAt) {
+        List<String> workbasketIds = new ArrayList<>();
+        for (int i = 0; i < amount; i++) {
+            workbasketIds.add(String.format("WBI:%036d", startAt + i));
+        }
+        return workbasketIds;
+    }
+
+    private List<ReportLineItemDefinition> getListOfReportLineItemDefinitions() {
+        List<ReportLineItemDefinition> reportLineItemDefinitions = new ArrayList<>();
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(Integer.MIN_VALUE, -11));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-10, -6));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-5, -2));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(-1));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(0));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(1));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(2, 5));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(6, 10));
+        reportLineItemDefinitions.add(new ReportLineItemDefinition(11, Integer.MAX_VALUE));
+        return reportLineItemDefinitions;
+    }
+
+    @AfterClass
+    public static void cleanUpClass() {
+        FileUtils.deleteRecursive("~/data", true);
+    }
+}

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCategoryReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCategoryReportAccTest.java
@@ -24,6 +24,7 @@ import pro.taskana.TaskanaEngine;
 import pro.taskana.TaskanaEngine.ConnectionManagementMode;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.database.TestDataGenerator;
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.impl.Report;
 import pro.taskana.impl.ReportLineItem;
 import pro.taskana.impl.ReportLineItemDefinition;
@@ -60,7 +61,7 @@ public class ProvideCategoryReportAccTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfTasksOfCategoryReport() {
+    public void testGetTotalNumbersOfTasksOfCategoryReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -84,7 +85,7 @@ public class ProvideCategoryReportAccTest {
     }
 
     @Test
-    public void testGetCategoryReportWithReportLineItemDefinitions() {
+    public void testGetCategoryReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -130,7 +131,7 @@ public class ProvideCategoryReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCategoryReport() {
+    public void testEachItemOfCategoryReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -169,7 +170,7 @@ public class ProvideCategoryReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCategoryReportNotInWorkingDays() {
+    public void testEachItemOfCategoryReportNotInWorkingDays() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -208,7 +209,7 @@ public class ProvideCategoryReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCategoryReportWithCategoryFilter() {
+    public void testEachItemOfCategoryReportWithCategoryFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -242,7 +243,7 @@ public class ProvideCategoryReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCategoryReportWithDomainFilter() {
+    public void testEachItemOfCategoryReportWithDomainFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideClassificationReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideClassificationReportAccTest.java
@@ -24,6 +24,7 @@ import pro.taskana.TaskanaEngine;
 import pro.taskana.TaskanaEngine.ConnectionManagementMode;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.database.TestDataGenerator;
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.impl.Report;
 import pro.taskana.impl.ReportLineItem;
 import pro.taskana.impl.ReportLineItemDefinition;
@@ -60,7 +61,7 @@ public class ProvideClassificationReportAccTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfTasksOfClassificationReport() {
+    public void testGetTotalNumbersOfTasksOfClassificationReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -89,7 +90,7 @@ public class ProvideClassificationReportAccTest {
     }
 
     @Test
-    public void testGetClassificationReportWithReportLineItemDefinitions() {
+    public void testGetClassificationReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -137,7 +138,7 @@ public class ProvideClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfClassificationReport() {
+    public void testEachItemOfClassificationReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -190,7 +191,7 @@ public class ProvideClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfClassificationReportNotInWorkingDays() {
+    public void testEachItemOfClassificationReportNotInWorkingDays() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -243,7 +244,7 @@ public class ProvideClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfClassificationReportWithCategoryFilter() {
+    public void testEachItemOfClassificationReportWithCategoryFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -277,7 +278,7 @@ public class ProvideClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfClassificationReportWithDomainFilter() {
+    public void testEachItemOfClassificationReportWithDomainFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCustomFieldValueReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideCustomFieldValueReportAccTest.java
@@ -25,6 +25,7 @@ import pro.taskana.TaskanaEngine;
 import pro.taskana.TaskanaEngine.ConnectionManagementMode;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.database.TestDataGenerator;
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.impl.Report;
 import pro.taskana.impl.ReportLineItem;
 import pro.taskana.impl.ReportLineItemDefinition;
@@ -61,7 +62,7 @@ public class ProvideCustomFieldValueReportAccTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfTasksOfCustomFieldValueReportForCustom1() {
+    public void testGetTotalNumbersOfTasksOfCustomFieldValueReportForCustom1() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -93,7 +94,7 @@ public class ProvideCustomFieldValueReportAccTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfTasksOfCustomFieldValueReportForCustom2() {
+    public void testGetTotalNumbersOfTasksOfCustomFieldValueReportForCustom2() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -124,7 +125,7 @@ public class ProvideCustomFieldValueReportAccTest {
     }
 
     @Test
-    public void testGetCustomFieldValueReportWithReportLineItemDefinitions() {
+    public void testGetCustomFieldValueReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -166,7 +167,7 @@ public class ProvideCustomFieldValueReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCustomFieldValueReport() {
+    public void testEachItemOfCustomFieldValueReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -210,7 +211,7 @@ public class ProvideCustomFieldValueReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCustomFieldValueReportNotInWorkingDays() {
+    public void testEachItemOfCustomFieldValueReportNotInWorkingDays() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -254,7 +255,7 @@ public class ProvideCustomFieldValueReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCustomFieldValueReportWithCategoryFilter() {
+    public void testEachItemOfCustomFieldValueReportWithCategoryFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -298,7 +299,7 @@ public class ProvideCustomFieldValueReportAccTest {
     }
 
     @Test
-    public void testEachItemOfCustomFieldValueReportWithDomainFilter() {
+    public void testEachItemOfCustomFieldValueReportWithDomainFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideDetailedClassificationReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideDetailedClassificationReportAccTest.java
@@ -24,6 +24,7 @@ import pro.taskana.TaskanaEngine;
 import pro.taskana.TaskanaEngine.ConnectionManagementMode;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.database.TestDataGenerator;
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.impl.DetailedClassificationReport;
 import pro.taskana.impl.DetailedReportLine;
 import pro.taskana.impl.Report;
@@ -63,7 +64,7 @@ public class ProvideDetailedClassificationReportAccTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfTasksOfDetailedClassificationReport() {
+    public void testGetTotalNumbersOfTasksOfDetailedClassificationReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -118,7 +119,7 @@ public class ProvideDetailedClassificationReportAccTest {
     }
 
     @Test
-    public void testGetDetailedClassificationReportWithReportLineItemDefinitions() {
+    public void testGetDetailedClassificationReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -155,7 +156,7 @@ public class ProvideDetailedClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfDetailedClassificationReport() {
+    public void testEachItemOfDetailedClassificationReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -271,7 +272,7 @@ public class ProvideDetailedClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfDetailedClassificationReportNotInWorkingDays() {
+    public void testEachItemOfDetailedClassificationReportNotInWorkingDays() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -387,7 +388,7 @@ public class ProvideDetailedClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfDetailedClassificationReportWithCategoryFilter() {
+    public void testEachItemOfDetailedClassificationReportWithCategoryFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -449,7 +450,7 @@ public class ProvideDetailedClassificationReportAccTest {
     }
 
     @Test
-    public void testEachItemOfDetailedClassificationReportWithDomainFilter() {
+    public void testEachItemOfDetailedClassificationReportWithDomainFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);

--- a/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideWorkbasketLevelReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/monitoring/ProvideWorkbasketLevelReportAccTest.java
@@ -24,6 +24,7 @@ import pro.taskana.TaskanaEngine;
 import pro.taskana.TaskanaEngine.ConnectionManagementMode;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.database.TestDataGenerator;
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.impl.Report;
 import pro.taskana.impl.ReportLineItem;
 import pro.taskana.impl.ReportLineItemDefinition;
@@ -60,7 +61,7 @@ public class ProvideWorkbasketLevelReportAccTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfTasksOfWorkbasketLevelReport() {
+    public void testGetTotalNumbersOfTasksOfWorkbasketLevelReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -82,7 +83,7 @@ public class ProvideWorkbasketLevelReportAccTest {
     }
 
     @Test
-    public void testGetWorkbasketLevelReportWithReportLineItemDefinitions() {
+    public void testGetWorkbasketLevelReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -128,7 +129,7 @@ public class ProvideWorkbasketLevelReportAccTest {
     }
 
     @Test
-    public void testEachItemOfWorkbasketLevelReport() {
+    public void testEachItemOfWorkbasketLevelReport() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -167,7 +168,7 @@ public class ProvideWorkbasketLevelReportAccTest {
     }
 
     @Test
-    public void testEachItemOfWorkbasketLevelReportNotInWorkingDays() {
+    public void testEachItemOfWorkbasketLevelReportNotInWorkingDays() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -206,7 +207,7 @@ public class ProvideWorkbasketLevelReportAccTest {
     }
 
     @Test
-    public void testEachItemOfWorkbasketLevelReportWithCategoryFilter() {
+    public void testEachItemOfWorkbasketLevelReportWithCategoryFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);
@@ -247,7 +248,7 @@ public class ProvideWorkbasketLevelReportAccTest {
     }
 
     @Test
-    public void testEachItemOfWorkbasketLevelReportWithDomainFilter() {
+    public void testEachItemOfWorkbasketLevelReportWithDomainFilter() throws InvalidArgumentException {
         TaskMonitorService taskMonitorService = taskanaEngine.getTaskMonitorService();
 
         List<String> workbasketIds = generateWorkbasketIds(3, 1);

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/DaysToWorkingDaysConverterTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/DaysToWorkingDaysConverterTest.java
@@ -12,6 +12,8 @@ import java.util.List;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import pro.taskana.exceptions.InvalidArgumentException;
+
 /**
  * Test for the DaysToWorkingDaysConverter.
  */
@@ -26,7 +28,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testInitializeForDifferentReportLineItemDefinitions() {
+    public void testInitializeForDifferentReportLineItemDefinitions() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance1 = DaysToWorkingDaysConverter
             .initialize(getShortListOfReportLineItemDefinitions(), Instant.parse("2018-02-03T00:00:00.000Z"));
         DaysToWorkingDaysConverter instance2 = DaysToWorkingDaysConverter
@@ -39,7 +41,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testInitializeForDifferentDates() {
+    public void testInitializeForDifferentDates() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance1 = DaysToWorkingDaysConverter
             .initialize(getShortListOfReportLineItemDefinitions(), Instant.parse("2018-02-04T00:00:00.000Z"));
         DaysToWorkingDaysConverter instance2 = DaysToWorkingDaysConverter
@@ -49,12 +51,12 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testConvertDaysToWorkingDays() {
+    public void testConvertDaysToWorkingDays() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-02-06T00:00:00.000Z"));
 
-        assertEquals(16, instance.convertDaysToWorkingDays(16));
-        assertEquals(11, instance.convertDaysToWorkingDays(15));
+        assertEquals(-16, instance.convertDaysToWorkingDays(-16));
+        assertEquals(-11, instance.convertDaysToWorkingDays(-15));
 
         assertEquals(-2, instance.convertDaysToWorkingDays(-4));
         assertEquals(-1, instance.convertDaysToWorkingDays(-3));
@@ -73,7 +75,40 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testEasterHolidays() {
+    public void testConvertWorkingDaysToDays() throws InvalidArgumentException {
+        DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
+            .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-02-27T00:00:00.000Z"));
+
+        assertEquals(-13, instance.convertWorkingDaysToDays(-13));
+        assertEquals(-12, instance.convertWorkingDaysToDays(-12));
+
+        assertEquals(-12, instance.convertWorkingDaysToDays(-8));
+        assertEquals(-11, instance.convertWorkingDaysToDays(-7));
+        assertEquals(-8, instance.convertWorkingDaysToDays(-6));
+        assertEquals(-7, instance.convertWorkingDaysToDays(-5));
+        assertEquals(-6, instance.convertWorkingDaysToDays(-4));
+        assertEquals(-5, instance.convertWorkingDaysToDays(-3));
+        assertEquals(-4, instance.convertWorkingDaysToDays(-2));
+        assertEquals(-1, instance.convertWorkingDaysToDays(-1));
+        assertEquals(0, instance.convertWorkingDaysToDays(0));
+        assertEquals(1, instance.convertWorkingDaysToDays(1));
+        assertEquals(2, instance.convertWorkingDaysToDays(2));
+        assertEquals(3, instance.convertWorkingDaysToDays(3));
+        assertEquals(6, instance.convertWorkingDaysToDays(4));
+        assertEquals(7, instance.convertWorkingDaysToDays(5));
+        assertEquals(8, instance.convertWorkingDaysToDays(6));
+        assertEquals(9, instance.convertWorkingDaysToDays(7));
+        assertEquals(10, instance.convertWorkingDaysToDays(8));
+        assertEquals(13, instance.convertWorkingDaysToDays(9));
+        assertEquals(14, instance.convertWorkingDaysToDays(10));
+        assertEquals(15, instance.convertWorkingDaysToDays(11));
+
+        assertEquals(12, instance.convertWorkingDaysToDays(12));
+        assertEquals(13, instance.convertWorkingDaysToDays(13));
+    }
+
+    @Test
+    public void testEasterHolidays() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-03-28T00:00:00.000Z"));
 
@@ -87,7 +122,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testWhitsunHolidays() {
+    public void testWhitsunHolidays() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-05-16T00:00:00.000Z"));
 
@@ -101,7 +136,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testLabourDayHoliday() {
+    public void testLabourDayHoliday() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-04-26T00:00:00.000Z"));
 
@@ -116,7 +151,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testAscensionDayHoliday() {
+    public void testAscensionDayHoliday() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-05-07T00:00:00.000Z"));
 
@@ -131,7 +166,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testDayOfGermanUnityHoliday() {
+    public void testDayOfGermanUnityHoliday() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-10-01T00:00:00.000Z"));
 
@@ -146,7 +181,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testChristmasAndNewYearHolidays() {
+    public void testChristmasAndNewYearHolidays() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-12-20T00:00:00.000Z"));
 
@@ -168,7 +203,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testCustomHolidaysWithDayOfReformationAndAllSaintsDay() {
+    public void testCustomHolidaysWithDayOfReformationAndAllSaintsDay() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getLargeListOfReportLineItemDefinitions(), Instant.parse("2018-10-26T00:00:00.000Z"));
 
@@ -184,7 +219,7 @@ public class DaysToWorkingDaysConverterTest {
     }
 
     @Test
-    public void testgetEasterSunday() {
+    public void testGetEasterSunday() throws InvalidArgumentException {
         DaysToWorkingDaysConverter instance = DaysToWorkingDaysConverter
             .initialize(getShortListOfReportLineItemDefinitions(), Instant.parse("2018-02-27T00:00:00.000Z"));
 

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/TaskMonitorServiceImplTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/TaskMonitorServiceImplTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import pro.taskana.configuration.TaskanaEngineConfiguration;
 import pro.taskana.CustomField;
 import pro.taskana.TaskState;
+import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.mappings.TaskMonitorMapper;
 
 /**
@@ -55,7 +56,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfWorkbasketLevelReport() {
+    public void testGetTotalNumbersOfWorkbasketLevelReport() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -66,8 +67,8 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setKey("WBI:000000000000000000000000000000000001");
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfWorkbasketsByWorkbasketsAndStates(
-            workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfWorkbaskets(workbasketIds, states,
+            categories, domains);
 
         Report actualResult = cut.getWorkbasketLevelReport(workbasketIds, states, categories, domains);
 
@@ -75,7 +76,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfWorkbasketsByWorkbasketsAndStates(any(), any(), any(),
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfWorkbaskets(any(), any(), any(),
             any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
@@ -87,7 +88,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetWorkbasketLevelReportWithReportLineItemDefinitions() {
+    public void testGetWorkbasketLevelReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -101,8 +102,8 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setAgeInDays(0);
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfWorkbasketsByWorkbasketsAndStates(
-            workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfWorkbaskets(workbasketIds, states,
+            categories, domains);
 
         Report actualResult = cut.getWorkbasketLevelReport(workbasketIds, states, categories, domains,
             reportLineItemDefinitions);
@@ -111,8 +112,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfWorkbasketsByWorkbasketsAndStates(any(), any(), any(),
-            any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfWorkbaskets(any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -130,7 +130,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfCatgoryReport() {
+    public void testGetTotalNumbersOfCatgoryReport() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -141,8 +141,8 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setKey("EXTERN");
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfCategoriesByWorkbasketsAndStates(
-            workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfCategories(workbasketIds, states, categories,
+            domains);
 
         Report actualResult = cut.getCategoryReport(workbasketIds, states, categories, domains);
 
@@ -150,8 +150,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfCategoriesByWorkbasketsAndStates(any(), any(), any(),
-            any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfCategories(any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -161,7 +160,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetCategoryReportWithReportLineItemDefinitions() {
+    public void testGetCategoryReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -175,8 +174,8 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setAgeInDays(0);
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfCategoriesByWorkbasketsAndStates(
-            workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfCategories(workbasketIds, states, categories,
+            domains);
 
         Report actualResult = cut.getCategoryReport(workbasketIds, states, categories, domains,
             reportLineItemDefinitions);
@@ -185,8 +184,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfCategoriesByWorkbasketsAndStates(any(), any(), any(),
-            any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfCategories(any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -197,7 +195,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfClassificationReport() {
+    public void testGetTotalNumbersOfClassificationReport() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -208,8 +206,8 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setKey("CLI:000000000000000000000000000000000001");
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfClassificationsByWorkbasketsAndStates(
-            workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfClassifications(workbasketIds, states,
+            categories, domains);
 
         ClassificationReport actualResult = cut.getClassificationReport(workbasketIds, states, categories, domains);
 
@@ -217,8 +215,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfClassificationsByWorkbasketsAndStates(any(), any(), any(),
-            any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfClassifications(any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -229,7 +226,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetClassificationReportWithReportLineItemDefinitions() {
+    public void testGetClassificationReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -243,8 +240,8 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setAgeInDays(0);
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfClassificationsByWorkbasketsAndStates(
-            workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfClassifications(workbasketIds, states,
+            categories, domains);
 
         ClassificationReport actualResult = cut.getClassificationReport(workbasketIds, states, categories, domains,
             reportLineItemDefinitions);
@@ -253,8 +250,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfClassificationsByWorkbasketsAndStates(any(), any(), any(),
-            any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfClassifications(any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -270,7 +266,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfDetailedClassificationReport() {
+    public void testGetTotalNumbersOfDetailedClassificationReport() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -282,8 +278,8 @@ public class TaskMonitorServiceImplTest {
         detailedMonitorQueryItem.setAttachmentKey("CLI:000000000000000000000000000000000006");
         detailedMonitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(detailedMonitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock)
-            .getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfDetailedClassifications(workbasketIds,
+            states, categories, domains);
 
         DetailedClassificationReport actualResult = cut.getDetailedClassificationReport(workbasketIds, states,
             categories, domains);
@@ -292,8 +288,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(any(),
-            any(), any(), any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfDetailedClassifications(any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -306,7 +301,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetDetailedClassificationReportWithReportLineItemDefinitions() {
+    public void testGetDetailedClassificationReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -321,8 +316,8 @@ public class TaskMonitorServiceImplTest {
         detailedMonitorQueryItem.setAgeInDays(0);
         detailedMonitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(detailedMonitorQueryItem);
-        doReturn(expectedResult).when(taskMonitorMapperMock)
-            .getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(workbasketIds, states, categories, domains);
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskCountOfDetailedClassifications(workbasketIds,
+            states, categories, domains);
 
         DetailedClassificationReport actualResult = cut.getDetailedClassificationReport(workbasketIds, states,
             categories, domains, reportLineItemDefinitions);
@@ -331,8 +326,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1)).getTaskCountOfDetailedClassificationsByWorkbasketsAndStates(any(),
-            any(), any(), any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfDetailedClassifications(any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -352,7 +346,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetTotalNumbersOfCustomFieldValueReport() {
+    public void testGetTotalNumbersOfCustomFieldValueReport() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -364,8 +358,7 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
         doReturn(expectedResult).when(taskMonitorMapperMock)
-            .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(
-                workbasketIds, states, categories, domains, CustomField.CUSTOM_1);
+            .getTaskCountOfCustomFieldValues(workbasketIds, states, categories, domains, CustomField.CUSTOM_1);
 
         Report actualResult = cut.getCustomFieldValueReport(workbasketIds, states, categories, domains,
             CustomField.CUSTOM_1);
@@ -374,8 +367,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineImplMock, times(2)).getConfiguration();
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
-        verify(taskMonitorMapperMock, times(1))
-            .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(any(), any(), any(), any(), any());
+        verify(taskMonitorMapperMock, times(1)).getTaskCountOfCustomFieldValues(any(), any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -385,7 +377,7 @@ public class TaskMonitorServiceImplTest {
     }
 
     @Test
-    public void testGetCustomFieldValueReportWithReportLineItemDefinitions() {
+    public void testGetCustomFieldValueReportWithReportLineItemDefinitions() throws InvalidArgumentException {
         List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
         List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
         List<String> categories = Arrays.asList("EXTERN");
@@ -400,8 +392,7 @@ public class TaskMonitorServiceImplTest {
         monitorQueryItem.setNumberOfTasks(1);
         expectedResult.add(monitorQueryItem);
         doReturn(expectedResult).when(taskMonitorMapperMock)
-            .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(
-                workbasketIds, states, categories, domains, CustomField.CUSTOM_1);
+            .getTaskCountOfCustomFieldValues(workbasketIds, states, categories, domains, CustomField.CUSTOM_1);
 
         Report actualResult = cut.getCustomFieldValueReport(workbasketIds, states, categories, domains,
             CustomField.CUSTOM_1, reportLineItemDefinitions);
@@ -411,7 +402,7 @@ public class TaskMonitorServiceImplTest {
         verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
         verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
         verify(taskMonitorMapperMock, times(1))
-            .getTaskCountOfCustomFieldValuesByWorkbasketsAndStatesAndCustomField(any(), any(), any(), any(), any());
+            .getTaskCountOfCustomFieldValues(any(), any(), any(), any(), any());
         verify(taskanaEngineImplMock, times(1)).returnConnection();
         verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
 
@@ -420,5 +411,40 @@ public class TaskMonitorServiceImplTest {
         assertEquals(actualResult.getReportLines().get("Geschaeftsstelle A").getLineItems().get(0).getNumberOfTasks(),
             1);
         assertEquals(actualResult.getSumLine().getTotalNumberOfTasks(), 1);
+    }
+
+    @Test
+    public void testGetTaskIdsOfCategoryReportLineItems() throws InvalidArgumentException {
+        List<String> workbasketIds = Arrays.asList("WBI:000000000000000000000000000000000001");
+        List<TaskState> states = Arrays.asList(TaskState.CLAIMED, TaskState.READY);
+        List<String> categories = Arrays.asList("EXTERN");
+        List<String> domains = Arrays.asList("DOMAIN_A");
+        List<ReportLineItemDefinition> reportLineItemDefinitions = Arrays.asList(new ReportLineItemDefinition(),
+            new ReportLineItemDefinition());
+
+        SelectedItem selectedItem = new SelectedItem();
+        selectedItem.setKey("EXTERN");
+        selectedItem.setLowerAgeLimit(1);
+        selectedItem.setUpperAgeLimit(5);
+        List<SelectedItem> selectedItems = Arrays.asList(selectedItem);
+
+        List<String> expectedResult = Arrays.asList("TKI:000000000000000000000000000000000001");
+        doReturn(expectedResult).when(taskMonitorMapperMock).getTaskIdsOfCategoriesBySelectedItems(workbasketIds,
+            states, categories, domains, selectedItems);
+
+        List<String> actualResult = cut.getTaskIdsOfCategoryReportLineItems(workbasketIds, states, categories, domains,
+            reportLineItemDefinitions, true, selectedItems);
+
+        verify(taskanaEngineImplMock, times(1)).openConnection();
+        verify(taskanaEngineImplMock, times(2)).getConfiguration();
+        verify(taskanaEngineConfiguration, times(1)).isGermanPublicHolidaysEnabled();
+        verify(taskanaEngineConfiguration, times(1)).getCustomHolidays();
+        verify(taskMonitorMapperMock, times(1))
+            .getTaskIdsOfCategoriesBySelectedItems(any(), any(), any(), any(), any());
+        verify(taskanaEngineImplMock, times(1)).returnConnection();
+        verifyNoMoreInteractions(taskanaEngineImplMock, taskMonitorMapperMock, taskanaEngineConfiguration);
+
+        assertNotNull(actualResult);
+        assertEquals(expectedResult, actualResult);
     }
 }


### PR DESCRIPTION
- Add methods to determine task ids of classification report 
- Add acceptance and unit tests
- Check all TaskMonitorService methods if input parameters are null and throw an exception if necessary
