### PR TITLE
TSK-861: Throw error when File upload aborted

### DIFF
--- a/rest/taskana-rest-spring-example/src/main/resources/application.properties
+++ b/rest/taskana-rest-spring-example/src/main/resources/application.properties
@@ -52,6 +52,9 @@ spring.resources.cache.cachecontrol.cache-private=true
 ####### for upload of big workbasket- or classification-files
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+server.tomcat.max-http-post-size=-1
+server.tomcat.max-save-post-size=-1
+server.tomcat.max-swallow-size=-1
 ####### tomcat is not detecting the x-forward headers from bluemix as a trustworthy proxy
 server.tomcat.internal-proxies=.*
 server.use-forward-headers=true

--- a/rest/taskana-rest-spring-wildfly-example/src/main/resources/application.properties
+++ b/rest/taskana-rest-spring-wildfly-example/src/main/resources/application.properties
@@ -30,6 +30,12 @@ taskana.ldap.groupsOfUser=memberUid
 taskana.jobscheduler.async.cron=0 * * * * *
 ####### cache static resources properties
 spring.resources.cache.cachecontrol.cache-private=true
+####### for upload of big workbasket- or classification-files
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+server.tomcat.max-http-post-size=-1
+server.tomcat.max-save-post-size=-1
+server.tomcat.max-swallow-size=-1
 ####### tomcat is not detecting the x-forward headers from bluemix as a trustworthy proxy
 server.tomcat.internal-proxies=.*
 server.use-forward-headers=true

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/rest/TaskanaRestExceptionHandler.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/rest/TaskanaRestExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import pro.taskana.exceptions.ClassificationAlreadyExistException;
@@ -120,6 +121,11 @@ public class TaskanaRestExceptionHandler extends ResponseEntityExceptionHandler 
     @ExceptionHandler(DomainNotFoundException.class)
     protected ResponseEntity<Object> handleDomainNotFound(DomainNotFoundException ex, WebRequest req) {
         return buildResponse(ex, req, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    protected ResponseEntity<Object> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex, WebRequest req) {
+        return buildResponse(ex, req, HttpStatus.PAYLOAD_TOO_LARGE);
     }
 
     @ExceptionHandler(Exception.class)

--- a/web/src/app/administration/components/import-export/import-export.component.ts
+++ b/web/src/app/administration/components/import-export/import-export.component.ts
@@ -58,7 +58,7 @@ export class ImportExportComponent implements OnInit {
     formdata.append('file', file);
     ajax.upload.addEventListener('progress', this.progressHandler.bind(this), false);
     ajax.addEventListener('load', this.resetProgress.bind(this), false);
-    ajax.addEventListener('error', this.errorHandler.bind(this), false);
+    ajax.addEventListener('error', this.onFailedResponse.bind(this, ajax), false);
     ajax.onreadystatechange = this.onReadyStateChangeHandler.bind(this, ajax);
     if (this.currentSelection === TaskanaType.WORKBASKETS) {
       ajax.open('POST', environment.taskanaRestUrl + '/v1/workbasket-definitions');
@@ -109,6 +109,8 @@ export class ImportExportComponent implements OnInit {
         title = 'Import was not successful, operation was not found.';
       } else if (event.status === 409) {
         title = 'Import was not successful, operation has some conflicts.';
+      } else if (event.status === 413) {
+        title = 'Import was not successful, maximum file size exceeded.'
       }
       this.errorHandler(title, JSON.parse(event.responseText).message);
 
@@ -117,6 +119,11 @@ export class ImportExportComponent implements OnInit {
       this.importExportService.setImportingFinished(true);
       this.resetProgress();
     }
+  }
+
+  private onFailedResponse(event) {
+    this.errorHandler('Upload failed', 'The upload didn\'t proceed sucessfully. \
+    \n Probably the uploaded file exceeded the maximum file size of 10 MB');
   }
 
   private errorHandler(title = 'Import was not successful', message) {


### PR DESCRIPTION
This commit increases the maximum size for the Upload to 10 MB.

For bigger files a new ExceptionHandler is added, which returns a PayloadTooLarge-Status.
This Status is received by the Import-Export-Component and shows an own Message.

But most browers (eg. Chrome, Firefox, Opera) automatically stop sending an upload file when the servers maximum file size is reached.
Due to this feature no response is received (although the server sends it) and an network-error is thrown.
In this case the Import-Export-Module now shows a special message when the upload is aborted because of an error.