### PR TITLE
TSK-531 Access id validation failing refinement

### DIFF
--- a/rest/taskana-rest-spring-example/src/test/java/pro/taskana/rest/GenenalExceptionHandlingTest.java
+++ b/rest/taskana-rest-spring-example/src/test/java/pro/taskana/rest/GenenalExceptionHandlingTest.java
@@ -89,28 +89,31 @@ public class GenenalExceptionHandlingTest {
         try {
 
             AccessIdController.setLdapCache(new LdapCacheTestImpl());
-            ResponseEntity<List<AccessIdResource>> response = template.exchange(
+            template.exchange(
                 server + port + "/v1/access-ids?searchFor=al", HttpMethod.GET, request,
                 new ParameterizedTypeReference<List<AccessIdResource>>() {
 
                 });
         } catch (Exception ex) {
             verify(mockAppender).doAppend(captorLoggingEvent.capture());
-            assertTrue(captorLoggingEvent.getValue().getMessage().contains("is too short. Minimum Length ="));
+            assertTrue(
+                captorLoggingEvent.getValue().getMessage().contains("is too short. Minimum searchFor length = "));
         }
     }
 
     @Test
     public void testDeleteNonExisitingClassificationExceptionIsLogged() {
         try {
-            ResponseEntity<PagedResources<ClassificationSummaryResource>> response = template.exchange(
+            template.exchange(
                 server + port + "/v1/classifications/non-existing-id", HttpMethod.DELETE, request,
                 new ParameterizedTypeReference<PagedResources<ClassificationSummaryResource>>() {
 
                 });
-        } catch (Exception ex){
+        } catch (Exception ex) {
             verify(mockAppender).doAppend(captorLoggingEvent.capture());
-            assertTrue(captorLoggingEvent.getValue().getMessage().contains("The classification \"non-existing-id\" wasn't found"));
+            assertTrue(captorLoggingEvent.getValue()
+                .getMessage()
+                .contains("The classification \"non-existing-id\" wasn't found"));
         }
 
     }

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/rest/AccessIdController.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/rest/AccessIdController.java
@@ -35,9 +35,9 @@ public class AccessIdController {
 
     @GetMapping
     public ResponseEntity<List<AccessIdResource>> validateAccessIds(
-        @RequestParam(required = false) String searchFor) throws InvalidArgumentException {
-        if (searchFor == null || searchFor.length() < ldapClient.getMinSearchForLength()) {
-            throw new InvalidArgumentException("searchFor string " + searchFor + " is too short. Minimum Length = "
+        @RequestParam String searchFor) throws InvalidArgumentException {
+        if (searchFor.length() < ldapClient.getMinSearchForLength()) {
+            throw new InvalidArgumentException("searchFor string '" + searchFor + "' is too short. Minimum searchFor length = "
                 + ldapClient.getMinSearchForLength());
         }
         if (ldapClient.useLdap()) {


### PR DESCRIPTION
- Remove required = false annotation since parameter it's required indeed
- Remove null check since requiring parameter will do that
- Add test for check BadRequest with an invalid parameter lenght