### PR TITLE
TSK-714 - Improve all workbasket access items for a user screen

### DIFF
--- a/rest/taskana-rest-spring-example/src/main/java/pro/taskana/ldap/LdapCacheTestImpl.java
+++ b/rest/taskana-rest-spring-example/src/main/java/pro/taskana/ldap/LdapCacheTestImpl.java
@@ -288,8 +288,8 @@ public class LdapCacheTestImpl implements LdapCache {
         new AccessIdResource("team_4", "cn=team_4" + ",ou=groups,o=TaskanaTest")));
 
     @Override
-    public List<AccessIdResource> findMatchingAccessId(String searchFor, int maxNumerOfReturnedAccessIds) {
-        return findAccessIdResource(searchFor, maxNumerOfReturnedAccessIds, false);
+    public List<AccessIdResource> findMatchingAccessId(String searchFor, int maxNumberOfReturnedAccessIds) {
+        return findAcessIdResource(searchFor, maxNumberOfReturnedAccessIds, false);
     }
 
     @Override
@@ -297,10 +297,17 @@ public class LdapCacheTestImpl implements LdapCache {
         if (users == null) {
             addUsersToGroups();
         }
-        return findAccessIdResource(searchFor, maxNumberOfReturnedAccessIds, true);
+        return findAcessIdResource(searchFor, maxNumberOfReturnedAccessIds, true);
     }
 
-    private List<AccessIdResource> findAccessIdResource(String searchFor, int maxNumerOfReturnedAccessIds,
+    @Override
+    public List<AccessIdResource> validateAccessId(String accessId) {
+        return accessIds.stream()
+            .filter(t -> (t.getAccessId().equalsIgnoreCase(accessId.toLowerCase())))
+            .collect(Collectors.toList());
+    }
+
+    private List<AccessIdResource> findAcessIdResource(String searchFor, int maxNumberOfReturnedAccessIds,
         boolean groupMember) {
         List<AccessIdResource> usersAndGroups = accessIds.stream()
             .filter(t -> (t.getName().toLowerCase().contains(searchFor.toLowerCase())
@@ -321,7 +328,7 @@ public class LdapCacheTestImpl implements LdapCache {
         });
 
         List<AccessIdResource> result = usersAndGroups.subList(0,
-            Math.min(usersAndGroups.size(), maxNumerOfReturnedAccessIds));
+            Math.min(usersAndGroups.size(), maxNumberOfReturnedAccessIds));
 
         return result;
     }

--- a/rest/taskana-rest-spring-example/src/test/java/pro/taskana/rest/AccessIdValidationControllerTest.java
+++ b/rest/taskana-rest-spring-example/src/test/java/pro/taskana/rest/AccessIdValidationControllerTest.java
@@ -51,7 +51,7 @@ public class AccessIdValidationControllerTest {
         headers.add("Authorization", "Basic dGVhbWxlYWRfMTp0ZWFtbGVhZF8x");
         HttpEntity<String> request = new HttpEntity<String>(headers);
         ResponseEntity<List<AccessIdResource>> response = template.exchange(
-            "http://127.0.0.1:" + port + "/v1/access-ids?searchFor=ali", HttpMethod.GET, request,
+            "http://127.0.0.1:" + port + "/v1/access-ids?search-for=ali", HttpMethod.GET, request,
             new ParameterizedTypeReference<List<AccessIdResource>>() {
 
             });
@@ -73,7 +73,7 @@ public class AccessIdValidationControllerTest {
         HttpEntity<String> request = new HttpEntity<String>(headers);
         try {
             template.exchange(
-                "http://127.0.0.1:" + port + "/v1/access-ids?searchFor=al", HttpMethod.GET, request,
+                "http://127.0.0.1:" + port + "/v1/access-ids?search-for=al", HttpMethod.GET, request,
                 new ParameterizedTypeReference<List<AccessIdResource>>() {
 
                 });

--- a/rest/taskana-rest-spring-example/src/test/java/pro/taskana/rest/GenenalExceptionHandlingTest.java
+++ b/rest/taskana-rest-spring-example/src/test/java/pro/taskana/rest/GenenalExceptionHandlingTest.java
@@ -90,7 +90,7 @@ public class GenenalExceptionHandlingTest {
 
             AccessIdController.setLdapCache(new LdapCacheTestImpl());
             template.exchange(
-                server + port + "/v1/access-ids?searchFor=al", HttpMethod.GET, request,
+                server + port + "/v1/access-ids?search-for=al", HttpMethod.GET, request,
                 new ParameterizedTypeReference<List<AccessIdResource>>() {
 
                 });

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/ldap/LdapCache.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/ldap/LdapCache.java
@@ -16,17 +16,24 @@ public interface LdapCache {
      *
      * @param searchFor
      *            the search string. The search is performed over names and ids of users and groups.
-     * @param maxNumerOfReturnedAccessIds
+     * @param maxNumberOfReturnedAccessIds
      *            the maximum number of results to return.
      * @return a List of access ids for users and group where the name or id contains the search string.
      */
-    List<AccessIdResource> findMatchingAccessId(String searchFor, int maxNumerOfReturnedAccessIds);
+    List<AccessIdResource> findMatchingAccessId(String searchFor, int maxNumberOfReturnedAccessIds);
 
     /**
-     *
+     * Find the groups belong to a user.
      * @param searchFor the search string. The search is performed over names and ids of group .
-     * @param maxNumerOfReturnedAccessIds
+     * @param maxNumberOfReturnedAccessIds the maximum number of results to return.
      * @return
      */
-    List<AccessIdResource> findGroupsOfUser(String searchFor, int maxNumerOfReturnedAccessIds);
+    List<AccessIdResource> findGroupsOfUser(String searchFor, int maxNumberOfReturnedAccessIds);
+
+    /**
+     * Validate a access id.
+     * @param accessId the search string.
+     * @return the corresponding access id.
+     */
+    List<AccessIdResource> validateAccessId(String accessId);
 }

--- a/web/src/app/administration/access-items-management/access-items-management.component.html
+++ b/web/src/app/administration/access-items-management/access-items-management.component.html
@@ -1,10 +1,5 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <div class="pull-right btn-group">
-      <button *ngIf="AccessItemsForm" type="button" (click)="revokeAccess()" class="btn btn-default" data-toggle="tooltip" title="Revoke access">
-        <span class="glyphicon glyphicon-remove red" aria-hidden="true"></span>
-      </button>
-    </div>
     <h4 class="panel-header">Acces items management</h4>
   </div>
   <div class="panel-body">
@@ -13,8 +8,8 @@
         (onSelect)="onSelectAccessId($event)" displayError=true></taskana-type-ahead>
     </div>
     <div *ngIf="!AccessItemsForm" class="center-block no-detail col-xs-12">
-        <h3 class="grey">Select an access id</h3>
-        <svg-icon class="empty-icon" src="./assets/icons/users.svg"></svg-icon>
+      <h3 class="grey">Select an access id</h3>
+      <svg-icon class="empty-icon" src="./assets/icons/users.svg"></svg-icon>
     </div>
     <div *ngIf="AccessItemsForm" class="row col-xs-12">
       <form [formGroup]="AccessItemsForm">
@@ -50,7 +45,8 @@
               <th class="text-align"><input type="text" formControlName="accessIdFilter" (keyup.enter)="searchForAccessItemsWorkbaskets()"
                   class="form-control" placeholder="Access id filter"></th>
               <th>
-                <button type="button" (click)="searchForAccessItemsWorkbaskets()" class="btn btn-default" data-toggle="tooltip" title="Search">
+                <button type="button" (click)="searchForAccessItemsWorkbaskets()" class="btn btn-default" data-toggle="tooltip"
+                  title="Search">
                   <span class="glyphicon glyphicon-search blue" aria-hidden="true"></span>
                 </button>
               </th>
@@ -80,8 +76,9 @@
               </td>
               <td *ngIf="accessIdField.lookupField else accessIdInput" colspan="2" class="text-align text-width taskana-type-ahead">
                 <div>
-                  <taskana-type-ahead formControlName="accessId" placeHolderMessage="* Access id is required" [validationValue]="toogleValidationAccessIdMap.get(index)"
-                    [displayError]="!isFieldValid('accessItem.value.accessId', index)" [disable]=true></taskana-type-ahead>
+                  <taskana-type-ahead formControlName="accessId" placeHolderMessage="* Access id is required"
+                    [validationValue]="toogleValidationAccessIdMap.get(index)" [displayError]="!isFieldValid('accessItem.value.accessId', index)"
+                    [disable]=true></taskana-type-ahead>
                 </div>
               </td>
               <ng-template #accessIdInput>
@@ -163,6 +160,41 @@
             </tr>
           </tbody>
         </table>
+
+        <button *ngIf="!isGroup" class="pull-left btn-group" type="button" class="btn btn-primary" data-toggle="modal"
+          data-target="#myModal">
+          Belonging groups
+        </button>
+
+        <div class="modal" id="myModal">
+          <div class="modal-dialog">
+            <div class="modal-content">
+
+              <div class="modal-header">
+                <h4 class="modal-title">Belonging groups</h4>
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+              </div>
+
+              <div class="modal-body">
+                <ul *ngIf="belongingGroups !== undefined && belongingGroups.length > 0 " class="list-group">
+                  <li *ngFor="let group of belongingGroups" class="list-group-item">{{group.name}}</li>
+                </ul>
+                <p *ngIf="belongingGroups === undefined || belongingGroups.length === 0">The user is not associated to any groups</p>
+              </div>
+
+              <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+              </div>
+
+            </div>
+          </div>
+        </div>
+        <div class="pull-right btn-group">
+          <button *ngIf="AccessItemsForm" type="button" class="btn btn-default" data-toggle="tooltip" title="Revoke access"
+            [disabled]=isGroup>
+            <span class="glyphicon glyphicon-remove red" aria-hidden="true"></span>
+          </button>
+        </div>
       </form>
     </div>
   </div>

--- a/web/src/app/administration/access-items-management/access-items-management.component.scss
+++ b/web/src/app/administration/access-items-management/access-items-management.component.scss
@@ -6,8 +6,8 @@
 }
 
 .required-header:after {
-    
-    content:" *"; 
+
+    content:" *";
     color: $invalid;
 }
 
@@ -31,3 +31,8 @@ td {
     word-wrap:break-word;
 }
 .min-width{ min-width: 135px;}
+
+.modal-title {
+  font-weight: bold;
+  display: inline;
+}

--- a/web/src/app/administration/access-items-management/access-items-management.component.ts
+++ b/web/src/app/administration/access-items-management/access-items-management.component.ts
@@ -32,8 +32,11 @@ export class AccessItemsManagementComponent implements OnInit, OnDestroy {
   accessItemPermissionsSubscription: Subscription;
   accessItemInformationsubscription: Subscription;
   accessIdsWithGroups: Array<AccessIdDefinition>;
+  belongingGroups: Array<AccessIdDefinition>;
   sortingFields = new Map([['workbasket-key', 'Workbasket Key'], ['access-id', 'Access id']]);
   sortModel: SortingModel;
+  isGroup: boolean;
+  groupsKey = 'ou=groups';
 
 
   accessIdField = this.customFieldsService.getCustomField('Owner', 'workbaskets.access-items.accessId');
@@ -89,11 +92,13 @@ export class AccessItemsManagementComponent implements OnInit, OnDestroy {
     }
     if (!this.AccessItemsForm || this.accessIdPrevious !== selected.accessId) {
       this.accessIdPrevious = selected.accessId
+      this.isGroup = selected.accessId.includes(this.groupsKey);
 
       this.unSubscribe(this.accessItemInformationsubscription)
       this.accessItemInformationsubscription = this.accessIdsService.getAccessItemsInformation(selected.accessId, true)
         .subscribe((accessIdsWithGroups: Array<AccessIdDefinition>) => {
           this.accessIdsWithGroups = accessIdsWithGroups;
+          this.belongingGroups = accessIdsWithGroups.filter(item => item.accessId.includes(this.groupsKey));
           this.searchForAccessItemsWorkbaskets();
         },
           error => {

--- a/web/src/app/shared/services/access-ids/access-ids.service.ts
+++ b/web/src/app/shared/services/access-ids/access-ids.service.ts
@@ -21,7 +21,11 @@ export class AccessIdsService {
     if (!token || token.length < 3) {
       return of([]);
     }
-    return this.httpClient.get<Array<AccessIdDefinition>>(`${this.url}?searchFor=${token}&searchInGroups=${searchInGroups}`);
+    if (searchInGroups) {
+      return this.httpClient.get<Array<AccessIdDefinition>>(`${this.url}/groups?access-id=${token}`);
+    } else {
+      return this.httpClient.get<Array<AccessIdDefinition>>(`${this.url}?search-for=${token}`);
+    }
   };
 
   getAccessItemsPermissions(

--- a/web/src/app/shared/sort/sort.component.scss
+++ b/web/src/app/shared/sort/sort.component.scss
@@ -6,3 +6,7 @@
 .sortby-dropdown {
     min-width: 200px;
 }
+
+ul {
+  list-style-type: none;
+}

--- a/web/src/app/shared/type-ahead/type-ahead.component.html
+++ b/web/src/app/shared/type-ahead/type-ahead.component.html
@@ -33,7 +33,7 @@
     </span>
 
     <div class="input-group">
-      <input #inputTypeAhead class=" form-control input-text" (blur)="typeaheadOnSelect({'item':dataSource.selected})" name="accessItem-{{index}}"
+      <input #inputTypeAhead class=" form-control input-text" [ngClass]="{'invalid': dataSource.length == null}" (blur)="typeaheadOnSelect({'item':dataSource.selected})" name="accessItem-{{index}}"
         required #accessItemName="ngModel" [(ngModel)]="value" [typeahead]="dataSource" typeaheadOptionField="name" [typeaheadItemTemplate]="customItemTemplate"
         (typeaheadOnSelect)="typeaheadOnSelect($event, index)" [typeaheadScrollable]="true" [typeaheadOptionsInScrollableView]="typeaheadOptionsInScrollableView"
         [typeaheadMinLength]="typeaheadMinLength" [typeaheadWaitMs]="typeaheadWaitMs" (typeaheadLoading)="changeTypeaheadLoading($event)"

--- a/web/src/app/shared/type-ahead/type-ahead.component.scss
+++ b/web/src/app/shared/type-ahead/type-ahead.component.scss
@@ -23,7 +23,7 @@
         white-space: nowrap;
         padding-right: 35px;
     }
-  
+
 }
 .custom-form-control {
     height: 50px;
@@ -46,7 +46,7 @@
     }
     padding-left: 12px;
     padding-right: 35px;
-    
+
 }
 
 .field-label-wrapper{
@@ -55,7 +55,7 @@
     padding-left: 12px;
     box-sizing: content-box;
     overflow: hidden;
-    pointer-events: none;    
+    pointer-events: none;
 }
 
 .form-control:focus {
@@ -73,7 +73,7 @@
     position: absolute;
     top: 0px;
     right: 0px;
-    
+
 }
 
 ::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
@@ -90,4 +90,8 @@
 
 .disable {
     cursor: not-allowed;
+}
+
+.invalid {
+  color: $invalid;
 }

--- a/web/src/assets/_colors.scss
+++ b/web/src/assets/_colors.scss
@@ -9,3 +9,4 @@ $invalid: #a94442;
 $aquamarine: #22a39f;
 $pallete-blue: #36bcee;
 $pallete-green: #5fbca1;
+$transparent-grey: rgba(192, 192, 192, 0.65);

--- a/web/src/assets/_site.scss
+++ b/web/src/assets/_site.scss
@@ -352,3 +352,7 @@ li.list-group-item:hover {
         outline: none;
     }
 }
+
+.modal-backdrop.show {
+  background-color: $transparent-grey;
+}


### PR DESCRIPTION
- Create new endpoint to get the groups associated to an access id (validating the access id)
- Show in the popup the group associated to access id (only for a user)
- TypeAhead is red when the access id is invalid.
- The delete button is on bottom right position (just activated for the user)
- Disable delete button for groups
- Remove the dots of the lists