### PR TITLE
TSK-1046 Changed default sorting in workbasket list to Name

### DIFF
--- a/web/src/app/administration/access-items-management/access-items-management.component.html
+++ b/web/src/app/administration/access-items-management/access-items-management.component.html
@@ -1,6 +1,6 @@
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h4 class="panel-header">Acces items management</h4>
+    <h4 class="panel-header">Access items management</h4>
   </div>
   <div class="panel-body">
     <div class="col-md-6 col-md-offset-3 margin">
@@ -17,7 +17,7 @@
           <thead>
             <tr>
               <th>
-                <taskana-sort [sortingFields]="sortingFields" (performSorting)="sorting($event)" menuPosition="left" [defaultSortBy]="'workbasket-key'"></taskana-sort>
+                <taskana-sort [sortingFields]="sortingFields" (performSorting)="sorting($event)" menuPosition="left" [defaultSortBy]="accessItemDefaultSortBy"></taskana-sort>
               </th>
               <th class="text-align min-width">Workbasket Key</th>
               <th colspan="2" class="text-align">Access Id</th>

--- a/web/src/app/administration/access-items-management/access-items-management.component.ts
+++ b/web/src/app/administration/access-items-management/access-items-management.component.ts
@@ -34,7 +34,8 @@ export class AccessItemsManagementComponent implements OnInit, OnDestroy {
   accessIdsWithGroups: Array<AccessIdDefinition>;
   belongingGroups: Array<AccessIdDefinition>;
   sortingFields = new Map([['workbasket-key', 'Workbasket Key'], ['access-id', 'Access id']]);
-  sortModel: SortingModel;
+  accessItemDefaultSortBy: string = 'workbasket-key';
+  sortModel: SortingModel = new SortingModel(this.accessItemDefaultSortBy);
   isGroup: boolean;
   groupsKey = 'ou=groups';
 

--- a/web/src/app/administration/workbasket/master/workbasket-list-toolbar/workbasket-list-toolbar.component.html
+++ b/web/src/app/administration/workbasket/master/workbasket-list-toolbar/workbasket-list-toolbar.component.html
@@ -7,7 +7,7 @@
       <taskana-import-export-component class="btn-group" [currentSelection]="selectionToImport"></taskana-import-export-component>
     </div>
     <div class="margin-right pull-right btn-group">
-      <taskana-sort [sortingFields]="sortingFields" (performSorting)="sorting($event)" class="btn-group"></taskana-sort>
+      <taskana-sort [sortingFields]="sortingFields" (performSorting)="sorting($event)" class="btn-group" [defaultSortBy]="workbasketDefaultSortBy"></taskana-sort>
       <button class="btn btn-default collapsed" type="button" id="collapsedMenufilterWb" aria-expanded="false" (click)="toolbarState=!toolbarState"
         data-toggle="tooltip" title="Filter">
         <span class="material-icons md-20 blue">{{!toolbarState? 'search' : 'expand_less'}}</span>

--- a/web/src/app/administration/workbasket/master/workbasket-list-toolbar/workbasket-list-toolbar.component.ts
+++ b/web/src/app/administration/workbasket/master/workbasket-list-toolbar/workbasket-list-toolbar.component.ts
@@ -20,6 +20,7 @@ import { ERROR_TYPES } from '../../../../services/general-modal/errors';
 })
 export class WorkbasketListToolbarComponent implements OnInit {
   @Input() workbaskets: Array<WorkbasketSummary>;
+  @Input() workbasketDefaultSortBy: string;
   @Output() performSorting = new EventEmitter<SortingModel>();
   @Output() performFilter = new EventEmitter<FilterModel>();
   workbasketServiceSubscription: Subscription;

--- a/web/src/app/administration/workbasket/master/workbasket-list.component.html
+++ b/web/src/app/administration/workbasket/master/workbasket-list.component.html
@@ -1,7 +1,7 @@
 <div class="footer-space-pagination-list">
   <div #wbToolbar>
     <taskana-workbasket-list-toolbar [workbaskets]="workbaskets" (performFilter)="performFilter($event)"
-      (performSorting)="performSorting($event)" (importSucessful)="refreshWorkbasketList()"></taskana-workbasket-list-toolbar>
+      (performSorting)="performSorting($event)" (importSucessful)="refreshWorkbasketList()" [workbasketDefaultSortBy]="workbasketDefaultSortBy"></taskana-workbasket-list-toolbar>
   </div>
   <div *ngIf="(workbaskets && workbaskets.length > 0) else empty_workbaskets">
     <ul #wbList id="wb-list-container" class="list-group">

--- a/web/src/app/administration/workbasket/master/workbasket-list.component.spec.ts
+++ b/web/src/app/administration/workbasket/master/workbasket-list.component.spec.ts
@@ -171,7 +171,7 @@ describe('WorkbasketListComponent', () => {
     });
     component.performFilter(filter);
 
-    expect(workbasketSummarySpy.calls.all()[1].args).toEqual([true, 'key', 'asc',
+    expect(workbasketSummarySpy.calls.all()[1].args).toEqual([true, 'name', 'asc',
       '', 'someName', 'someDescription', '', 'someOwner', 'PERSONAL', '', 'someKey', '']);
   }));
 });

--- a/web/src/app/administration/workbasket/master/workbasket-list.component.ts
+++ b/web/src/app/administration/workbasket/master/workbasket-list.component.ts
@@ -29,7 +29,8 @@ export class WorkbasketListComponent implements OnInit, OnDestroy {
   type = 'workbaskets';
   cards: number = this.pageSize;
 
-  sort: SortingModel = new SortingModel();
+  workbasketDefaultSortBy: string = 'name';
+  sort: SortingModel = new SortingModel(this.workbasketDefaultSortBy);
   filterBy: FilterModel = new FilterModel({ name: '', owner: '', type: '', description: '', key: '' });
 
   @ViewChild('wbToolbar', { static: true })

--- a/web/src/app/workplace/taskmaster/task-list-toolbar/task-list-toolbar.component.html
+++ b/web/src/app/workplace/taskmaster/task-list-toolbar/task-list-toolbar.component.html
@@ -21,7 +21,7 @@
         placeholder="Search by value ..." />
     </div>
     <div *ngIf="searched" class="pull-right margin-right btn-group">
-      <taskana-sort [sortingFields]="sortingFields" (performSorting)="sorting($event)" class="btn-group"></taskana-sort>
+      <taskana-sort [sortingFields]="sortingFields" (performSorting)="sorting($event)" class="btn-group" [defaultSortBy] = "taskDefaultSortBy"> </taskana-sort>
       <button class="btn btn-default collapsed" type="button" id="collapsedMenufilterWb" aria-expanded="false" (click)="toolbarState=!toolbarState">
         <span class="material-icons md-20 blue">search</span>
       </button>

--- a/web/src/app/workplace/taskmaster/task-list-toolbar/task-list-toolbar.component.ts
+++ b/web/src/app/workplace/taskmaster/task-list-toolbar/task-list-toolbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from '@angular/core';
+import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import { Task } from 'app/workplace/models/task';
 import { Workbasket } from 'app/models/workbasket';
 import { TaskService } from 'app/workplace/services/task.service';
@@ -22,10 +22,10 @@ export enum Search {
   styleUrls: ['./task-list-toolbar.component.scss']
 })
 export class TaskListToolbarComponent implements OnInit {
+  @Input() taskDefaultSortBy: string;
   @Output() performSorting = new EventEmitter<SortingModel>();
   @Output() performFilter = new EventEmitter<FilterModel>();
   @Output() selectSearchType = new EventEmitter();
-
 
   sortingFields = new Map([['name', 'Name'], ['priority', 'Priority'], ['due', 'Due'], ['planned', 'Planned']]);
   filterParams = { name: '', key: '', owner: '', priority: '', state: '' };

--- a/web/src/app/workplace/taskmaster/task-master.component.html
+++ b/web/src/app/workplace/taskmaster/task-master.component.html
@@ -1,7 +1,7 @@
 <div class="footer-space-pagination-list">
   <div #wbToolbar>
     <taskana-task-list-toolbar (performSorting)="performSorting($event)" (performFilter)="performFilter($event)"
-      (selectSearchType)="selectSearchType($event)">
+      (selectSearchType)="selectSearchType($event)" [taskDefaultSortBy]="taskDefaultSortBy">
     </taskana-task-list-toolbar>
   </div>
   <taskana-task-list *ngIf="!requestInProgress" [tasks]="tasks" [(selectedId)]="selectedId"></taskana-task-list>

--- a/web/src/app/workplace/taskmaster/task-master.component.ts
+++ b/web/src/app/workplace/taskmaster/task-master.component.ts
@@ -26,7 +26,8 @@ export class TaskMasterComponent implements OnInit, OnDestroy {
   type = 'tasks';
   currentBasket: Workbasket;
   selectedId = '';
-  sort: SortingModel = new SortingModel('priority');
+  taskDefaultSortBy: string = 'priority';
+  sort: SortingModel = new SortingModel(this.taskDefaultSortBy);
   filterBy: FilterModel = new FilterModel({
     name: '',
     owner: '',


### PR DESCRIPTION
It used to be possible that initial sorting of the list and initial check in dropdown sorting menu differ. That's why a property is added which centralizes the initial sorting.

In the workplace tasklist, sorting and checkbox differed and an error occured when changing the ascending order to descending order with initial sorting. This problem is fixed.