### PR TITLE
TSK-860: Beautify the build log by correcting DB operations

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/configuration/DbSchemaCreator.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/configuration/DbSchemaCreator.java
@@ -88,12 +88,17 @@ public class DbSchemaCreator {
 
     private boolean isSchemaPreexisting(Connection connection) {
         ScriptRunner runner = getScriptRunnerInstance(connection);
+        StringWriter errorWriter = new StringWriter();
+        runner.setErrorLogWriter(new PrintWriter(errorWriter));
         try {
             BufferedReader reader = new BufferedReader(new InputStreamReader(this.getClass()
                 .getResourceAsStream(selectDbSchemaDetectionScript(connection.getMetaData().getDatabaseProductName()))));
             runner.runScript(getSqlSchemaNameParsed(reader));
         } catch (Exception e) {
             LOGGER.debug("Schema does not exist.");
+            if (!errorWriter.toString().trim().isEmpty()) {
+                LOGGER.debug(errorWriter.toString());
+            }
             return false;
         }
         LOGGER.debug("Schema does exist.");

--- a/lib/taskana-core/src/main/java/pro/taskana/impl/TaskanaEngineImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/impl/TaskanaEngineImpl.java
@@ -303,10 +303,10 @@ public class TaskanaEngineImpl implements TaskanaEngine {
     @Override
     public void checkRoleMembership(TaskanaRole... roles) throws NotAuthorizedException {
         if (!isUserInRole(roles)) {
-            if (LOGGER.isErrorEnabled()) {
+            if (LOGGER.isDebugEnabled()) {
                 String accessIds = LoggerUtils.listToString(CurrentUserContext.getAccessIds());
                 String rolesAsString = Arrays.toString(roles);
-                LOGGER.error("Throwing NotAuthorizedException because accessIds {} are not member of roles {}",
+                LOGGER.debug("Throwing NotAuthorizedException because accessIds {} are not member of roles {}",
                     accessIds,
                     rolesAsString);
             }

--- a/lib/taskana-core/src/test/java/acceptance/AbstractAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/AbstractAccTest.java
@@ -33,19 +33,18 @@ public abstract class AbstractAccTest {
 
     protected static TaskanaEngineConfiguration taskanaEngineConfiguration;
     protected static TaskanaEngine taskanaEngine;
+    private static DBCleaner cleaner = new DBCleaner();
+    protected static TestDataGenerator testDataGenerator = new TestDataGenerator();
 
     @BeforeClass
     public static void setupTest() throws Exception {
-        resetDb();
+        resetDb(false);
     }
 
-    public static void resetDb(boolean... dropTables) throws SQLException, IOException {
+    public static void resetDb(boolean dropTables) throws SQLException, IOException {
         DataSource dataSource = TaskanaEngineConfigurationTest.getDataSource();
-        DBCleaner cleaner = new DBCleaner();
-        if (dropTables == null || dropTables.length == 0) {
-            cleaner.clearDb(dataSource, true);
-        } else {
-            cleaner.clearDb(dataSource, dropTables[0]);
+        if (dropTables) {
+            cleaner.clearDb(dataSource, dropTables);
         }
         dataSource = TaskanaEngineConfigurationTest.getDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false,
@@ -53,7 +52,6 @@ public abstract class AbstractAccTest {
         taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
         taskanaEngine.setConnectionManagementMode(ConnectionManagementMode.AUTOCOMMIT);
         cleaner.clearDb(dataSource, false);
-        TestDataGenerator testDataGenerator = new TestDataGenerator();
         testDataGenerator.generateTestData(dataSource);
     }
 

--- a/lib/taskana-core/src/test/java/acceptance/report/AbstractReportAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/report/AbstractReportAccTest.java
@@ -33,8 +33,6 @@ public class AbstractReportAccTest {
     private static void resetDb() throws SQLException, IOException {
         DataSource dataSource = TaskanaEngineConfigurationTest.getDataSource();
         DBCleaner cleaner = new DBCleaner();
-        cleaner.clearDb(dataSource, true);
-        dataSource = TaskanaEngineConfigurationTest.getDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false,
             TaskanaEngineConfigurationTest.getSchemaName());
         taskanaEngineConfiguration.setGermanPublicHolidaysEnabled(false);

--- a/lib/taskana-core/src/test/java/acceptance/workbasket/DeleteWorkbasketAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/workbasket/DeleteWorkbasketAccTest.java
@@ -159,12 +159,13 @@ public class DeleteWorkbasketAccTest extends AbstractAccTest {
         workbasket.setOrgLevel1("company");
         workbasket = workbasketService.createWorkbasket(workbasket);
 
+        boolean failed = false;
         try {
             workbasketService.deleteWorkbasket(workbasket.getId());
         } catch (Exception e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
+            failed = true;
         }
+        assertTrue(failed);
     }
 
     @WithAccessId(userName = "teamlead_2", groupNames = {"businessadmin"})

--- a/lib/taskana-core/src/test/java/acceptance/workbasket/DeleteWorkbasketAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/workbasket/DeleteWorkbasketAccTest.java
@@ -19,14 +19,12 @@ import pro.taskana.Workbasket;
 import pro.taskana.WorkbasketAccessItem;
 import pro.taskana.WorkbasketService;
 import pro.taskana.WorkbasketType;
-import pro.taskana.exceptions.DomainNotFoundException;
 import pro.taskana.exceptions.InvalidArgumentException;
 import pro.taskana.exceptions.InvalidOwnerException;
 import pro.taskana.exceptions.InvalidStateException;
-import pro.taskana.exceptions.InvalidWorkbasketException;
 import pro.taskana.exceptions.NotAuthorizedException;
+import pro.taskana.exceptions.NotAuthorizedToQueryWorkbasketException;
 import pro.taskana.exceptions.TaskNotFoundException;
-import pro.taskana.exceptions.WorkbasketAlreadyExistException;
 import pro.taskana.exceptions.WorkbasketInUseException;
 import pro.taskana.exceptions.WorkbasketNotFoundException;
 import pro.taskana.impl.TaskImpl;
@@ -146,12 +144,9 @@ public class DeleteWorkbasketAccTest extends AbstractAccTest {
     @WithAccessId(
         userName = "user_1_2",
         groupNames = {"businessadmin"})
-    @Test
-    public void testCreateAndDeleteWorkbasket()
-        throws NotAuthorizedException, InvalidWorkbasketException, WorkbasketAlreadyExistException,
-        DomainNotFoundException {
+    @Test(expected = NotAuthorizedToQueryWorkbasketException.class)
+    public void testCreateAndDeleteWorkbasket() throws Exception {
         WorkbasketService workbasketService = taskanaEngine.getWorkbasketService();
-        int before = workbasketService.createWorkbasketQuery().domainIn("DOMAIN_A").list().size();
 
         Workbasket workbasket = workbasketService.newWorkbasket("NT1234", "DOMAIN_A");
         workbasket.setName("TheUltimate");
@@ -159,13 +154,7 @@ public class DeleteWorkbasketAccTest extends AbstractAccTest {
         workbasket.setOrgLevel1("company");
         workbasket = workbasketService.createWorkbasket(workbasket);
 
-        boolean failed = false;
-        try {
-            workbasketService.deleteWorkbasket(workbasket.getId());
-        } catch (Exception e) {
-            failed = true;
-        }
-        assertTrue(failed);
+        workbasketService.deleteWorkbasket(workbasket.getId());
     }
 
     @WithAccessId(userName = "teamlead_2", groupNames = {"businessadmin"})

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskServiceImplIntAutocommitTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskServiceImplIntAutocommitTest.java
@@ -13,7 +13,6 @@ import javax.sql.DataSource;
 
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -72,12 +71,6 @@ public class TaskServiceImplIntAutocommitTest {
     private ClassificationService classificationService;
     private WorkbasketService workbasketService;
 
-    @BeforeClass
-    public static void resetDb() {
-        DataSource ds = TaskanaEngineConfigurationTest.getDataSource();
-        DBCleaner cleaner = new DBCleaner();
-        cleaner.clearDb(ds, true);
-    }
 
     @Before
     public void setup() throws SQLException {
@@ -113,7 +106,6 @@ public class TaskServiceImplIntAutocommitTest {
         task.setClassificationKey(classification.getKey());
         task.setPrimaryObjRef(JunitHelper.createDefaultObjRef());
         task = taskServiceImpl.createTask(task);
-        // skanaEngineImpl.getSqlSession().commit(); // needed so that the change is visible in the other session
 
         TaskanaEngine te2 = taskanaEngineConfiguration.buildTaskanaEngine();
         TaskServiceImpl taskServiceImpl2 = (TaskServiceImpl) te2.getTaskService();
@@ -157,8 +149,6 @@ public class TaskServiceImplIntAutocommitTest {
         WorkbasketNotFoundException, ClassificationNotFoundException, ClassificationAlreadyExistException,
         TaskAlreadyExistException, InvalidWorkbasketException, InvalidArgumentException,
         WorkbasketAlreadyExistException, DomainNotFoundException {
-        DBCleaner cleaner = new DBCleaner();
-        cleaner.clearDb(TaskanaEngineConfiguration.createDefaultDataSource(), false);
         TaskanaEngineConfiguration taskanaEngineConfiguration = new TaskanaEngineConfiguration(null, false, false,
             null);
         TaskanaEngine te = taskanaEngineConfiguration.buildTaskanaEngine();

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskServiceImplIntExplicitTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskServiceImplIntExplicitTest.java
@@ -98,7 +98,6 @@ public class TaskServiceImplIntExplicitTest {
         taskanaEngineImpl.setConnectionManagementMode(ConnectionManagementMode.EXPLICIT);
         workbasketService = taskanaEngine.getWorkbasketService();
         cleaner = new DBCleaner();
-        cleaner.clearDb(dataSource, true);
         DbSchemaCreator creator = new DbSchemaCreator(dataSource, dataSource.getConnection().getSchema());
         creator.run();
     }
@@ -181,8 +180,6 @@ public class TaskServiceImplIntExplicitTest {
         TaskAlreadyExistException, InvalidWorkbasketException, InvalidArgumentException,
         WorkbasketAlreadyExistException, DomainNotFoundException {
         DataSource ds = TaskanaEngineConfiguration.createDefaultDataSource();
-        DBCleaner cleaner = new DBCleaner();
-        cleaner.clearDb(ds, false);
         TaskanaEngineConfiguration taskanaEngineConfiguration = new TaskanaEngineConfiguration(ds, false, false,
             null);
         TaskanaEngine te = taskanaEngineConfiguration.buildTaskanaEngine();

--- a/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskServiceImplIntExplicitTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/impl/integration/TaskServiceImplIntExplicitTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import java.io.File;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
@@ -78,17 +79,14 @@ public class TaskServiceImplIntExplicitTest {
     private static ClassificationService classificationService;
     private static WorkbasketService workbasketService;
 
-    @Before
-    public void resetDb() {
-        cleaner.clearDb(dataSource, false);
-    }
-
     @BeforeClass
     public static void setup() throws SQLException {
         String userHomeDirectroy = System.getProperty("user.home");
         String propertiesFileName = userHomeDirectroy + "/taskanaUnitTest.properties";
 
-        dataSource = TaskanaEngineConfigurationTest.createDataSourceFromProperties(propertiesFileName);
+        dataSource = new File(propertiesFileName).exists()
+            ? TaskanaEngineConfigurationTest.createDataSourceFromProperties(propertiesFileName)
+            : TaskanaEngineConfiguration.createDefaultDataSource();
         taskanaEngineConfiguration = new TaskanaEngineConfiguration(dataSource, false,
             TaskanaEngineConfigurationTest.getSchemaName());
         taskanaEngine = taskanaEngineConfiguration.buildTaskanaEngine();
@@ -100,6 +98,11 @@ public class TaskServiceImplIntExplicitTest {
         cleaner = new DBCleaner();
         DbSchemaCreator creator = new DbSchemaCreator(dataSource, dataSource.getConnection().getSchema());
         creator.run();
+    }
+
+    @Before
+    public void resetDb() {
+        cleaner.clearDb(dataSource, false);
     }
 
     @WithAccessId(userName = "Elena", groupNames = {"businessadmin"})


### PR DESCRIPTION
Removed 
- SQL Errors produced by checking if table exists. Now printed only in DEBUG mode
- wrong usages of DBCleaner (printed Errors in log)
- printed stackTrace for expected Error in DeleteWorkbasketAccTest