### PR TITLE
TSK-844: Reorder columns in history view and sort by "created"-value

### DIFF
--- a/web/src/app/history/services/task-query/task-query.service.ts
+++ b/web/src/app/history/services/task-query/task-query.service.ts
@@ -17,7 +17,7 @@ export class TaskQueryService {
     constructor(private httpClient: HttpClient) { }
 
     queryTask(
-        orderBy: string = 'task-id',
+        orderBy: string = 'created',
         sortDirection: string = Direction.ASC,
         taskId: string,
         parentBPI: string,
@@ -38,6 +38,7 @@ export class TaskQueryService {
         custom2: string,
         custom3: string,
         custom4: string,
+        created: string,
         allPages: boolean = false
     ): Observable<TaskHistoryEventResourceData> {
 
@@ -63,6 +64,7 @@ export class TaskQueryService {
             custom2,
             custom3,
             custom4,
+            created,
             allPages
         )}`);
 
@@ -90,6 +92,7 @@ export class TaskQueryService {
         custom2: string,
         custom3: string,
         custom4: string,
+        created: string,
         allPages: boolean = false): string {
 
         const parameters = new QueryParametersModel();
@@ -114,6 +117,7 @@ export class TaskQueryService {
         parameters.CUSTOM_2_LIKE = custom2;
         parameters.CUSTOM_3_LIKE = custom3;
         parameters.CUSTOM_4_LIKE = custom4;
+        parameters.CREATED = created;
 
         if (allPages) { TaskanaQueryParameters.page = undefined; TaskanaQueryParameters.pageSize = undefined; }
 

--- a/web/src/app/history/task-query/task-query.component.html
+++ b/web/src/app/history/task-query/task-query.component.html
@@ -39,8 +39,11 @@
           </div>
           <div class="divTableRow">
             <ng-container *ngFor="let taskHeader of taskQueryHeader | mapToIterable">
-              <div class="divTableHeader" *ngIf="filterFieldsToShow(taskHeader.key) && !filterExpandGroup(taskHeader.key)">
-                <input type="text" (keyup.enter)="search()" class="form-control input-sm" placeholder="{{getHeaderFieldDescription(taskHeader.key)}}"
+              <div class="divTableHeader divDate" *ngIf="isDate(taskHeader.key)">
+                <taskana-date-picker type="text" placeholder="{{getHeaderFieldDescription(taskHeader.key)}}" [name]="'this.created'" [id]="'created'" (dateOutput)="updateDate($event)" formControlName="{{taskHeader.key}}"></taskana-date-picker>
+              </div>
+              <div class="divTableHeader" *ngIf="!isDate(taskHeader.key) && filterFieldsToShow(taskHeader.key) && !filterExpandGroup(taskHeader.key)">
+                <input type="text" class="form-control input-sm" (keyup.enter)="search()" placeholder="{{getHeaderFieldDescription(taskHeader.key)}}"
                   formControlName="{{taskHeader.key}}">
               </div>
               <div class="divTableHeader divTableHeaderSeparator" [ngClass]="{'zoom-in': !toggleExpand, 'zoom-out': toggleExpand}"
@@ -56,7 +59,10 @@
         <div class="divTableBody">
           <div *ngFor="let task of taskQuery" class="divTableRow">
             <ng-container *ngFor="let taskHeader of taskQueryHeader | mapToIterable">
-              <div class="divTableCell" *ngIf="filterFieldsToShow(taskHeader.key) && !filterExpandGroup(taskHeader.key)">
+              <div class="divTableCell" *ngIf="isDate(taskHeader.key)">
+                {{task[taskHeader.key] | dateTimeZone:'yyyy-MM-dd'}}
+              </div>
+              <div class="divTableCell" *ngIf="!isDate(taskHeader.key) && filterFieldsToShow(taskHeader.key) && !filterExpandGroup(taskHeader.key)">
                 {{task[taskHeader.key]}}
               </div>
               <div class="divTableCell divTableCellSeparator" *ngIf="taskHeader.key === 'custom1'" [ngClass]="{'zoom-in': !toggleExpand, 'zoom-out': toggleExpand}"

--- a/web/src/app/history/task-query/task-query.component.scss
+++ b/web/src/app/history/task-query/task-query.component.scss
@@ -12,6 +12,10 @@
 	max-height: 34px;
 }
 
+.divDate {
+    padding-right: 20px;
+}
+
 .btn-xs{
 	padding: 0px;
 }

--- a/web/src/app/history/task-query/task-query.component.ts
+++ b/web/src/app/history/task-query/task-query.component.ts
@@ -22,9 +22,10 @@ export class TaskQueryComponent implements OnInit {
   taskQueryResource: TaskHistoryEventResourceData;
   taskQuery: Array<TaskHistoryEventData>
   taskQueryHeader = new TaskHistoryEventData();
-  orderBy = new SortingModel(TaskanaQueryParameters.parameters.WORKBASKET_KEY);
+  orderBy = new SortingModel(TaskanaQueryParameters.parameters.CREATED);
   orientationSubscription: Subscription;
   taskQuerySubscription: Subscription;
+  created = undefined;
 
   taskQueryForm = new FormGroup({
   });
@@ -99,6 +100,11 @@ export class TaskQueryComponent implements OnInit {
         return property;
     }
   }
+
+  isDate(fieldName: string): boolean {
+      return (fieldName === 'created')
+  }
+
   filterFieldsToAllowQuerying(fieldName: string): boolean {
     if (!fieldName || fieldName === 'oldData' || fieldName === 'newData' || fieldName === 'comment'
       || fieldName === 'oldValue' || fieldName === 'newValue') {
@@ -109,7 +115,7 @@ export class TaskQueryComponent implements OnInit {
   }
 
   filterFieldsToShow(fieldName: string): boolean {
-    if (fieldName === 'taskHistoryId' || fieldName === 'page' || fieldName === 'created' || fieldName === '_links') {
+    if (fieldName === 'taskHistoryId' || fieldName === 'page' || fieldName === '_links') {
       return false;
     }
     return true;
@@ -194,6 +200,7 @@ export class TaskQueryComponent implements OnInit {
       this.taskQueryForm.get('custom2') ? this.taskQueryForm.get('custom2').value : undefined,
       this.taskQueryForm.get('custom3') ? this.taskQueryForm.get('custom3').value : undefined,
       this.taskQueryForm.get('custom4') ? this.taskQueryForm.get('custom4').value : undefined,
+      this.created ? this.created.toISOString().substring(0, 10) : undefined,
       false).subscribe(taskQueryResource => {
         this.requestInProgressService.setRequestInProgress(false);
         if (!taskQueryResource._embedded) {
@@ -221,6 +228,11 @@ export class TaskQueryComponent implements OnInit {
     const cards = Math.round((totalHeight - (unusedHeight)) / rowHeight);
     TaskanaQueryParameters.page ? TaskanaQueryParameters.page = TaskanaQueryParameters.page : TaskanaQueryParameters.page = 1;
     cards > 0 ? TaskanaQueryParameters.pageSize = cards : TaskanaQueryParameters.pageSize = 1;
+  }
+
+  updateDate($event: string) {
+      this.created = new Date($event);
+      this.performRequest();
   }
 
   onDestroy() {

--- a/web/src/app/models/query-parameters.ts
+++ b/web/src/app/models/query-parameters.ts
@@ -32,7 +32,7 @@ export class QueryParametersModel {
     PARENT_BUSINESS_PROCESS_ID_LIKE: string;
     BUSINESS_PROCESS_ID_LIKE: string;
     EVENT_TYPE_LIKE: string;
-    CREATED_LIKE: string;
+    CREATED: string;
     USER_ID_LIKE: string;
     POR_COMPANY_LIKE: string;
     POR_SYSTEM_LIKE: string;

--- a/web/src/app/models/task-history-event.ts
+++ b/web/src/app/models/task-history-event.ts
@@ -2,19 +2,19 @@ import { Page } from './page';
 
 export class TaskHistoryEventData {
     taskHistoryId = 0;
-    taskId = '';
     parentBusinessProcessId = '';
     businessProcessId = '';
-    eventType = '';
     created = '';
     userId = '';
-    domain = '';
+    eventType = '';
     workbasketKey = '';
+    porType = '';
+    porValue = '';
+    domain = '';
+    taskId = '';
     porCompany = '';
     porSystem = '';
     porInstance = '';
-    porType = '';
-    porValue = '';
     taskClassificationKey = '';
     taskClassificationCategory = '';
     attachmentClassificationKey = '';

--- a/web/src/app/shared/date-picker/date-picker.component.ts
+++ b/web/src/app/shared/date-picker/date-picker.component.ts
@@ -15,7 +15,7 @@ export class DatePickerComponent implements OnInit {
   valueDate: Date;
 
   ngOnInit(): void {
-    this.valueDate = this.value ? new Date(this.value) : new Date();
+    this.valueDate = this.value ? new Date(this.value) : undefined;
   }
 
   dateChange(newValue: Date) {

--- a/web/src/app/shared/pipes/date-time-zone/date-time-zone.pipe.ts
+++ b/web/src/app/shared/pipes/date-time-zone/date-time-zone.pipe.ts
@@ -8,12 +8,11 @@ export class DateTimeZonePipe implements PipeTransform {
 
   private datesMap = new Map<string, string>();
 
-  transform(value: any, args?: any): any {
+  transform(value: any, format: string, args?: any): any {
 
     let date = this.datesMap.get(value);
     if (!date) {
-      date = TaskanaDate.getDateToDisplay(value);
-      this.datesMap.set(value, date);
+      date = TaskanaDate.getDateToDisplay(value, format);
     }
     return date;
   }

--- a/web/src/app/shared/util/query-parameters.ts
+++ b/web/src/app/shared/util/query-parameters.ts
@@ -13,6 +13,7 @@ export class TaskanaQueryParameters {
     OWNERLIKE: 'owner-like',
     TYPE: 'type',
     KEY: 'key',
+    CREATED: 'created',
     WORKBASKET_KEY: 'workbasket-key',
     KEYLIKE: 'key-like',
     PRIORITY: 'priority',

--- a/web/src/app/shared/util/taskana.date.ts
+++ b/web/src/app/shared/util/taskana.date.ts
@@ -16,12 +16,11 @@ export class TaskanaDate {
     return datePipe.transform(date, dateFormat);
   }
 
-  public static getDateToDisplay(date: string): string {
-    return this.applyTimeZone(date);
+  public static getDateToDisplay(date: string, dateFormat: string = this.dateFormat): string {
+    return this.applyTimeZone(date, dateFormat);
   }
 
-  private static applyTimeZone(date: string): string | null {
-    const dateFormat = 'yyyy-MM-dd HH:mm:ss';
+  public static applyTimeZone(date: string, dateFormat): string | null {
     const dateLocale = 'en-US';
     const datePipe = new DatePipe(dateLocale);
 


### PR DESCRIPTION
Reorders the columns and add the "created"-Instant (works as timestamp).
Default ordering is by "created" ascending.

A translation for the date-query is still missing.
It should be translated into a "TimeInterval"-Entity of the History-Service