### PR TITLE
TSK-909

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/CallbackState.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/CallbackState.java
@@ -4,5 +4,5 @@ package pro.taskana;
  * This enum contains all status of synchronization between a taskana task and a task in a remote system.
  */
 public enum CallbackState {
-    NONE, CALLBACK_PROCESSING_REQUIRED, CALLBACK_PROCESSING_COMPLETED
+    NONE, CALLBACK_PROCESSING_REQUIRED, CLAIMED, CALLBACK_PROCESSING_COMPLETED
 }


### PR DESCRIPTION
-Added a new CallbackState which is needed when a task was claimed by TASKANA
-Added ruleset logic to determine if the public API is allowed to set the desired CallbackState
-Added test for the ruleset logic