### PR TITLE
TSK-777 Set default rest url to window.host

### DIFF
--- a/rest/taskana-rest-spring-example/src/main/resources/static/environments/data-sources/environment-information.json
+++ b/rest/taskana-rest-spring-example/src/main/resources/static/environments/data-sources/environment-information.json
@@ -1,3 +1,3 @@
 {
-  "taskanaRestUrl": "https://taskana.mybluemix.net"
+  "taskanaRestUrl": ""
 }

--- a/web/src/app/services/startup-service/startup.service.ts
+++ b/web/src/app/services/startup-service/startup.service.ts
@@ -3,7 +3,6 @@ import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { environment } from 'app/../environments/environment';
 import { Injectable, Injector } from '@angular/core';
-import { TitlesService } from 'app/services/titles/titles.service';
 import { CustomFieldsService } from 'app/services/custom-fields/custom-fields.service';
 import { TaskanaEngineService } from 'app/services/taskana-engine/taskana-engine.service';
 import { map } from 'rxjs/operators';
@@ -11,11 +10,8 @@ import { WindowRefService } from 'app/services/window/window.service';
 
 @Injectable()
 export class StartupService {
-
-
     constructor(
         private httpClient: HttpClient,
-        private titlesService: TitlesService,
         private customFieldsService: CustomFieldsService,
         private taskanaEngineService: TaskanaEngineService,
         private injector: Injector,
@@ -36,10 +32,10 @@ export class StartupService {
     }
 
     getEnvironmentFilePromise() {
-        return this.httpClient.get<any>('environments/data-sources/environment-information.json').pipe(map(jsonFile => {
-            if (jsonFile) {
+        return this.httpClient.get<any>('/environments/data-sources/environment-information.json').pipe(map(jsonFile => {
+            if (jsonFile && environment.taskanaRestUrl === '') {
                 environment.taskanaRestUrl = jsonFile.taskanaRestUrl === '' ?
-                    environment.taskanaRestUrl : jsonFile.taskanaRestUrl;
+                    window.location.protocol + '//' + window.location.host : jsonFile.taskanaRestUrl;
                 this.customFieldsService.initCustomFields('EN', jsonFile);
             }
         })).toPromise()


### PR DESCRIPTION
Default url of rest api is window.host property, if there is a environment-information.json file with a overriden url web application will use the one defined in the file.