### PR TITLE
Task/tsk 1168

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
@@ -179,7 +179,7 @@ public interface Classification extends ClassificationSummary {
   void setCustom8(String custom8);
 
   /**
-   * Return a summary of the current Classification.
+   * Return a summary of the current Classification without the id.
    *
    * @return the ClassificationSummary object for the current classification
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
@@ -51,11 +51,12 @@ public interface Classification extends ClassificationSummary {
   void setApplicationEntryPoint(String applicationEntryPoint);
 
   /**
-   * Duplicates this Classification.
+   * Duplicates this Classification without the id.
    *
+   * @param key for the new Classification
    * @return a copy of this Classification
    */
-  Classification copy();
+  Classification copy(String key);
 
   /**
    * Get a flag if the classification if currently valid in the used domain.
@@ -179,7 +180,7 @@ public interface Classification extends ClassificationSummary {
   void setCustom8(String custom8);
 
   /**
-   * Return a summary of the current Classification without the id.
+   * Return a summary of the current Classification.
    *
    * @return the ClassificationSummary object for the current classification
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
@@ -37,6 +37,27 @@ public interface Classification extends ClassificationSummary {
   String getDomain();
 
   /**
+   * Get the logical name of the associated application entry point.
+   *
+   * @return applicationEntryPoint
+   */
+  String getApplicationEntryPoint();
+
+  /**
+   * Set the logical name of the associated application entry point.
+   *
+   * @param applicationEntryPoint The application entry point
+   */
+  void setApplicationEntryPoint(String applicationEntryPoint);
+
+  /**
+   * Duplicates this Classification.
+   *
+   * @return a copy of this Classification
+   */
+  Classification copy();
+
+  /**
    * Get a flag if the classification if currently valid in the used domain.
    *
    * @return isValidInDomain - flag
@@ -102,20 +123,6 @@ public interface Classification extends ClassificationSummary {
   void setServiceLevel(String serviceLevel);
 
   /**
-   * Get the logical name of the associated application entry point.
-   *
-   * @return applicationEntryPoint
-   */
-  String getApplicationEntryPoint();
-
-  /**
-   * Set the logical name of the associated application entry point.
-   *
-   * @param applicationEntryPoint The application entry point
-   */
-  void setApplicationEntryPoint(String applicationEntryPoint);
-
-  /**
    * Set/Change the 1. custom-attribute.
    *
    * @param custom1 the first custom attribute
@@ -177,11 +184,4 @@ public interface Classification extends ClassificationSummary {
    * @return the ClassificationSummary object for the current classification
    */
   ClassificationSummary asSummary();
-
-  /**
-   * Duplicates this Classification
-   *
-   * @return a copy of this Classification
-   */
-  Classification clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/Classification.java
@@ -177,4 +177,11 @@ public interface Classification extends ClassificationSummary {
    * @return the ClassificationSummary object for the current classification
    */
   ClassificationSummary asSummary();
+
+  /**
+   * Duplicates this Classification
+   *
+   * @return a copy of this Classification
+   */
+  Classification clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/ClassificationSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/ClassificationSummary.java
@@ -4,7 +4,7 @@ package pro.taskana.classification.api.models;
  * Interface for ClassificationSummaries. This is a specific short model-object which only requieres
  * the most important informations. Specific ones can be load afterwards via ID.
  */
-public interface ClassificationSummary extends Cloneable {
+public interface ClassificationSummary {
 
   /**
    * Gets the id of the classification.
@@ -141,9 +141,9 @@ public interface ClassificationSummary extends Cloneable {
   String getCustom8();
 
   /**
-   * Duplicates this ClassificationSummary
+   * Duplicates this ClassificationSummary.
    *
    * @return a copy of this ClassificationSummary
    */
-  ClassificationSummary clone();
+  ClassificationSummary copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/ClassificationSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/ClassificationSummary.java
@@ -141,7 +141,7 @@ public interface ClassificationSummary {
   String getCustom8();
 
   /**
-   * Duplicates this ClassificationSummary.
+   * Duplicates this ClassificationSummary without the id.
    *
    * @return a copy of this ClassificationSummary
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/ClassificationSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/api/models/ClassificationSummary.java
@@ -4,7 +4,7 @@ package pro.taskana.classification.api.models;
  * Interface for ClassificationSummaries. This is a specific short model-object which only requieres
  * the most important informations. Specific ones can be load afterwards via ID.
  */
-public interface ClassificationSummary {
+public interface ClassificationSummary extends Cloneable {
 
   /**
    * Gets the id of the classification.
@@ -63,8 +63,8 @@ public interface ClassificationSummary {
   String getParentKey();
 
   /**
-   * Gets the service level of the classification. It is a String in ISO-8601 duration
-   * format. See the parse() method of {@code Duration} for details.
+   * Gets the service level of the classification. It is a String in ISO-8601 duration format. See
+   * the parse() method of {@code Duration} for details.
    *
    * @return the service level
    */
@@ -139,4 +139,11 @@ public interface ClassificationSummary {
    * @return custom8
    */
   String getCustom8();
+
+  /**
+   * Duplicates this ClassificationSummary
+   *
+   * @return a copy of this ClassificationSummary
+   */
+  ClassificationSummary clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/ClassificationServiceImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/ClassificationServiceImpl.java
@@ -335,7 +335,7 @@ public class ClassificationServiceImpl implements ClassificationService {
   private void addClassificationToMasterDomain(ClassificationImpl classificationImpl) {
     if (!Objects.equals(classificationImpl.getDomain(), "")) {
       boolean doesExist = true;
-      ClassificationImpl masterClassification = new ClassificationImpl(classificationImpl);
+      ClassificationImpl masterClassification = classificationImpl.copy();
       masterClassification.setId(IdGenerator.generateWithPrefix(ID_PREFIX_CLASSIFICATION));
       masterClassification.setParentKey(classificationImpl.getParentKey());
       masterClassification.setDomain("");

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/ClassificationServiceImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/ClassificationServiceImpl.java
@@ -332,19 +332,19 @@ public class ClassificationServiceImpl implements ClassificationService {
     }
   }
 
-  private void addClassificationToMasterDomain(ClassificationImpl classificationImpl) {
-    if (!Objects.equals(classificationImpl.getDomain(), "")) {
+  private void addClassificationToMasterDomain(ClassificationImpl classification) {
+    if (!Objects.equals(classification.getDomain(), "")) {
       boolean doesExist = true;
-      ClassificationImpl masterClassification = classificationImpl.copy();
+      ClassificationImpl masterClassification = classification.copy(classification.getKey());
       masterClassification.setId(IdGenerator.generateWithPrefix(ID_PREFIX_CLASSIFICATION));
-      masterClassification.setParentKey(classificationImpl.getParentKey());
+      masterClassification.setParentKey(classification.getParentKey());
       masterClassification.setDomain("");
       masterClassification.setIsValidInDomain(false);
       try {
-        if (classificationImpl.getParentKey() != null
-            && !"".equals(classificationImpl.getParentKey())) {
+        if (classification.getParentKey() != null
+            && !"".equals(classification.getParentKey())) {
           masterClassification.setParentId(
-              getClassification(classificationImpl.getParentKey(), "").getId());
+              getClassification(classification.getParentKey(), "").getId());
         }
         this.getClassification(masterClassification.getKey(), masterClassification.getDomain());
         throw new ClassificationAlreadyExistException(masterClassification);

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationImpl.java
@@ -16,75 +16,13 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
 
   public ClassificationImpl() {}
 
-  private ClassificationImpl(ClassificationImpl copyFrom) {
+  private ClassificationImpl(ClassificationImpl copyFrom, String key) {
     super(copyFrom);
     isValidInDomain = copyFrom.isValidInDomain;
     created = copyFrom.created;
     modified = copyFrom.modified;
     description = copyFrom.description;
-  }
-
-  @Override
-  public Boolean getIsValidInDomain() {
-    return isValidInDomain;
-  }
-
-  @Override
-  public void setIsValidInDomain(Boolean isValidInDomain) {
-    this.isValidInDomain = isValidInDomain;
-  }
-
-  @Override
-  public Instant getCreated() {
-    return created;
-  }
-
-  public void setCreated(Instant created) {
-    this.created = created;
-  }
-
-  @Override
-  public Instant getModified() {
-    return modified;
-  }
-
-  public void setModified(Instant modified) {
-    this.modified = modified;
-  }
-
-  @Override
-  public String getDescription() {
-    return description;
-  }
-
-  @Override
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  @Override
-  public ClassificationSummary asSummary() {
-    ClassificationSummaryImpl summary = new ClassificationSummaryImpl();
-    summary.setCategory(this.category);
-    summary.setDomain(this.domain);
-    summary.setId(this.id);
-    summary.setKey(this.key);
-    summary.setName(this.name);
-    summary.setType(this.type);
-    summary.setParentId(this.parentId);
-    summary.setParentKey(this.parentKey);
-    summary.setPriority(this.priority);
-    summary.setServiceLevel(this.serviceLevel);
-    summary.setApplicationEntryPoint(this.applicationEntryPoint);
-    summary.setCustom1(custom1);
-    summary.setCustom2(custom2);
-    summary.setCustom3(custom3);
-    summary.setCustom4(custom4);
-    summary.setCustom5(custom5);
-    summary.setCustom6(custom6);
-    summary.setCustom7(custom7);
-    summary.setCustom8(custom8);
-    return summary;
+    this.key = key;
   }
 
   @Override
@@ -95,11 +33,6 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
   @Override
   public void setApplicationEntryPoint(String applicationEntryPoint) {
     this.applicationEntryPoint = applicationEntryPoint;
-  }
-
-  @Override
-  public ClassificationImpl copy() {
-    return new ClassificationImpl(this);
   }
 
   protected boolean canEqual(Object other) {
@@ -178,5 +111,73 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
         + ", custom8="
         + custom8
         + "]";
+  }
+
+  @Override
+  public ClassificationImpl copy(String key) {
+    return new ClassificationImpl(this, key);
+  }
+
+  @Override
+  public Boolean getIsValidInDomain() {
+    return isValidInDomain;
+  }
+
+  @Override
+  public void setIsValidInDomain(Boolean isValidInDomain) {
+    this.isValidInDomain = isValidInDomain;
+  }
+
+  @Override
+  public Instant getCreated() {
+    return created;
+  }
+
+  public void setCreated(Instant created) {
+    this.created = created;
+  }
+
+  @Override
+  public Instant getModified() {
+    return modified;
+  }
+
+  public void setModified(Instant modified) {
+    this.modified = modified;
+  }
+
+  @Override
+  public String getDescription() {
+    return description;
+  }
+
+  @Override
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  @Override
+  public ClassificationSummary asSummary() {
+    ClassificationSummaryImpl summary = new ClassificationSummaryImpl();
+    summary.setCategory(this.category);
+    summary.setDomain(this.domain);
+    summary.setId(this.id);
+    summary.setKey(this.key);
+    summary.setName(this.name);
+    summary.setType(this.type);
+    summary.setParentId(this.parentId);
+    summary.setParentKey(this.parentKey);
+    summary.setPriority(this.priority);
+    summary.setServiceLevel(this.serviceLevel);
+    summary.setApplicationEntryPoint(this.applicationEntryPoint);
+    summary.setCustom1(custom1);
+    summary.setCustom2(custom2);
+    summary.setCustom3(custom3);
+    summary.setCustom4(custom4);
+    summary.setCustom5(custom5);
+    summary.setCustom6(custom6);
+    summary.setCustom7(custom7);
+    summary.setCustom8(custom8);
+    return summary;
   }
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationImpl.java
@@ -63,16 +63,6 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
   }
 
   @Override
-  public String getApplicationEntryPoint() {
-    return applicationEntryPoint;
-  }
-
-  @Override
-  public void setApplicationEntryPoint(String applicationEntryPoint) {
-    this.applicationEntryPoint = applicationEntryPoint;
-  }
-
-  @Override
   public ClassificationSummary asSummary() {
     ClassificationSummaryImpl summary = new ClassificationSummaryImpl();
     summary.setCategory(this.category);
@@ -97,13 +87,23 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
     return summary;
   }
 
-  protected boolean canEqual(Object other) {
-    return (other instanceof ClassificationImpl);
+  @Override
+  public String getApplicationEntryPoint() {
+    return applicationEntryPoint;
   }
 
   @Override
-  public ClassificationImpl clone() {
+  public void setApplicationEntryPoint(String applicationEntryPoint) {
+    this.applicationEntryPoint = applicationEntryPoint;
+  }
+
+  @Override
+  public ClassificationImpl copy() {
     return new ClassificationImpl(this);
+  }
+
+  protected boolean canEqual(Object other) {
+    return (other instanceof ClassificationImpl);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationImpl.java
@@ -16,30 +16,12 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
 
   public ClassificationImpl() {}
 
-  public ClassificationImpl(ClassificationImpl classification) {
-    this.id = classification.getId();
-    this.key = classification.getKey();
-    this.parentId = classification.getParentId();
-    this.parentKey = classification.getParentKey();
-    this.category = classification.getCategory();
-    this.type = classification.getType();
-    this.domain = classification.getDomain();
-    this.isValidInDomain = classification.getIsValidInDomain();
-    this.created = classification.getCreated();
-    this.modified = classification.getModified();
-    this.name = classification.getName();
-    this.description = classification.getDescription();
-    this.priority = classification.getPriority();
-    this.serviceLevel = classification.getServiceLevel();
-    this.applicationEntryPoint = classification.getApplicationEntryPoint();
-    this.custom1 = classification.getCustom1();
-    this.custom2 = classification.getCustom2();
-    this.custom3 = classification.getCustom3();
-    this.custom4 = classification.getCustom4();
-    this.custom5 = classification.getCustom5();
-    this.custom6 = classification.getCustom6();
-    this.custom7 = classification.getCustom7();
-    this.custom8 = classification.getCustom8();
+  private ClassificationImpl(ClassificationImpl copyFrom) {
+    super(copyFrom);
+    isValidInDomain = copyFrom.isValidInDomain;
+    created = copyFrom.created;
+    modified = copyFrom.modified;
+    description = copyFrom.description;
   }
 
   @Override
@@ -120,9 +102,13 @@ public class ClassificationImpl extends ClassificationSummaryImpl implements Cla
   }
 
   @Override
+  public ClassificationImpl clone() {
+    return new ClassificationImpl(this);
+  }
+
+  @Override
   public int hashCode() {
-    return Objects.hash(
-        super.hashCode(), isValidInDomain, created, modified, description);
+    return Objects.hash(super.hashCode(), isValidInDomain, created, modified, description);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
@@ -33,7 +33,6 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     applicationEntryPoint = copyFrom.applicationEntryPoint;
     category = copyFrom.category;
     domain = copyFrom.domain;
-    key = copyFrom.key;
     name = copyFrom.name;
     parentId = copyFrom.parentId;
     parentKey = copyFrom.parentKey;

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
@@ -30,7 +30,6 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
   public ClassificationSummaryImpl() {}
 
   protected ClassificationSummaryImpl(ClassificationSummaryImpl copyFrom) {
-    id = copyFrom.id;
     applicationEntryPoint = copyFrom.applicationEntryPoint;
     category = copyFrom.category;
     domain = copyFrom.domain;

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
@@ -29,6 +29,28 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
 
   public ClassificationSummaryImpl() {}
 
+  protected ClassificationSummaryImpl(ClassificationSummaryImpl copyFrom) {
+    id = copyFrom.id;
+    applicationEntryPoint = copyFrom.applicationEntryPoint;
+    category = copyFrom.category;
+    domain = copyFrom.domain;
+    key = copyFrom.key;
+    name = copyFrom.name;
+    parentId = copyFrom.parentId;
+    parentKey = copyFrom.parentKey;
+    priority = copyFrom.priority;
+    serviceLevel = copyFrom.serviceLevel;
+    type = copyFrom.type;
+    custom1 = copyFrom.custom1;
+    custom2 = copyFrom.custom2;
+    custom3 = copyFrom.custom3;
+    custom4 = copyFrom.custom4;
+    custom5 = copyFrom.custom5;
+    custom6 = copyFrom.custom6;
+    custom7 = copyFrom.custom7;
+    custom8 = copyFrom.custom8;
+  }
+
   @Override
   public String getId() {
     return id;
@@ -97,14 +119,26 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     return parentKey;
   }
 
+  public void setParentKey(String parentKey) {
+    this.parentKey = parentKey;
+  }
+
   @Override
   public String getServiceLevel() {
     return serviceLevel;
   }
 
+  public void setServiceLevel(String serviceLevel) {
+    this.serviceLevel = serviceLevel;
+  }
+
   @Override
   public String getApplicationEntryPoint() {
     return this.applicationEntryPoint;
+  }
+
+  public void setApplicationEntryPoint(String applicationEntryPoint) {
+    this.applicationEntryPoint = applicationEntryPoint;
   }
 
   @Override
@@ -188,20 +222,13 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     this.custom8 = custom8;
   }
 
-  public void setApplicationEntryPoint(String applicationEntryPoint) {
-    this.applicationEntryPoint = applicationEntryPoint;
-  }
-
-  public void setServiceLevel(String serviceLevel) {
-    this.serviceLevel = serviceLevel;
-  }
-
-  public void setParentKey(String parentKey) {
-    this.parentKey = parentKey;
-  }
-
   protected boolean canEqual(Object other) {
     return (other instanceof ClassificationSummaryImpl);
+  }
+
+  @Override
+  public ClassificationSummaryImpl clone() {
+    return new ClassificationSummaryImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/classification/internal/models/ClassificationSummaryImpl.java
@@ -222,13 +222,13 @@ public class ClassificationSummaryImpl implements ClassificationSummary {
     this.custom8 = custom8;
   }
 
-  protected boolean canEqual(Object other) {
-    return (other instanceof ClassificationSummaryImpl);
+  @Override
+  public ClassificationSummaryImpl copy() {
+    return new ClassificationSummaryImpl(this);
   }
 
-  @Override
-  public ClassificationSummaryImpl clone() {
-    return new ClassificationSummaryImpl(this);
+  protected boolean canEqual(Object other) {
+    return (other instanceof ClassificationSummaryImpl);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
@@ -59,7 +59,7 @@ public interface Attachment extends AttachmentSummary {
   AttachmentSummary asSummary();
 
   /**
-   * Duplicates this Attachment.
+   * Duplicates this Attachment without the id.
    *
    * @return a copy of this Attachment
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
@@ -57,4 +57,11 @@ public interface Attachment extends AttachmentSummary {
    * @return the AttachmentSummary object for the current attachment
    */
   AttachmentSummary asSummary();
+
+  /**
+   * Duplicates this Attachment
+   *
+   * @return a copy of this Attachment
+   */
+  Attachment clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
@@ -59,9 +59,9 @@ public interface Attachment extends AttachmentSummary {
   AttachmentSummary asSummary();
 
   /**
-   * Duplicates this Attachment
+   * Duplicates this Attachment.
    *
    * @return a copy of this Attachment
    */
-  Attachment clone();
+  Attachment copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Attachment.java
@@ -59,7 +59,7 @@ public interface Attachment extends AttachmentSummary {
   AttachmentSummary asSummary();
 
   /**
-   * Duplicates this Attachment without the id.
+   * Duplicates this Attachment without the id and taskId.
    *
    * @return a copy of this Attachment
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
@@ -67,7 +67,7 @@ public interface AttachmentSummary {
   Instant getReceived();
 
   /**
-   * Duplicates this AttachmentSummary.
+   * Duplicates this AttachmentSummary without the id.
    *
    * @return a copy of this AttachmentSummary
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
@@ -8,7 +8,7 @@ import pro.taskana.classification.api.models.ClassificationSummary;
  * Interface for AttachmentSummaries. This is a specific short model-object which only contains the
  * most important information.
  */
-public interface AttachmentSummary extends Cloneable {
+public interface AttachmentSummary {
 
   /**
    * Gets the id of the attachment.
@@ -67,9 +67,9 @@ public interface AttachmentSummary extends Cloneable {
   Instant getReceived();
 
   /**
-   * Duplicates this AttachmentSummary
+   * Duplicates this AttachmentSummary.
    *
    * @return a copy of this AttachmentSummary
    */
-  AttachmentSummary clone();
+  AttachmentSummary copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
@@ -8,7 +8,7 @@ import pro.taskana.classification.api.models.ClassificationSummary;
  * Interface for AttachmentSummaries. This is a specific short model-object which only contains the
  * most important information.
  */
-public interface AttachmentSummary {
+public interface AttachmentSummary extends Cloneable {
 
   /**
    * Gets the id of the attachment.
@@ -65,4 +65,11 @@ public interface AttachmentSummary {
    * @return received Instant
    */
   Instant getReceived();
+
+  /**
+   * Duplicates this AttachmentSummary
+   *
+   * @return a copy of this AttachmentSummary
+   */
+  AttachmentSummary clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/AttachmentSummary.java
@@ -67,7 +67,7 @@ public interface AttachmentSummary {
   Instant getReceived();
 
   /**
-   * Duplicates this AttachmentSummary without the id.
+   * Duplicates this AttachmentSummary without the id and taskId.
    *
    * @return a copy of this AttachmentSummary
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/ObjectReference.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/ObjectReference.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import pro.taskana.common.api.exceptions.InvalidArgumentException;
 
 /** ObjectReference entity. */
-public class ObjectReference {
+public class ObjectReference implements Cloneable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ObjectReference.class);
   private String id;
   private String company;
@@ -15,6 +15,44 @@ public class ObjectReference {
   private String systemInstance;
   private String type;
   private String value;
+
+  public ObjectReference() {}
+
+  private ObjectReference(ObjectReference copyFrom) {
+    id = copyFrom.id;
+    company = copyFrom.company;
+    system = copyFrom.system;
+    systemInstance = copyFrom.systemInstance;
+    type = copyFrom.type;
+    value = copyFrom.value;
+  }
+
+  public static void validate(ObjectReference objectReference, String objRefType, String objName)
+      throws InvalidArgumentException {
+    LOGGER.debug("entry to validateObjectReference()");
+    // check that all values in the ObjectReference are set correctly
+    if (objectReference == null) {
+      throw new InvalidArgumentException(
+          String.format("ObectReferenc %s of %s must not be null.", objRefType, objName));
+    } else if (objectReference.getCompany() == null || objectReference.getCompany().length() == 0) {
+      throw new InvalidArgumentException(
+          String.format("Company of %s of %s must not be empty", objRefType, objName));
+    } else if (objectReference.getSystem() == null || objectReference.getSystem().length() == 0) {
+      throw new InvalidArgumentException(
+          String.format("System of %s of %s must not be empty", objRefType, objName));
+    } else if (objectReference.getSystemInstance() == null
+        || objectReference.getSystemInstance().length() == 0) {
+      throw new InvalidArgumentException(
+          String.format("SystemInstance of %s of %s must not be empty", objRefType, objName));
+    } else if (objectReference.getType() == null || objectReference.getType().length() == 0) {
+      throw new InvalidArgumentException(
+          String.format("Type of %s of %s must not be empty", objRefType, objName));
+    } else if (objectReference.getValue() == null || objectReference.getValue().length() == 0) {
+      throw new InvalidArgumentException(
+          String.format("Value of %s of %s must not be empty", objRefType, objName));
+    }
+    LOGGER.debug("exit from validateObjectReference()");
+  }
 
   public String getId() {
     return id;
@@ -64,31 +102,9 @@ public class ObjectReference {
     this.value = value;
   }
 
-  public static void validate(ObjectReference objectReference, String objRefType, String objName)
-      throws InvalidArgumentException {
-    LOGGER.debug("entry to validateObjectReference()");
-    // check that all values in the ObjectReference are set correctly
-    if (objectReference == null) {
-      throw new InvalidArgumentException(
-          String.format("ObectReferenc %s of %s must not be null.", objRefType, objName));
-    } else if (objectReference.getCompany() == null || objectReference.getCompany().length() == 0) {
-      throw new InvalidArgumentException(
-          String.format("Company of %s of %s must not be empty", objRefType, objName));
-    } else if (objectReference.getSystem() == null || objectReference.getSystem().length() == 0) {
-      throw new InvalidArgumentException(
-          String.format("System of %s of %s must not be empty", objRefType, objName));
-    } else if (objectReference.getSystemInstance() == null
-        || objectReference.getSystemInstance().length() == 0) {
-      throw new InvalidArgumentException(
-          String.format("SystemInstance of %s of %s must not be empty", objRefType, objName));
-    } else if (objectReference.getType() == null || objectReference.getType().length() == 0) {
-      throw new InvalidArgumentException(
-          String.format("Type of %s of %s must not be empty", objRefType, objName));
-    } else if (objectReference.getValue() == null || objectReference.getValue().length() == 0) {
-      throw new InvalidArgumentException(
-          String.format("Value of %s of %s must not be empty", objRefType, objName));
-    }
-    LOGGER.debug("exit from validateObjectReference()");
+  @Override
+  protected ObjectReference clone() {
+    return new ObjectReference(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/ObjectReference.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/ObjectReference.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import pro.taskana.common.api.exceptions.InvalidArgumentException;
 
 /** ObjectReference entity. */
-public class ObjectReference implements Cloneable {
+public class ObjectReference {
   private static final Logger LOGGER = LoggerFactory.getLogger(ObjectReference.class);
   private String id;
   private String company;
@@ -102,8 +102,7 @@ public class ObjectReference implements Cloneable {
     this.value = value;
   }
 
-  @Override
-  protected ObjectReference clone() {
+  protected ObjectReference copy() {
     return new ObjectReference(this);
   }
 

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/ObjectReference.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/ObjectReference.java
@@ -19,7 +19,6 @@ public class ObjectReference {
   public ObjectReference() {}
 
   private ObjectReference(ObjectReference copyFrom) {
-    id = copyFrom.id;
     company = copyFrom.company;
     system = copyFrom.system;
     systemInstance = copyFrom.systemInstance;

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
@@ -189,7 +189,7 @@ public interface Task extends TaskSummary {
   String getClassificationCategory();
 
   /**
-   * Duplicates this Task.
+   * Duplicates this Task without the id.
    *
    * @return a copy of this Task
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
@@ -187,4 +187,11 @@ public interface Task extends TaskSummary {
    * @return classificationCategory
    */
   String getClassificationCategory();
+
+  /**
+   * Duplicates this Task
+   *
+   * @return a copy of this Task
+   */
+  Task clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
@@ -189,9 +189,9 @@ public interface Task extends TaskSummary {
   String getClassificationCategory();
 
   /**
-   * Duplicates this Task
+   * Duplicates this Task.
    *
    * @return a copy of this Task
    */
-  Task clone();
+  Task copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/Task.java
@@ -189,7 +189,8 @@ public interface Task extends TaskSummary {
   String getClassificationCategory();
 
   /**
-   * Duplicates this Task without the id.
+   * Duplicates this Task without the internal and external id.
+   * All referenced {@link Attachment}s are copied as well.
    *
    * @return a copy of this Task
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskComment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskComment.java
@@ -3,7 +3,7 @@ package pro.taskana.task.api.models;
 import java.time.Instant;
 
 /** TaskComment-Interface to specify TaskComment Attributes. */
-public interface TaskComment extends Cloneable {
+public interface TaskComment {
 
   /**
    * Gets the id of the task comment.
@@ -33,8 +33,11 @@ public interface TaskComment extends Cloneable {
    */
   String getTextField();
 
-  /** Sets the text field of the task comment. */
+  /**
+   * Sets the text field of the task comment.
+   *
    * @param textField the text field
+   */
   void setTextField(String textField);
 
   /**
@@ -52,9 +55,9 @@ public interface TaskComment extends Cloneable {
   Instant getModified();
 
   /**
-   * Duplicates this TaskComment
+   * Duplicates this TaskComment.
    *
    * @return a copy of this TaskComment
    */
-  TaskComment clone();
+  TaskComment copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskComment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskComment.java
@@ -3,7 +3,7 @@ package pro.taskana.task.api.models;
 import java.time.Instant;
 
 /** TaskComment-Interface to specify TaskComment Attributes. */
-public interface TaskComment {
+public interface TaskComment extends Cloneable {
 
   /**
    * Gets the id of the task comment.
@@ -33,11 +33,8 @@ public interface TaskComment {
    */
   String getTextField();
 
-  /**
-   * Sets the text field of the task comment.
-   *
+  /** Sets the text field of the task comment. */
    * @param textField the text field
-   */
   void setTextField(String textField);
 
   /**
@@ -54,6 +51,10 @@ public interface TaskComment {
    */
   Instant getModified();
 
-
-
+  /**
+   * Duplicates this TaskComment
+   *
+   * @return a copy of this TaskComment
+   */
+  TaskComment clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskComment.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskComment.java
@@ -55,7 +55,7 @@ public interface TaskComment {
   Instant getModified();
 
   /**
-   * Duplicates this TaskComment.
+   * Duplicates this TaskComment without the id.
    *
    * @return a copy of this TaskComment
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
@@ -194,7 +194,7 @@ public interface TaskSummary {
   String getCustomAttribute(String num) throws InvalidArgumentException;
 
   /**
-   * Duplicates this TaskSummary without the id.
+   * Duplicates this TaskSummary without the internal and external id.
    *
    * @return a copy of this TaskSummary
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
@@ -12,7 +12,7 @@ import pro.taskana.workbasket.api.models.WorkbasketSummary;
  * Interface for TaskSummary. This is a specific short model-object which only contains the most
  * important information.
  */
-public interface TaskSummary {
+public interface TaskSummary extends Cloneable {
 
   /**
    * Gets the id of the task.
@@ -192,4 +192,11 @@ public interface TaskSummary {
    * @throws InvalidArgumentException if num has not a value of "1", "2" ... "16"
    */
   String getCustomAttribute(String num) throws InvalidArgumentException;
+
+  /**
+   * Duplicates this TaskSummary
+   *
+   * @return a copy of this TaskSummary
+   */
+  TaskSummary clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
@@ -194,7 +194,7 @@ public interface TaskSummary {
   String getCustomAttribute(String num) throws InvalidArgumentException;
 
   /**
-   * Duplicates this TaskSummary.
+   * Duplicates this TaskSummary without the id.
    *
    * @return a copy of this TaskSummary
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
@@ -12,7 +12,7 @@ import pro.taskana.workbasket.api.models.WorkbasketSummary;
  * Interface for TaskSummary. This is a specific short model-object which only contains the most
  * important information.
  */
-public interface TaskSummary extends Cloneable {
+public interface TaskSummary {
 
   /**
    * Gets the id of the task.
@@ -194,9 +194,9 @@ public interface TaskSummary extends Cloneable {
   String getCustomAttribute(String num) throws InvalidArgumentException;
 
   /**
-   * Duplicates this TaskSummary
+   * Duplicates this TaskSummary.
    *
    * @return a copy of this TaskSummary
    */
-  TaskSummary clone();
+  TaskSummary copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentImpl.java
@@ -18,6 +18,11 @@ public class AttachmentImpl extends AttachmentSummaryImpl implements Attachment 
 
   public AttachmentImpl() {}
 
+  private AttachmentImpl(AttachmentImpl copyFrom) {
+    super(copyFrom);
+    customAttributes = new HashMap<>(copyFrom.customAttributes);
+  }
+
   @Override
   public Map<String, String> getCustomAttributes() {
     if (customAttributes == null) {
@@ -47,6 +52,11 @@ public class AttachmentImpl extends AttachmentSummaryImpl implements Attachment 
 
   protected boolean canEqual(Object other) {
     return (!(other instanceof AttachmentImpl));
+  }
+
+  @Override
+  public AttachmentImpl clone() {
+    return new AttachmentImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentImpl.java
@@ -50,13 +50,13 @@ public class AttachmentImpl extends AttachmentSummaryImpl implements Attachment 
     return summary;
   }
 
-  protected boolean canEqual(Object other) {
-    return (!(other instanceof AttachmentImpl));
+  @Override
+  public AttachmentImpl copy() {
+    return new AttachmentImpl(this);
   }
 
-  @Override
-  public AttachmentImpl clone() {
-    return new AttachmentImpl(this);
+  protected boolean canEqual(Object other) {
+    return (!(other instanceof AttachmentImpl));
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
@@ -137,6 +137,11 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
     this.received = received;
   }
 
+  @Override
+  public AttachmentSummaryImpl copy() {
+    return new AttachmentSummaryImpl(this);
+  }
+
   // auxiliary method to enable MyBatis access to classificationSummary
   @SuppressWarnings("unused")
   public ClassificationSummaryImpl getClassificationSummaryImpl() {
@@ -151,11 +156,6 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
 
   protected boolean canEqual(Object other) {
     return (!(other instanceof AttachmentSummaryImpl));
-  }
-
-  @Override
-  public AttachmentSummaryImpl clone() {
-    return new AttachmentSummaryImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
@@ -22,6 +22,17 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
 
   AttachmentSummaryImpl() {}
 
+  protected AttachmentSummaryImpl(AttachmentSummaryImpl copyFrom) {
+    id = copyFrom.id;
+    taskId = copyFrom.taskId;
+    created = copyFrom.created;
+    modified = copyFrom.modified;
+    classificationSummary = copyFrom.classificationSummary;
+    objectReference = copyFrom.objectReference;
+    channel = copyFrom.channel;
+    received = copyFrom.received;
+  }
+
   /*
    * (non-Javadoc)
    * @see pro.taskana.impl.AttachmentSummary#getId()
@@ -96,6 +107,10 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
     return channel;
   }
 
+  public void setChannel(String channel) {
+    this.channel = channel;
+  }
+
   /*
    * (non-Javadoc)
    * @see pro.taskana.impl.AttachmentSummary#getClassification()
@@ -122,10 +137,6 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
     this.received = received;
   }
 
-  public void setChannel(String channel) {
-    this.channel = channel;
-  }
-
   // auxiliary method to enable MyBatis access to classificationSummary
   @SuppressWarnings("unused")
   public ClassificationSummaryImpl getClassificationSummaryImpl() {
@@ -140,6 +151,11 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
 
   protected boolean canEqual(Object other) {
     return (!(other instanceof AttachmentSummaryImpl));
+  }
+
+  @Override
+  public AttachmentSummaryImpl clone() {
+    return new AttachmentSummaryImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
@@ -23,7 +23,6 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
   AttachmentSummaryImpl() {}
 
   protected AttachmentSummaryImpl(AttachmentSummaryImpl copyFrom) {
-    taskId = copyFrom.taskId;
     created = copyFrom.created;
     modified = copyFrom.modified;
     classificationSummary = copyFrom.classificationSummary;

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/AttachmentSummaryImpl.java
@@ -23,7 +23,6 @@ public class AttachmentSummaryImpl implements AttachmentSummary {
   AttachmentSummaryImpl() {}
 
   protected AttachmentSummaryImpl(AttachmentSummaryImpl copyFrom) {
-    id = copyFrom.id;
     taskId = copyFrom.taskId;
     created = copyFrom.created;
     modified = copyFrom.modified;

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskCommentImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskCommentImpl.java
@@ -16,7 +16,7 @@ public class TaskCommentImpl implements TaskComment {
 
   public TaskCommentImpl() {}
 
-  private TaskCommentImpl(TaskCommentImpl copyFrom) {
+  public TaskCommentImpl(TaskCommentImpl copyFrom) {
     id = copyFrom.id;
     taskId = copyFrom.taskId;
     textField = copyFrom.textField;
@@ -78,13 +78,13 @@ public class TaskCommentImpl implements TaskComment {
     this.modified = modified;
   }
 
-  protected boolean canEqual(Object other) {
-    return (other instanceof TaskCommentImpl);
+  @Override
+  public TaskCommentImpl copy() {
+    return new TaskCommentImpl(this);
   }
 
-  @Override
-  public TaskCommentImpl clone() {
-    return new TaskCommentImpl(this);
+  protected boolean canEqual(Object other) {
+    return (other instanceof TaskCommentImpl);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskCommentImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskCommentImpl.java
@@ -17,7 +17,6 @@ public class TaskCommentImpl implements TaskComment {
   public TaskCommentImpl() {}
 
   public TaskCommentImpl(TaskCommentImpl copyFrom) {
-    id = copyFrom.id;
     taskId = copyFrom.taskId;
     textField = copyFrom.textField;
     creator = copyFrom.creator;

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskCommentImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskCommentImpl.java
@@ -14,6 +14,17 @@ public class TaskCommentImpl implements TaskComment {
   private Instant created;
   private Instant modified;
 
+  public TaskCommentImpl() {}
+
+  private TaskCommentImpl(TaskCommentImpl copyFrom) {
+    id = copyFrom.id;
+    taskId = copyFrom.taskId;
+    textField = copyFrom.textField;
+    creator = copyFrom.creator;
+    created = copyFrom.created;
+    modified = copyFrom.modified;
+  }
+
   @Override
   public String getId() {
     return id;
@@ -45,6 +56,10 @@ public class TaskCommentImpl implements TaskComment {
     return textField;
   }
 
+  public void setTextField(String textField) {
+    this.textField = textField;
+  }
+
   @Override
   public Instant getCreated() {
     return created;
@@ -63,23 +78,18 @@ public class TaskCommentImpl implements TaskComment {
     this.modified = modified;
   }
 
-  public void setTextField(String textField) {
-    this.textField = textField;
-  }
-
   protected boolean canEqual(Object other) {
     return (other instanceof TaskCommentImpl);
   }
 
   @Override
+  public TaskCommentImpl clone() {
+    return new TaskCommentImpl(this);
+  }
+
+  @Override
   public int hashCode() {
-    return Objects.hash(
-        id,
-        taskId,
-        textField,
-        creator,
-        created,
-        modified);
+    return Objects.hash(id, taskId, textField, creator, created, modified);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
@@ -262,17 +262,17 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
     ((ClassificationSummaryImpl) this.classificationSummary).setCategory(classificationCategory);
   }
 
+  @Override
+  public TaskImpl copy() {
+    return new TaskImpl(this);
+  }
+
   public String getClassificationId() {
     return classificationSummary == null ? null : classificationSummary.getId();
   }
 
   protected boolean canEqual(Object other) {
     return (other instanceof TaskImpl);
-  }
-
-  @Override
-  public TaskImpl clone() {
-    return new TaskImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
@@ -29,6 +29,14 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
 
   public TaskImpl() {}
 
+  private TaskImpl(TaskImpl copyFrom) {
+    super(copyFrom);
+    customAttributes = new HashMap<>(copyFrom.customAttributes);
+    callbackInfo = new HashMap<>(copyFrom.callbackInfo);
+    callbackState = copyFrom.callbackState;
+    attachments = new ArrayList<>(copyFrom.attachments);
+  }
+
   public CallbackState getCallbackState() {
     return callbackState;
   }
@@ -170,6 +178,14 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
     return attachments;
   }
 
+  public void setAttachments(List<Attachment> attachments) {
+    if (attachments != null) {
+      this.attachments = attachments;
+    } else if (this.attachments == null) {
+      this.attachments = new ArrayList<>();
+    }
+  }
+
   @Override
   public TaskSummary asSummary() {
     TaskSummaryImpl taskSummary = new TaskSummaryImpl();
@@ -246,20 +262,17 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
     ((ClassificationSummaryImpl) this.classificationSummary).setCategory(classificationCategory);
   }
 
-  public void setAttachments(List<Attachment> attachments) {
-    if (attachments != null) {
-      this.attachments = attachments;
-    } else if (this.attachments == null) {
-      this.attachments = new ArrayList<>();
-    }
-  }
-
   public String getClassificationId() {
     return classificationSummary == null ? null : classificationSummary.getId();
   }
 
   protected boolean canEqual(Object other) {
     return (other instanceof TaskImpl);
+  }
+
+  @Override
+  public TaskImpl clone() {
+    return new TaskImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import pro.taskana.classification.internal.models.ClassificationSummaryImpl;
 import pro.taskana.common.api.exceptions.InvalidArgumentException;
@@ -34,7 +35,7 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
     customAttributes = new HashMap<>(copyFrom.customAttributes);
     callbackInfo = new HashMap<>(copyFrom.callbackInfo);
     callbackState = copyFrom.callbackState;
-    attachments = new ArrayList<>(copyFrom.attachments);
+    attachments = copyFrom.attachments.stream().map(Attachment::copy).collect(Collectors.toList());
   }
 
   public CallbackState getCallbackState() {

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
@@ -472,6 +472,11 @@ public class TaskSummaryImpl implements TaskSummary {
     }
   }
 
+  @Override
+  public TaskSummaryImpl copy() {
+    return new TaskSummaryImpl(this);
+  }
+
   // utility method to allow mybatis access to workbasketSummary
   public WorkbasketSummaryImpl getWorkbasketSummaryImpl() {
     return (WorkbasketSummaryImpl) workbasketSummary;
@@ -645,11 +650,6 @@ public class TaskSummaryImpl implements TaskSummary {
 
   protected boolean canEqual(Object other) {
     return (other instanceof TaskSummaryImpl);
-  }
-
-  @Override
-  public TaskSummaryImpl clone() {
-    return new TaskSummaryImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
@@ -64,6 +64,48 @@ public class TaskSummaryImpl implements TaskSummary {
 
   public TaskSummaryImpl() {}
 
+  protected TaskSummaryImpl(TaskSummaryImpl copyFrom) {
+    id = copyFrom.id;
+    externalId = copyFrom.externalId;
+    created = copyFrom.created;
+    claimed = copyFrom.claimed;
+    completed = copyFrom.completed;
+    modified = copyFrom.modified;
+    planned = copyFrom.planned;
+    due = copyFrom.due;
+    name = copyFrom.name;
+    creator = copyFrom.creator;
+    note = copyFrom.note;
+    description = copyFrom.description;
+    priority = copyFrom.priority;
+    state = copyFrom.state;
+    classificationSummary = copyFrom.classificationSummary;
+    workbasketSummary = copyFrom.workbasketSummary;
+    businessProcessId = copyFrom.businessProcessId;
+    parentBusinessProcessId = copyFrom.parentBusinessProcessId;
+    owner = copyFrom.owner;
+    primaryObjRef = copyFrom.primaryObjRef;
+    isRead = copyFrom.isRead;
+    isTransferred = copyFrom.isTransferred;
+    attachmentSummaries = new ArrayList<>(copyFrom.attachmentSummaries);
+    custom1 = copyFrom.custom1;
+    custom2 = copyFrom.custom2;
+    custom3 = copyFrom.custom3;
+    custom4 = copyFrom.custom4;
+    custom5 = copyFrom.custom5;
+    custom6 = copyFrom.custom6;
+    custom7 = copyFrom.custom7;
+    custom8 = copyFrom.custom8;
+    custom9 = copyFrom.custom9;
+    custom10 = copyFrom.custom10;
+    custom11 = copyFrom.custom11;
+    custom12 = copyFrom.custom12;
+    custom13 = copyFrom.custom13;
+    custom14 = copyFrom.custom14;
+    custom15 = copyFrom.custom15;
+    custom16 = copyFrom.custom16;
+  }
+
   /*
    * (non-Javadoc)
    * @see pro.taskana.TaskSummary#getTaskId()
@@ -97,6 +139,10 @@ public class TaskSummaryImpl implements TaskSummary {
   @Override
   public String getCreator() {
     return creator;
+  }
+
+  public void setCreator(String creator) {
+    this.creator = creator;
   }
 
   /*
@@ -276,6 +322,10 @@ public class TaskSummaryImpl implements TaskSummary {
     return attachmentSummaries;
   }
 
+  public void setAttachmentSummaries(List<AttachmentSummary> attachmentSummaries) {
+    this.attachmentSummaries = attachmentSummaries;
+  }
+
   /*
    * (non-Javadoc)
    * @see pro.taskana.TaskSummary#getDomain()
@@ -420,14 +470,6 @@ public class TaskSummaryImpl implements TaskSummary {
       default:
         throw new InvalidArgumentException(String.format(NOT_A_VALID_NUMBER_GET, number));
     }
-  }
-
-  public void setAttachmentSummaries(List<AttachmentSummary> attachmentSummaries) {
-    this.attachmentSummaries = attachmentSummaries;
-  }
-
-  public void setCreator(String creator) {
-    this.creator = creator;
   }
 
   // utility method to allow mybatis access to workbasketSummary
@@ -603,6 +645,11 @@ public class TaskSummaryImpl implements TaskSummary {
 
   protected boolean canEqual(Object other) {
     return (other instanceof TaskSummaryImpl);
+  }
+
+  @Override
+  public TaskSummaryImpl clone() {
+    return new TaskSummaryImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
@@ -65,7 +65,6 @@ public class TaskSummaryImpl implements TaskSummary {
   public TaskSummaryImpl() {}
 
   protected TaskSummaryImpl(TaskSummaryImpl copyFrom) {
-    id = copyFrom.id;
     externalId = copyFrom.externalId;
     created = copyFrom.created;
     claimed = copyFrom.claimed;

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
@@ -65,7 +65,6 @@ public class TaskSummaryImpl implements TaskSummary {
   public TaskSummaryImpl() {}
 
   protected TaskSummaryImpl(TaskSummaryImpl copyFrom) {
-    externalId = copyFrom.externalId;
     created = copyFrom.created;
     claimed = copyFrom.claimed;
     completed = copyFrom.completed;

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
@@ -126,4 +126,11 @@ public interface Workbasket extends WorkbasketSummary {
    * @return the WorkbasketSummary object for the current work basket
    */
   WorkbasketSummary asSummary();
+
+  /**
+   * Duplicates this Workbasket
+   *
+   * @return a copy of this Workbasket
+   */
+  Workbasket clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
@@ -100,7 +100,7 @@ public interface Workbasket extends WorkbasketSummary {
   void setMarkedForDeletion(boolean markedForDeletion);
 
   /**
-   * Duplicates this Workbasket.
+   * Duplicates this Workbasket without the id.
    *
    * @return a copy of this Workbasket
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
@@ -100,6 +100,13 @@ public interface Workbasket extends WorkbasketSummary {
   void setMarkedForDeletion(boolean markedForDeletion);
 
   /**
+   * Duplicates this Workbasket.
+   *
+   * @return a copy of this Workbasket
+   */
+  Workbasket copy();
+
+  /**
    * Sets the owner-ID of the workbasket.
    *
    * @param owner of the current workbasket
@@ -126,11 +133,4 @@ public interface Workbasket extends WorkbasketSummary {
    * @return the WorkbasketSummary object for the current work basket
    */
   WorkbasketSummary asSummary();
-
-  /**
-   * Duplicates this Workbasket
-   *
-   * @return a copy of this Workbasket
-   */
-  Workbasket clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/Workbasket.java
@@ -102,9 +102,10 @@ public interface Workbasket extends WorkbasketSummary {
   /**
    * Duplicates this Workbasket without the id.
    *
+   * @param key for the new Workbasket
    * @return a copy of this Workbasket
    */
-  Workbasket copy();
+  Workbasket copy(String key);
 
   /**
    * Sets the owner-ID of the workbasket.

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketAccessItem.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketAccessItem.java
@@ -6,7 +6,7 @@ package pro.taskana.workbasket.api.models;
  *
  * @author bbr
  */
-public interface WorkbasketAccessItem extends Cloneable {
+public interface WorkbasketAccessItem {
 
   /**
    * Returns the current id of the WorkbasketAccessItem.
@@ -317,9 +317,9 @@ public interface WorkbasketAccessItem extends Cloneable {
   void setPermCustom12(boolean permCustom12);
 
   /**
-   * Duplicates this WorkbasketAccessItem
+   * Duplicates this WorkbasketAccessItem.
    *
    * @return a copy of this WorkbasketAccessItem
    */
-  WorkbasketAccessItem clone();
+  WorkbasketAccessItem copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketAccessItem.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketAccessItem.java
@@ -6,7 +6,7 @@ package pro.taskana.workbasket.api.models;
  *
  * @author bbr
  */
-public interface WorkbasketAccessItem {
+public interface WorkbasketAccessItem extends Cloneable {
 
   /**
    * Returns the current id of the WorkbasketAccessItem.
@@ -315,4 +315,11 @@ public interface WorkbasketAccessItem {
    * @param permCustom12 specifies whether custom12 permission is granted
    */
   void setPermCustom12(boolean permCustom12);
+
+  /**
+   * Duplicates this WorkbasketAccessItem
+   *
+   * @return a copy of this WorkbasketAccessItem
+   */
+  WorkbasketAccessItem clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketAccessItem.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketAccessItem.java
@@ -317,7 +317,7 @@ public interface WorkbasketAccessItem {
   void setPermCustom12(boolean permCustom12);
 
   /**
-   * Duplicates this WorkbasketAccessItem.
+   * Duplicates this WorkbasketAccessItem without the id.
    *
    * @return a copy of this WorkbasketAccessItem
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketSummary.java
@@ -6,7 +6,7 @@ import pro.taskana.workbasket.api.WorkbasketType;
  * Interface for WorkbasketSummary. This is a specific short model-object which only contains the
  * most important information.
  */
-public interface WorkbasketSummary {
+public interface WorkbasketSummary extends Cloneable {
 
   /**
    * Gets the id of the workbasket.
@@ -119,4 +119,11 @@ public interface WorkbasketSummary {
    * @return the workbasket's markedForDeletion property
    */
   boolean isMarkedForDeletion();
+
+  /**
+   * Duplicates this WorkbasketSummary
+   *
+   * @return a copy of this WorkbasketSummary
+   */
+  WorkbasketSummary clone();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketSummary.java
@@ -121,7 +121,7 @@ public interface WorkbasketSummary {
   boolean isMarkedForDeletion();
 
   /**
-   * Duplicates this WorkbasketSummary.
+   * Duplicates this WorkbasketSummary without the id.
    *
    * @return a copy of this WorkbasketSummary
    */

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/api/models/WorkbasketSummary.java
@@ -6,7 +6,7 @@ import pro.taskana.workbasket.api.WorkbasketType;
  * Interface for WorkbasketSummary. This is a specific short model-object which only contains the
  * most important information.
  */
-public interface WorkbasketSummary extends Cloneable {
+public interface WorkbasketSummary {
 
   /**
    * Gets the id of the workbasket.
@@ -121,9 +121,9 @@ public interface WorkbasketSummary extends Cloneable {
   boolean isMarkedForDeletion();
 
   /**
-   * Duplicates this WorkbasketSummary
+   * Duplicates this WorkbasketSummary.
    *
    * @return a copy of this WorkbasketSummary
    */
-  WorkbasketSummary clone();
+  WorkbasketSummary copy();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketAccessItemImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketAccessItemImpl.java
@@ -33,7 +33,6 @@ public class WorkbasketAccessItemImpl implements WorkbasketAccessItem {
   public WorkbasketAccessItemImpl() {}
 
   private WorkbasketAccessItemImpl(WorkbasketAccessItemImpl copyFrom) {
-    id = copyFrom.id;
     workbasketId = copyFrom.workbasketId;
     workbasketKey = copyFrom.workbasketKey;
     accessId = copyFrom.accessId;

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketAccessItemImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketAccessItemImpl.java
@@ -30,8 +30,31 @@ public class WorkbasketAccessItemImpl implements WorkbasketAccessItem {
   private boolean permCustom11;
   private boolean permCustom12;
 
-  public WorkbasketAccessItemImpl() {
-    super();
+  public WorkbasketAccessItemImpl() {}
+
+  private WorkbasketAccessItemImpl(WorkbasketAccessItemImpl copyFrom) {
+    id = copyFrom.id;
+    workbasketId = copyFrom.workbasketId;
+    workbasketKey = copyFrom.workbasketKey;
+    accessId = copyFrom.accessId;
+    accessName = copyFrom.accessName;
+    permRead = copyFrom.permRead;
+    permOpen = copyFrom.permOpen;
+    permAppend = copyFrom.permAppend;
+    permTransfer = copyFrom.permTransfer;
+    permDistribute = copyFrom.permDistribute;
+    permCustom1 = copyFrom.permCustom1;
+    permCustom2 = copyFrom.permCustom2;
+    permCustom3 = copyFrom.permCustom3;
+    permCustom4 = copyFrom.permCustom4;
+    permCustom5 = copyFrom.permCustom5;
+    permCustom6 = copyFrom.permCustom6;
+    permCustom7 = copyFrom.permCustom7;
+    permCustom8 = copyFrom.permCustom8;
+    permCustom9 = copyFrom.permCustom9;
+    permCustom10 = copyFrom.permCustom10;
+    permCustom11 = copyFrom.permCustom11;
+    permCustom12 = copyFrom.permCustom12;
   }
 
   /*
@@ -404,6 +427,11 @@ public class WorkbasketAccessItemImpl implements WorkbasketAccessItem {
   @Override
   public void setPermCustom12(boolean permCustom12) {
     this.permCustom12 = permCustom12;
+  }
+
+  @Override
+  public WorkbasketAccessItemImpl clone() {
+    return new WorkbasketAccessItemImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketAccessItemImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketAccessItemImpl.java
@@ -430,7 +430,7 @@ public class WorkbasketAccessItemImpl implements WorkbasketAccessItem {
   }
 
   @Override
-  public WorkbasketAccessItemImpl clone() {
+  public WorkbasketAccessItemImpl copy() {
     return new WorkbasketAccessItemImpl(this);
   }
 

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketImpl.java
@@ -60,6 +60,11 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
     return result;
   }
 
+  @Override
+  public WorkbasketImpl copy() {
+    return new WorkbasketImpl(this);
+  }
+
   protected boolean canEqual(Object other) {
     return (other instanceof WorkbasketImpl);
   }
@@ -103,11 +108,6 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
       return false;
     }
     return Objects.equals(created, other.created) && Objects.equals(modified, other.modified);
-  }
-
-  @Override
-  public WorkbasketImpl clone() {
-    return new WorkbasketImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketImpl.java
@@ -14,10 +14,16 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
 
   public WorkbasketImpl() {}
 
-  private WorkbasketImpl(WorkbasketImpl copyFrom) {
+  private WorkbasketImpl(WorkbasketImpl copyFrom, String key) {
     super(copyFrom);
     created = copyFrom.created;
     modified = copyFrom.modified;
+    this.key = key;
+  }
+
+  @Override
+  public WorkbasketImpl copy(String key) {
+    return new WorkbasketImpl(this, key);
   }
 
   @Override
@@ -58,11 +64,6 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
     result.setOrgLevel4(this.getOrgLevel4());
     result.setMarkedForDeletion(this.isMarkedForDeletion());
     return result;
-  }
-
-  @Override
-  public WorkbasketImpl copy() {
-    return new WorkbasketImpl(this);
   }
 
   protected boolean canEqual(Object other) {

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketImpl.java
@@ -14,6 +14,12 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
 
   public WorkbasketImpl() {}
 
+  private WorkbasketImpl(WorkbasketImpl copyFrom) {
+    super(copyFrom);
+    created = copyFrom.created;
+    modified = copyFrom.modified;
+  }
+
   @Override
   public Instant getCreated() {
     return created;
@@ -97,6 +103,11 @@ public class WorkbasketImpl extends WorkbasketSummaryImpl implements Workbasket 
       return false;
     }
     return Objects.equals(created, other.created) && Objects.equals(modified, other.modified);
+  }
+
+  @Override
+  public WorkbasketImpl clone() {
+    return new WorkbasketImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
@@ -28,7 +28,6 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
   public WorkbasketSummaryImpl() {}
 
   protected WorkbasketSummaryImpl(WorkbasketSummaryImpl copyFrom) {
-    key = copyFrom.key;
     name = copyFrom.name;
     description = copyFrom.description;
     owner = copyFrom.owner;

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
@@ -250,6 +250,11 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
     this.markedForDeletion = markedForDeletion;
   }
 
+  @Override
+  public WorkbasketSummaryImpl copy() {
+    return new WorkbasketSummaryImpl(this);
+  }
+
   protected boolean canEqual(Object other) {
     return (other instanceof WorkbasketSummaryImpl);
   }
@@ -303,11 +308,6 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
         && Objects.equals(orgLevel2, other.orgLevel2)
         && Objects.equals(orgLevel3, other.orgLevel3)
         && Objects.equals(orgLevel4, other.orgLevel4);
-  }
-
-  @Override
-  public WorkbasketSummaryImpl clone() {
-    return new WorkbasketSummaryImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
@@ -27,6 +27,25 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
 
   public WorkbasketSummaryImpl() {}
 
+  protected WorkbasketSummaryImpl(WorkbasketSummaryImpl copyFrom) {
+    id = copyFrom.id;
+    key = copyFrom.key;
+    name = copyFrom.name;
+    description = copyFrom.description;
+    owner = copyFrom.owner;
+    domain = copyFrom.domain;
+    type = copyFrom.type;
+    custom1 = copyFrom.custom1;
+    custom2 = copyFrom.custom2;
+    custom3 = copyFrom.custom3;
+    custom4 = copyFrom.custom4;
+    orgLevel1 = copyFrom.orgLevel1;
+    orgLevel2 = copyFrom.orgLevel2;
+    orgLevel3 = copyFrom.orgLevel3;
+    orgLevel4 = copyFrom.orgLevel4;
+    markedForDeletion = copyFrom.markedForDeletion;
+  }
+
   /*
    * (non-Javadoc)
    * @see pro.taskana.impl.WorkbasketSummary#getId()
@@ -284,6 +303,11 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
         && Objects.equals(orgLevel2, other.orgLevel2)
         && Objects.equals(orgLevel3, other.orgLevel3)
         && Objects.equals(orgLevel4, other.orgLevel4);
+  }
+
+  @Override
+  public WorkbasketSummaryImpl clone() {
+    return new WorkbasketSummaryImpl(this);
   }
 
   @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/workbasket/internal/models/WorkbasketSummaryImpl.java
@@ -28,7 +28,6 @@ public class WorkbasketSummaryImpl implements WorkbasketSummary {
   public WorkbasketSummaryImpl() {}
 
   protected WorkbasketSummaryImpl(WorkbasketSummaryImpl copyFrom) {
-    id = copyFrom.id;
     key = copyFrom.key;
     name = copyFrom.name;
     description = copyFrom.description;

--- a/lib/taskana-core/src/test/java/acceptance/classification/CreateClassificationAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/classification/CreateClassificationAccTest.java
@@ -2,6 +2,8 @@ package acceptance.classification;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import acceptance.AbstractAccTest;
 import org.junit.jupiter.api.Test;
@@ -250,5 +252,20 @@ class CreateClassificationAccTest extends AbstractAccTest {
     classification.setId("EXPLICIT ID");
     assertThatThrownBy(() -> classificationService.createClassification(classification))
         .isInstanceOf(InvalidArgumentException.class);
+  }
+
+  @WithAccessId(
+      userName = "teamlead_1",
+      groupNames = {"group_1", "businessadmin"})
+  @Test
+  void should_beAbleToCreateNewClassification_When_ClassificationCopy() throws Exception {
+    ClassificationImpl oldClassification =
+        (ClassificationImpl) classificationService.getClassification("T2100", "DOMAIN_B");
+    Classification newClassification = oldClassification.copy("T9949");
+
+    newClassification = classificationService.createClassification(newClassification);
+
+    assertNotNull(newClassification.getId());
+    assertNotEquals(newClassification.getId(), oldClassification.getId());
   }
 }

--- a/lib/taskana-core/src/test/java/acceptance/task/CreateTaskAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/task/CreateTaskAccTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -39,6 +40,7 @@ import pro.taskana.task.api.exceptions.InvalidStateException;
 import pro.taskana.task.api.exceptions.TaskAlreadyExistException;
 import pro.taskana.task.api.exceptions.TaskNotFoundException;
 import pro.taskana.task.api.models.Attachment;
+import pro.taskana.task.api.models.AttachmentSummary;
 import pro.taskana.task.api.models.ObjectReference;
 import pro.taskana.task.api.models.Task;
 import pro.taskana.task.internal.AttachmentMapper;
@@ -59,6 +61,23 @@ class CreateTaskAccTest extends AbstractAccTest {
   void setup() {
     taskService = taskanaEngine.getTaskService();
     classificationService = taskanaEngine.getClassificationService();
+  }
+
+  @WithAccessId(
+      userName = "user_1_1",
+      groupNames = {"group_1"})
+  @Test
+  void should_beAbleToCreateNewTask_When_TaskCopy() throws Exception {
+    Task oldTask = taskService.getTask("TKI:000000000000000000000000000000000000");
+
+    Task newTask = oldTask.copy();
+    newTask = taskService.createTask(newTask);
+
+    assertNotNull(newTask.getId());
+    assertNotEquals(newTask.getId(), oldTask.getId());
+    org.assertj.core.api.Assertions.assertThat(newTask.getAttachments())
+        .extracting(AttachmentSummary::getTaskId)
+        .containsOnly(newTask.getId());
   }
 
   @WithAccessId(

--- a/lib/taskana-core/src/test/java/acceptance/workbasket/CreateWorkbasketAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/workbasket/CreateWorkbasketAccTest.java
@@ -1,6 +1,7 @@
 package acceptance.workbasket;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -23,6 +24,7 @@ import pro.taskana.workbasket.api.exceptions.WorkbasketAlreadyExistException;
 import pro.taskana.workbasket.api.exceptions.WorkbasketNotFoundException;
 import pro.taskana.workbasket.api.models.Workbasket;
 import pro.taskana.workbasket.api.models.WorkbasketAccessItem;
+import pro.taskana.workbasket.internal.models.WorkbasketImpl;
 
 /** Acceptance test for all "create workbasket" scenarios. */
 @ExtendWith(JaasExtension.class)
@@ -77,6 +79,22 @@ class CreateWorkbasketAccTest extends AbstractAccTest {
 
     Assertions.assertThrows(
         NotAuthorizedException.class, () -> workbasketService.createWorkbasket(workbasket));
+  }
+
+  @WithAccessId(
+      userName = "teamlead_1",
+      groupNames = {"group_1", "businessadmin"})
+  @Test
+  void should_beAbleToCreateNewWorkbasket_When_WorkbasketCopy() throws Exception {
+    WorkbasketService workbasketService = taskanaEngine.getWorkbasketService();
+    WorkbasketImpl oldWorkbasket =
+        (WorkbasketImpl) workbasketService.getWorkbasket("GPK_KSC", "DOMAIN_A");
+
+    WorkbasketImpl newWorkbasket = oldWorkbasket.copy("keyname");
+    newWorkbasket = (WorkbasketImpl) workbasketService.createWorkbasket(newWorkbasket);
+
+    assertNotNull(newWorkbasket.getId());
+    assertNotEquals(newWorkbasket.getId(), oldWorkbasket.getId());
   }
 
   @WithAccessId(

--- a/lib/taskana-core/src/test/java/pro/taskana/classification/api/models/ClassificationModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/classification/api/models/ClassificationModelsCloneTest.java
@@ -10,7 +10,7 @@ import pro.taskana.classification.internal.models.ClassificationSummaryImpl;
 class ClassificationModelsCloneTest {
 
   @Test
-  void testCloneInClassificationSummary() {
+  void should_CopyWithoutId_When_ClassificationSummaryClone() {
     Classification dummyClassificationForSummaryTest = new ClassificationImpl();
     dummyClassificationForSummaryTest.setApplicationEntryPoint("dummyEntryPoint");
     dummyClassificationForSummaryTest.setCategory("dummyCategory");
@@ -32,7 +32,9 @@ class ClassificationModelsCloneTest {
     ClassificationSummaryImpl dummyClassificationSummary =
         (ClassificationSummaryImpl) dummyClassificationForSummaryTest.asSummary();
     dummyClassificationSummary.setId("dummyId");
+
     ClassificationSummaryImpl dummyClassificationSummaryCloned = dummyClassificationSummary.copy();
+
     assertThat(dummyClassificationSummaryCloned).isNotEqualTo(dummyClassificationSummary);
     dummyClassificationSummaryCloned.setId(dummyClassificationSummary.getId());
     assertThat(dummyClassificationSummaryCloned).isEqualTo(dummyClassificationSummary);
@@ -40,7 +42,7 @@ class ClassificationModelsCloneTest {
   }
 
   @Test
-  void testCloneInClassification() {
+  void should_CopyWithoutId_When_ClassificationClone() {
     ClassificationImpl dummyClassification = new ClassificationImpl();
     dummyClassification.setId("dummyId");
     dummyClassification.setApplicationEntryPoint("dummyEntryPoint");
@@ -60,7 +62,10 @@ class ClassificationModelsCloneTest {
     dummyClassification.setPriority(1);
     dummyClassification.setName("dummyName");
     dummyClassification.setParentKey("dummyParentKey");
-    ClassificationImpl dummyClassificationCloned = dummyClassification.copy();
+
+    ClassificationImpl dummyClassificationCloned =
+        dummyClassification.copy(dummyClassification.getKey());
+
     assertThat(dummyClassificationCloned).isNotEqualTo(dummyClassification);
     dummyClassificationCloned.setId(dummyClassification.getId());
     assertThat(dummyClassificationCloned).isEqualTo(dummyClassification);

--- a/lib/taskana-core/src/test/java/pro/taskana/classification/api/models/ClassificationModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/classification/api/models/ClassificationModelsCloneTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 
 import pro.taskana.classification.internal.models.ClassificationImpl;
+import pro.taskana.classification.internal.models.ClassificationSummaryImpl;
 
 class ClassificationModelsCloneTest {
 
@@ -28,16 +29,20 @@ class ClassificationModelsCloneTest {
     dummyClassificationForSummaryTest.setPriority(1);
     dummyClassificationForSummaryTest.setName("dummyName");
     dummyClassificationForSummaryTest.setParentKey("dummyParentKey");
-    ClassificationSummary dummyClassificationSummary =
-        dummyClassificationForSummaryTest.asSummary();
-    ClassificationSummary dummyClassificationSummaryCloned = dummyClassificationSummary.copy();
+    ClassificationSummaryImpl dummyClassificationSummary =
+        (ClassificationSummaryImpl) dummyClassificationForSummaryTest.asSummary();
+    dummyClassificationSummary.setId("dummyId");
+    ClassificationSummaryImpl dummyClassificationSummaryCloned = dummyClassificationSummary.copy();
+    assertThat(dummyClassificationSummaryCloned).isNotEqualTo(dummyClassificationSummary);
+    dummyClassificationSummaryCloned.setId(dummyClassificationSummary.getId());
     assertThat(dummyClassificationSummaryCloned).isEqualTo(dummyClassificationSummary);
     assertThat(dummyClassificationSummaryCloned).isNotSameAs(dummyClassificationSummary);
   }
 
   @Test
   void testCloneInClassification() {
-    Classification dummyClassification = new ClassificationImpl();
+    ClassificationImpl dummyClassification = new ClassificationImpl();
+    dummyClassification.setId("dummyId");
     dummyClassification.setApplicationEntryPoint("dummyEntryPoint");
     dummyClassification.setCategory("dummyCategory");
     dummyClassification.setCustom1("dummyCustom1");
@@ -55,7 +60,9 @@ class ClassificationModelsCloneTest {
     dummyClassification.setPriority(1);
     dummyClassification.setName("dummyName");
     dummyClassification.setParentKey("dummyParentKey");
-    Classification dummyClassificationCloned = dummyClassification.copy();
+    ClassificationImpl dummyClassificationCloned = dummyClassification.copy();
+    assertThat(dummyClassificationCloned).isNotEqualTo(dummyClassification);
+    dummyClassificationCloned.setId(dummyClassification.getId());
     assertThat(dummyClassificationCloned).isEqualTo(dummyClassification);
     assertThat(dummyClassificationCloned).isNotSameAs(dummyClassification);
   }

--- a/lib/taskana-core/src/test/java/pro/taskana/classification/api/models/ClassificationModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/classification/api/models/ClassificationModelsCloneTest.java
@@ -1,0 +1,62 @@
+package pro.taskana.classification.api.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import pro.taskana.classification.internal.models.ClassificationImpl;
+
+class ClassificationModelsCloneTest {
+
+  @Test
+  void testCloneInClassificationSummary() {
+    Classification dummyClassificationForSummaryTest = new ClassificationImpl();
+    dummyClassificationForSummaryTest.setApplicationEntryPoint("dummyEntryPoint");
+    dummyClassificationForSummaryTest.setCategory("dummyCategory");
+    dummyClassificationForSummaryTest.setCustom1("dummyCustom1");
+    dummyClassificationForSummaryTest.setCustom2("dummyCustom2");
+    dummyClassificationForSummaryTest.setCustom3("dummyCustom3");
+    dummyClassificationForSummaryTest.setCustom4("dummyCustom4");
+    dummyClassificationForSummaryTest.setCustom5("dummyCustom5");
+    dummyClassificationForSummaryTest.setCustom6("dummyCustom6");
+    dummyClassificationForSummaryTest.setCustom7("dummyCustom7");
+    dummyClassificationForSummaryTest.setCustom8("dummyCustom8");
+    dummyClassificationForSummaryTest.setDescription("dummyDescription");
+    dummyClassificationForSummaryTest.setIsValidInDomain(true);
+    dummyClassificationForSummaryTest.setParentId("dummyParentId");
+    dummyClassificationForSummaryTest.setServiceLevel("dummyServiceLevel");
+    dummyClassificationForSummaryTest.setPriority(1);
+    dummyClassificationForSummaryTest.setName("dummyName");
+    dummyClassificationForSummaryTest.setParentKey("dummyParentKey");
+    ClassificationSummary dummyClassificationSummary =
+        dummyClassificationForSummaryTest.asSummary();
+    ClassificationSummary dummyClassificationSummaryCloned = dummyClassificationSummary.copy();
+    assertThat(dummyClassificationSummaryCloned).isEqualTo(dummyClassificationSummary);
+    assertThat(dummyClassificationSummaryCloned).isNotSameAs(dummyClassificationSummary);
+  }
+
+  @Test
+  void testCloneInClassification() {
+    Classification dummyClassification = new ClassificationImpl();
+    dummyClassification.setApplicationEntryPoint("dummyEntryPoint");
+    dummyClassification.setCategory("dummyCategory");
+    dummyClassification.setCustom1("dummyCustom1");
+    dummyClassification.setCustom2("dummyCustom2");
+    dummyClassification.setCustom3("dummyCustom3");
+    dummyClassification.setCustom4("dummyCustom4");
+    dummyClassification.setCustom5("dummyCustom5");
+    dummyClassification.setCustom6("dummyCustom6");
+    dummyClassification.setCustom7("dummyCustom7");
+    dummyClassification.setCustom8("dummyCustom8");
+    dummyClassification.setDescription("dummyDescription");
+    dummyClassification.setIsValidInDomain(true);
+    dummyClassification.setParentId("dummyParentId");
+    dummyClassification.setServiceLevel("dummyServiceLevel");
+    dummyClassification.setPriority(1);
+    dummyClassification.setName("dummyName");
+    dummyClassification.setParentKey("dummyParentKey");
+    Classification dummyClassificationCloned = dummyClassification.copy();
+    assertThat(dummyClassificationCloned).isEqualTo(dummyClassification);
+    assertThat(dummyClassificationCloned).isNotSameAs(dummyClassification);
+  }
+}

--- a/lib/taskana-core/src/test/java/pro/taskana/task/api/models/TaskModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/api/models/TaskModelsCloneTest.java
@@ -8,7 +8,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import pro.taskana.task.internal.CreateTaskModelHelper;
+import pro.taskana.task.internal.models.AttachmentImpl;
+import pro.taskana.task.internal.models.AttachmentSummaryImpl;
 import pro.taskana.task.internal.models.TaskCommentImpl;
+import pro.taskana.task.internal.models.TaskImpl;
 import pro.taskana.task.internal.models.TaskSummaryImpl;
 
 class TaskModelsCloneTest {
@@ -16,7 +19,7 @@ class TaskModelsCloneTest {
   @Test
   void testCloneInTaskSummary() {
     TaskSummaryImpl dummyTaskSummary = new TaskSummaryImpl();
-
+    dummyTaskSummary.setId("dummyId");
     Attachment dummyAttachmentForSummaryTestPreClone =
         CreateTaskModelHelper.createAttachment("uniqueIdForDeepTest", "uniqueTaskIdForDeepTest");
     AttachmentSummary dummyAttachmentSummary = dummyAttachmentForSummaryTestPreClone.asSummary();
@@ -24,7 +27,9 @@ class TaskModelsCloneTest {
     attachmentSummaries.add(dummyAttachmentSummary);
     dummyTaskSummary.setAttachmentSummaries(attachmentSummaries);
 
-    TaskSummary dummyTaskSummaryCloned = dummyTaskSummary.copy();
+    TaskSummaryImpl dummyTaskSummaryCloned = dummyTaskSummary.copy();
+    assertThat(dummyTaskSummaryCloned).isNotEqualTo(dummyTaskSummary);
+    dummyTaskSummaryCloned.setId(dummyTaskSummary.getId());
     assertThat(dummyTaskSummaryCloned).isEqualTo(dummyTaskSummary);
     assertThat(dummyTaskSummaryCloned).isNotSameAs(dummyTaskSummary);
 
@@ -38,7 +43,7 @@ class TaskModelsCloneTest {
 
   @Test
   void testCloneInTask() {
-    Task dummyTask =
+    TaskImpl dummyTask =
         CreateTaskModelHelper.createUnitTestTask(
             "dummyTaskId",
             "dummyTaskName",
@@ -51,7 +56,9 @@ class TaskModelsCloneTest {
     dummyCallbackInfoPreClone.put("dummyCallbackKey", "dummyCallbackValue");
     dummyTask.setCallbackInfo(dummyCallbackInfoPreClone);
 
-    Task dummyTaskCloned = dummyTask.copy();
+    TaskImpl dummyTaskCloned = dummyTask.copy();
+    assertThat(dummyTaskCloned).isNotEqualTo(dummyTask);
+    dummyTaskCloned.setId(dummyTask.getId());
     assertThat(dummyTaskCloned).isEqualTo(dummyTask);
     assertThat(dummyTaskCloned).isNotSameAs(dummyTask);
 
@@ -64,7 +71,10 @@ class TaskModelsCloneTest {
   void testCloneInTaskComment() {
     TaskCommentImpl dummyComment = new TaskCommentImpl();
     dummyComment.setTextField("dummyTextField");
-    TaskComment dummyCommentCloned = dummyComment.copy();
+    dummyComment.setId("dummyId");
+    TaskCommentImpl dummyCommentCloned = dummyComment.copy();
+    assertThat(dummyCommentCloned).isNotEqualTo(dummyComment);
+    dummyCommentCloned.setId(dummyComment.getId());
     assertThat(dummyCommentCloned).isEqualTo(dummyComment);
     assertThat(dummyCommentCloned).isNotSameAs(dummyComment);
   }
@@ -79,6 +89,8 @@ class TaskModelsCloneTest {
     dummyReference.setType("dummyType");
     dummyReference.setValue("dummyValue");
     ObjectReference dummyReferenceCloned = dummyReference.copy();
+    assertThat(dummyReferenceCloned).isNotEqualTo(dummyReference);
+    dummyReferenceCloned.setId(dummyReference.getId());
     assertThat(dummyReferenceCloned).isEqualTo(dummyReference);
     assertThat(dummyReferenceCloned).isNotSameAs(dummyReference);
   }
@@ -87,22 +99,27 @@ class TaskModelsCloneTest {
   void testCloneInAttachmentSummary() {
     Attachment dummyAttachmentForSummaryTest =
         CreateTaskModelHelper.createAttachment("dummyAttachmentId", "dummyTaskId");
-    AttachmentSummary dummyAttachmentSummary = dummyAttachmentForSummaryTest.asSummary();
-    AttachmentSummary dummyAttachmentSummaryCloned = dummyAttachmentSummary.copy();
+    AttachmentSummaryImpl dummyAttachmentSummary =
+        (AttachmentSummaryImpl) dummyAttachmentForSummaryTest.asSummary();
+    AttachmentSummaryImpl dummyAttachmentSummaryCloned = dummyAttachmentSummary.copy();
+    assertThat(dummyAttachmentSummaryCloned).isNotEqualTo(dummyAttachmentSummary);
+    dummyAttachmentSummaryCloned.setId(dummyAttachmentSummary.getId());
     assertThat(dummyAttachmentSummaryCloned).isEqualTo(dummyAttachmentSummary);
     assertThat(dummyAttachmentSummaryCloned).isNotSameAs(dummyAttachmentSummary);
   }
 
   @Test
   void testCloneInAttachment() {
-    Attachment dummyAttachment =
+    AttachmentImpl dummyAttachment =
         CreateTaskModelHelper.createAttachment("dummyAttachmentId", "dummyTaskId");
 
     Map<String, String> dummyMapPreClone = new HashMap<>();
     dummyMapPreClone.put("dummyString1", "dummyString2");
     dummyAttachment.setCustomAttributes(dummyMapPreClone);
 
-    Attachment dummyAttachmentCloned = dummyAttachment.copy();
+    AttachmentImpl dummyAttachmentCloned = dummyAttachment.copy();
+    assertThat(dummyAttachmentCloned).isNotEqualTo(dummyAttachment);
+    dummyAttachmentCloned.setId(dummyAttachment.getId());
     assertThat(dummyAttachmentCloned).isEqualTo(dummyAttachment);
     assertThat(dummyAttachmentCloned).isNotSameAs(dummyAttachment);
 

--- a/lib/taskana-core/src/test/java/pro/taskana/task/api/models/TaskModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/api/models/TaskModelsCloneTest.java
@@ -1,13 +1,17 @@
 package pro.taskana.task.api.models;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static pro.taskana.task.internal.CreateTaskModelHelper.createAttachment;
+import static pro.taskana.task.internal.CreateTaskModelHelper.createDummyClassification;
+import static pro.taskana.task.internal.CreateTaskModelHelper.createUnitTestTask;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-import pro.taskana.task.internal.CreateTaskModelHelper;
 import pro.taskana.task.internal.models.AttachmentImpl;
 import pro.taskana.task.internal.models.AttachmentSummaryImpl;
 import pro.taskana.task.internal.models.TaskCommentImpl;
@@ -20,8 +24,9 @@ class TaskModelsCloneTest {
   void testCloneInTaskSummary() {
     TaskSummaryImpl dummyTaskSummary = new TaskSummaryImpl();
     dummyTaskSummary.setId("dummyId");
+    dummyTaskSummary.setExternalId("externalId");
     Attachment dummyAttachmentForSummaryTestPreClone =
-        CreateTaskModelHelper.createAttachment("uniqueIdForDeepTest", "uniqueTaskIdForDeepTest");
+        createAttachment("uniqueIdForDeepTest", "uniqueTaskIdForDeepTest");
     AttachmentSummary dummyAttachmentSummary = dummyAttachmentForSummaryTestPreClone.asSummary();
     ArrayList<AttachmentSummary> attachmentSummaries = new ArrayList<>();
     attachmentSummaries.add(dummyAttachmentSummary);
@@ -30,12 +35,12 @@ class TaskModelsCloneTest {
     TaskSummaryImpl dummyTaskSummaryCloned = dummyTaskSummary.copy();
     assertThat(dummyTaskSummaryCloned).isNotEqualTo(dummyTaskSummary);
     dummyTaskSummaryCloned.setId(dummyTaskSummary.getId());
+    dummyTaskSummaryCloned.setExternalId(dummyTaskSummary.getExternalId());
     assertThat(dummyTaskSummaryCloned).isEqualTo(dummyTaskSummary);
     assertThat(dummyTaskSummaryCloned).isNotSameAs(dummyTaskSummary);
 
     Attachment dummyAttachmentForSummaryTestPostClone =
-        CreateTaskModelHelper.createAttachment(
-            "differentIdForDeepTest", "differentTaskIdForDeepTest");
+        createAttachment("differentIdForDeepTest", "differentTaskIdForDeepTest");
     AttachmentSummary dummyAttachmentSummary2 = dummyAttachmentForSummaryTestPostClone.asSummary();
     attachmentSummaries.add(dummyAttachmentSummary2);
     assertThat(dummyTaskSummaryCloned).isNotEqualTo(dummyTaskSummary);
@@ -44,11 +49,8 @@ class TaskModelsCloneTest {
   @Test
   void testCloneInTask() {
     TaskImpl dummyTask =
-        CreateTaskModelHelper.createUnitTestTask(
-            "dummyTaskId",
-            "dummyTaskName",
-            "workbasketKey",
-            CreateTaskModelHelper.createDummyClassification());
+        createUnitTestTask(
+            "dummyTaskId", "dummyTaskName", "workbasketKey", createDummyClassification());
     Map<String, String> dummyCustomAttributesPreClone = new HashMap<>();
     dummyCustomAttributesPreClone.put("dummyAttributeKey", "dummyAttributeValue");
     dummyTask.setCustomAttributes(dummyCustomAttributesPreClone);
@@ -59,16 +61,54 @@ class TaskModelsCloneTest {
     TaskImpl dummyTaskCloned = dummyTask.copy();
     assertThat(dummyTaskCloned).isNotEqualTo(dummyTask);
     dummyTaskCloned.setId(dummyTask.getId());
+    dummyTaskCloned.setExternalId(dummyTask.getExternalId());
     assertThat(dummyTaskCloned).isEqualTo(dummyTask);
     assertThat(dummyTaskCloned).isNotSameAs(dummyTask);
 
     dummyCustomAttributesPreClone.put("deepTestAttributeKey", "deepTestAttributeValue");
     dummyCallbackInfoPreClone.put("deepTestCallbackKey", "deepTestCallbackValue");
-    assertThat(dummyTaskCloned).isNotEqualTo(dummyTask);
+    assertThat(dummyTaskCloned).isNotSameAs(dummyTask);
   }
 
   @Test
-  void testCloneInTaskComment() {
+  void should_PerformDeepCopyOfAttachments_When_TaskClone() {
+    TaskImpl dummyTask =
+        createUnitTestTask(
+            "dummyTaskId", "dummyTaskName", "dummyWorkbasketKey", createDummyClassification());
+    List<Attachment> attachments =
+        new ArrayList<>(
+            Arrays.asList(
+                createAttachment("abc", "dummyTaskId"), createAttachment("def", "dummyTaskId")));
+    dummyTask.setAttachments(attachments);
+
+    TaskImpl dummyTaskCloned = dummyTask.copy();
+
+    assertThat(dummyTask.getAttachments()).isNotSameAs(dummyTaskCloned.getAttachments());
+  }
+
+  @Test
+  void should_RemoveAttachmentAndTaskIds_When_TaskClone() {
+    TaskImpl dummyTask =
+        createUnitTestTask(
+            "dummyTaskId", "dummyTaskName", "workbasketKey", createDummyClassification());
+    List<Attachment> attachments =
+        new ArrayList<>(
+            Arrays.asList(
+                createAttachment("abc", "dummyTaskId"), createAttachment("def", "dummyTaskId")));
+    dummyTask.setAttachments(attachments);
+
+    TaskImpl dummyTaskCloned = dummyTask.copy();
+
+    assertThat(dummyTaskCloned.getAttachments())
+        .extracting(AttachmentSummary::getId)
+        .containsOnly((String) null);
+    assertThat(dummyTaskCloned.getAttachments())
+        .extracting(AttachmentSummary::getTaskId)
+        .containsOnly((String) null);
+  }
+
+  @Test
+  void should_CopyWithoutId_When_TaskCommentClone() {
     TaskCommentImpl dummyComment = new TaskCommentImpl();
     dummyComment.setTextField("dummyTextField");
     dummyComment.setId("dummyId");
@@ -80,7 +120,7 @@ class TaskModelsCloneTest {
   }
 
   @Test
-  void testCloneInObjectReference() {
+  void should_CopyWithoutId_When_ObjectReferenceClone() {
     ObjectReference dummyReference = new ObjectReference();
     dummyReference.setId("dummyId");
     dummyReference.setSystem("dummySystem");
@@ -88,7 +128,9 @@ class TaskModelsCloneTest {
     dummyReference.setSystemInstance("dummySystemInstance");
     dummyReference.setType("dummyType");
     dummyReference.setValue("dummyValue");
+
     ObjectReference dummyReferenceCloned = dummyReference.copy();
+
     assertThat(dummyReferenceCloned).isNotEqualTo(dummyReference);
     dummyReferenceCloned.setId(dummyReference.getId());
     assertThat(dummyReferenceCloned).isEqualTo(dummyReference);
@@ -96,22 +138,23 @@ class TaskModelsCloneTest {
   }
 
   @Test
-  void testCloneInAttachmentSummary() {
-    Attachment dummyAttachmentForSummaryTest =
-        CreateTaskModelHelper.createAttachment("dummyAttachmentId", "dummyTaskId");
+  void should_CopyWithoutIdAndTaskId_When_AttachmentSummaryClone() {
+    Attachment dummyAttachmentForSummaryTest = createAttachment("dummyAttachmentId", "dummyTaskId");
     AttachmentSummaryImpl dummyAttachmentSummary =
         (AttachmentSummaryImpl) dummyAttachmentForSummaryTest.asSummary();
+
     AttachmentSummaryImpl dummyAttachmentSummaryCloned = dummyAttachmentSummary.copy();
     assertThat(dummyAttachmentSummaryCloned).isNotEqualTo(dummyAttachmentSummary);
+
     dummyAttachmentSummaryCloned.setId(dummyAttachmentSummary.getId());
+    dummyAttachmentSummaryCloned.setTaskId(dummyAttachmentSummary.getTaskId());
     assertThat(dummyAttachmentSummaryCloned).isEqualTo(dummyAttachmentSummary);
     assertThat(dummyAttachmentSummaryCloned).isNotSameAs(dummyAttachmentSummary);
   }
 
   @Test
-  void testCloneInAttachment() {
-    AttachmentImpl dummyAttachment =
-        CreateTaskModelHelper.createAttachment("dummyAttachmentId", "dummyTaskId");
+  void should_CopyWithoutIdAndTaskId_When_AttachmentClone() {
+    AttachmentImpl dummyAttachment = createAttachment("dummyAttachmentId", "dummyTaskId");
 
     Map<String, String> dummyMapPreClone = new HashMap<>();
     dummyMapPreClone.put("dummyString1", "dummyString2");
@@ -120,6 +163,7 @@ class TaskModelsCloneTest {
     AttachmentImpl dummyAttachmentCloned = dummyAttachment.copy();
     assertThat(dummyAttachmentCloned).isNotEqualTo(dummyAttachment);
     dummyAttachmentCloned.setId(dummyAttachment.getId());
+    dummyAttachmentCloned.setTaskId(dummyAttachment.getTaskId());
     assertThat(dummyAttachmentCloned).isEqualTo(dummyAttachment);
     assertThat(dummyAttachmentCloned).isNotSameAs(dummyAttachment);
 

--- a/lib/taskana-core/src/test/java/pro/taskana/task/api/models/TaskModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/api/models/TaskModelsCloneTest.java
@@ -1,0 +1,112 @@
+package pro.taskana.task.api.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+import pro.taskana.task.internal.CreateTaskModelHelper;
+import pro.taskana.task.internal.models.TaskCommentImpl;
+import pro.taskana.task.internal.models.TaskSummaryImpl;
+
+class TaskModelsCloneTest {
+
+  @Test
+  void testCloneInTaskSummary() {
+    TaskSummaryImpl dummyTaskSummary = new TaskSummaryImpl();
+
+    Attachment dummyAttachmentForSummaryTestPreClone =
+        CreateTaskModelHelper.createAttachment("uniqueIdForDeepTest", "uniqueTaskIdForDeepTest");
+    AttachmentSummary dummyAttachmentSummary = dummyAttachmentForSummaryTestPreClone.asSummary();
+    ArrayList<AttachmentSummary> attachmentSummaries = new ArrayList<>();
+    attachmentSummaries.add(dummyAttachmentSummary);
+    dummyTaskSummary.setAttachmentSummaries(attachmentSummaries);
+
+    TaskSummary dummyTaskSummaryCloned = dummyTaskSummary.copy();
+    assertThat(dummyTaskSummaryCloned).isEqualTo(dummyTaskSummary);
+    assertThat(dummyTaskSummaryCloned).isNotSameAs(dummyTaskSummary);
+
+    Attachment dummyAttachmentForSummaryTestPostClone =
+        CreateTaskModelHelper.createAttachment(
+            "differentIdForDeepTest", "differentTaskIdForDeepTest");
+    AttachmentSummary dummyAttachmentSummary2 = dummyAttachmentForSummaryTestPostClone.asSummary();
+    attachmentSummaries.add(dummyAttachmentSummary2);
+    assertThat(dummyTaskSummaryCloned).isNotEqualTo(dummyTaskSummary);
+  }
+
+  @Test
+  void testCloneInTask() {
+    Task dummyTask =
+        CreateTaskModelHelper.createUnitTestTask(
+            "dummyTaskId",
+            "dummyTaskName",
+            "workbasketKey",
+            CreateTaskModelHelper.createDummyClassification());
+    Map<String, String> dummyCustomAttributesPreClone = new HashMap<>();
+    dummyCustomAttributesPreClone.put("dummyAttributeKey", "dummyAttributeValue");
+    dummyTask.setCustomAttributes(dummyCustomAttributesPreClone);
+    Map<String, String> dummyCallbackInfoPreClone = new HashMap<>();
+    dummyCallbackInfoPreClone.put("dummyCallbackKey", "dummyCallbackValue");
+    dummyTask.setCallbackInfo(dummyCallbackInfoPreClone);
+
+    Task dummyTaskCloned = dummyTask.copy();
+    assertThat(dummyTaskCloned).isEqualTo(dummyTask);
+    assertThat(dummyTaskCloned).isNotSameAs(dummyTask);
+
+    dummyCustomAttributesPreClone.put("deepTestAttributeKey", "deepTestAttributeValue");
+    dummyCallbackInfoPreClone.put("deepTestCallbackKey", "deepTestCallbackValue");
+    assertThat(dummyTaskCloned).isNotEqualTo(dummyTask);
+  }
+
+  @Test
+  void testCloneInTaskComment() {
+    TaskCommentImpl dummyComment = new TaskCommentImpl();
+    dummyComment.setTextField("dummyTextField");
+    TaskComment dummyCommentCloned = dummyComment.copy();
+    assertThat(dummyCommentCloned).isEqualTo(dummyComment);
+    assertThat(dummyCommentCloned).isNotSameAs(dummyComment);
+  }
+
+  @Test
+  void testCloneInObjectReference() {
+    ObjectReference dummyReference = new ObjectReference();
+    dummyReference.setId("dummyId");
+    dummyReference.setSystem("dummySystem");
+    dummyReference.setCompany("dummyCompany");
+    dummyReference.setSystemInstance("dummySystemInstance");
+    dummyReference.setType("dummyType");
+    dummyReference.setValue("dummyValue");
+    ObjectReference dummyReferenceCloned = dummyReference.copy();
+    assertThat(dummyReferenceCloned).isEqualTo(dummyReference);
+    assertThat(dummyReferenceCloned).isNotSameAs(dummyReference);
+  }
+
+  @Test
+  void testCloneInAttachmentSummary() {
+    Attachment dummyAttachmentForSummaryTest =
+        CreateTaskModelHelper.createAttachment("dummyAttachmentId", "dummyTaskId");
+    AttachmentSummary dummyAttachmentSummary = dummyAttachmentForSummaryTest.asSummary();
+    AttachmentSummary dummyAttachmentSummaryCloned = dummyAttachmentSummary.copy();
+    assertThat(dummyAttachmentSummaryCloned).isEqualTo(dummyAttachmentSummary);
+    assertThat(dummyAttachmentSummaryCloned).isNotSameAs(dummyAttachmentSummary);
+  }
+
+  @Test
+  void testCloneInAttachment() {
+    Attachment dummyAttachment =
+        CreateTaskModelHelper.createAttachment("dummyAttachmentId", "dummyTaskId");
+
+    Map<String, String> dummyMapPreClone = new HashMap<>();
+    dummyMapPreClone.put("dummyString1", "dummyString2");
+    dummyAttachment.setCustomAttributes(dummyMapPreClone);
+
+    Attachment dummyAttachmentCloned = dummyAttachment.copy();
+    assertThat(dummyAttachmentCloned).isEqualTo(dummyAttachment);
+    assertThat(dummyAttachmentCloned).isNotSameAs(dummyAttachment);
+
+    dummyMapPreClone.put("deepTestString1", "deepTestString2");
+    assertThat(dummyAttachment).isNotEqualTo(dummyAttachmentCloned);
+  }
+}

--- a/lib/taskana-core/src/test/java/pro/taskana/task/internal/CreateTaskModelHelper.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/internal/CreateTaskModelHelper.java
@@ -1,0 +1,61 @@
+package pro.taskana.task.internal;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+
+import pro.taskana.classification.api.models.Classification;
+import pro.taskana.classification.internal.models.ClassificationImpl;
+import pro.taskana.task.api.models.Attachment;
+import pro.taskana.task.internal.models.AttachmentImpl;
+import pro.taskana.task.internal.models.TaskImpl;
+import pro.taskana.workbasket.internal.models.WorkbasketImpl;
+
+public class CreateTaskModelHelper {
+
+  public static TaskImpl createUnitTestTask(
+      String id, String name, String workbasketKey, Classification classification) {
+    TaskImpl task = new TaskImpl();
+    task.setId(id);
+    task.setExternalId(id);
+    task.setName(name);
+    task.setWorkbasketKey(workbasketKey);
+    task.setDomain("");
+    task.setAttachments(new ArrayList<>());
+    Instant now = Instant.now().minus(Duration.ofMinutes(1L));
+    task.setCreated(now);
+    task.setModified(now);
+    if (classification == null) {
+      classification = createDummyClassification();
+    }
+    task.setClassificationSummary(classification.asSummary());
+    task.setClassificationKey(classification.getKey());
+    task.setDomain(classification.getDomain());
+    return task;
+  }
+
+  public static Classification createDummyClassification() {
+    ClassificationImpl classification = new ClassificationImpl();
+    classification.setName("dummy-classification");
+    classification.setDomain("dummy-domain");
+    classification.setKey("dummy-classification-key");
+    classification.setId("DummyClassificationId");
+    return classification;
+  }
+
+  public static WorkbasketImpl createWorkbasket(String id, String key) {
+    WorkbasketImpl workbasket = new WorkbasketImpl();
+    workbasket.setId(id);
+    workbasket.setDomain("Domain1");
+    workbasket.setKey(key);
+    workbasket.setName("Workbasket " + id);
+    return workbasket;
+  }
+
+  public static Attachment createAttachment(String id, String taskId) {
+    AttachmentImpl attachment = new AttachmentImpl();
+    attachment.setId(id);
+    attachment.setTaskId(taskId);
+    return attachment;
+  }
+}

--- a/lib/taskana-core/src/test/java/pro/taskana/task/internal/CreateTaskModelHelper.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/internal/CreateTaskModelHelper.java
@@ -6,33 +6,12 @@ import java.util.ArrayList;
 
 import pro.taskana.classification.api.models.Classification;
 import pro.taskana.classification.internal.models.ClassificationImpl;
-import pro.taskana.task.api.models.Attachment;
+import pro.taskana.task.api.TaskState;
 import pro.taskana.task.internal.models.AttachmentImpl;
 import pro.taskana.task.internal.models.TaskImpl;
 import pro.taskana.workbasket.internal.models.WorkbasketImpl;
 
 public class CreateTaskModelHelper {
-
-  public static TaskImpl createUnitTestTask(
-      String id, String name, String workbasketKey, Classification classification) {
-    TaskImpl task = new TaskImpl();
-    task.setId(id);
-    task.setExternalId(id);
-    task.setName(name);
-    task.setWorkbasketKey(workbasketKey);
-    task.setDomain("");
-    task.setAttachments(new ArrayList<>());
-    Instant now = Instant.now().minus(Duration.ofMinutes(1L));
-    task.setCreated(now);
-    task.setModified(now);
-    if (classification == null) {
-      classification = createDummyClassification();
-    }
-    task.setClassificationSummary(classification.asSummary());
-    task.setClassificationKey(classification.getKey());
-    task.setDomain(classification.getDomain());
-    return task;
-  }
 
   public static Classification createDummyClassification() {
     ClassificationImpl classification = new ClassificationImpl();
@@ -52,10 +31,32 @@ public class CreateTaskModelHelper {
     return workbasket;
   }
 
-  public static Attachment createAttachment(String id, String taskId) {
+  public static AttachmentImpl createAttachment(String id, String taskId) {
     AttachmentImpl attachment = new AttachmentImpl();
     attachment.setId(id);
     attachment.setTaskId(taskId);
     return attachment;
+  }
+
+  public static TaskImpl createUnitTestTask(
+      String id, String name, String workbasketKey, Classification classification) {
+    TaskImpl task = new TaskImpl();
+    task.setId(id);
+    task.setExternalId(id);
+    task.setName(name);
+    task.setWorkbasketKey(workbasketKey);
+    task.setDomain("");
+    task.setAttachments(new ArrayList<>());
+    Instant now = Instant.now().minus(Duration.ofMinutes(1L));
+    task.setCreated(now);
+    task.setModified(now);
+    task.setState(TaskState.READY);
+    if (classification == null) {
+      classification = createDummyClassification();
+    }
+    task.setClassificationSummary(classification.asSummary());
+    task.setClassificationKey(classification.getKey());
+    task.setDomain(classification.getDomain());
+    return task;
   }
 }

--- a/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskAttachmentTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskAttachmentTest.java
@@ -9,15 +9,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 import pro.taskana.classification.internal.models.ClassificationImpl;
 import pro.taskana.task.api.models.Attachment;
 import pro.taskana.task.api.models.AttachmentSummary;
 import pro.taskana.task.api.models.ObjectReference;
-import pro.taskana.task.internal.models.AttachmentImpl;
 import pro.taskana.task.internal.models.TaskImpl;
 
 /**
@@ -25,16 +21,15 @@ import pro.taskana.task.internal.models.TaskImpl;
  * This test should test every interaction with Attachments, which means adding, removing, nulling
  * them.
  */
-@ExtendWith(MockitoExtension.class)
 class TaskAttachmentTest {
 
-  @InjectMocks private TaskImpl cut;
+  private TaskImpl cut = new TaskImpl();
 
   @Test
   void testAddAttachmentWithValidValue() {
-    Attachment attachment1 = createAttachment("ID1", "taskId1");
-    Attachment attachment2 = createAttachment("ID2", "taskId1");
-    Attachment attachment3 = createAttachment("ID3", "taskId1");
+    Attachment attachment1 = CreateTaskModelHelper.createAttachment("ID1", "taskId1");
+    Attachment attachment2 = CreateTaskModelHelper.createAttachment("ID2", "taskId1");
+    Attachment attachment3 = CreateTaskModelHelper.createAttachment("ID3", "taskId1");
 
     cut.addAttachment(attachment1);
     cut.addAttachment(attachment2);
@@ -45,7 +40,7 @@ class TaskAttachmentTest {
 
   @Test
   void testAddNullValue() {
-    Attachment attachment1 = createAttachment("ID1", "taskId1");
+    Attachment attachment1 = CreateTaskModelHelper.createAttachment("ID1", "taskId1");
 
     cut.addAttachment(attachment1);
     cut.addAttachment(null);
@@ -56,8 +51,8 @@ class TaskAttachmentTest {
   @Test
   void testAddSameTwice() {
     // Same values, not same REF. Important.
-    Attachment attachment1 = createAttachment("ID1", "taskId1");
-    Attachment attachment2 = createAttachment("ID1", "taskId1");
+    Attachment attachment1 = CreateTaskModelHelper.createAttachment("ID1", "taskId1");
+    Attachment attachment2 = CreateTaskModelHelper.createAttachment("ID1", "taskId1");
 
     cut.addAttachment(attachment1);
     cut.addAttachment(attachment2);
@@ -75,8 +70,8 @@ class TaskAttachmentTest {
   @Test
   void testRemoveAttachment() {
     // Testing normal way
-    Attachment attachment1 = createAttachment("ID1", "taskId1");
-    Attachment attachment2 = createAttachment("ID2", "taskId1");
+    Attachment attachment1 = CreateTaskModelHelper.createAttachment("ID1", "taskId1");
+    Attachment attachment2 = CreateTaskModelHelper.createAttachment("ID2", "taskId1");
     cut.addAttachment(attachment1);
     cut.addAttachment(attachment2);
 
@@ -88,7 +83,7 @@ class TaskAttachmentTest {
 
   @Test
   void testRemoveLoopStopsAtResult() {
-    Attachment attachment1 = createAttachment("ID2", "taskId1");
+    Attachment attachment1 = CreateTaskModelHelper.createAttachment("ID2", "taskId1");
     // adding same uncommon way to test that the loop will stop.
     cut.getAttachments().add(attachment1);
     cut.getAttachments().add(attachment1);
@@ -110,7 +105,7 @@ class TaskAttachmentTest {
     Map<String, String> customAttr = new HashMap<>();
     customAttr.put("key", "value");
 
-    Attachment attachment1 = createAttachment("ID1", "taskId1");
+    Attachment attachment1 = CreateTaskModelHelper.createAttachment("ID1", "taskId1");
     attachment1.setChannel("channel");
     attachment1.setClassificationSummary(new ClassificationImpl().asSummary());
     attachment1.setReceived(Instant.now());
@@ -142,12 +137,5 @@ class TaskAttachmentTest {
     assertThat(summaries.size(), equalTo(1));
     summaries = cut.asSummary().getAttachmentSummaries();
     assertThat(summaries.size(), equalTo(0));
-  }
-
-  private Attachment createAttachment(String id, String taskId) {
-    AttachmentImpl attachment = new AttachmentImpl();
-    attachment.setId(id);
-    attachment.setTaskId(taskId);
-    return attachment;
   }
 }

--- a/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskServiceImplTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskServiceImplTest.java
@@ -3,20 +3,15 @@ package pro.taskana.task.internal;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
-import java.time.Duration;
-import java.time.Instant;
-import java.util.ArrayList;
 import org.junit.jupiter.api.Test;
 
 import pro.taskana.classification.api.models.Classification;
-import pro.taskana.classification.internal.models.ClassificationImpl;
 import pro.taskana.common.internal.JunitHelper;
 import pro.taskana.task.api.TaskState;
 import pro.taskana.task.api.models.ObjectReference;
 import pro.taskana.task.api.models.TaskSummary;
 import pro.taskana.task.internal.models.TaskImpl;
 import pro.taskana.workbasket.api.models.Workbasket;
-import pro.taskana.workbasket.internal.models.WorkbasketImpl;
 
 /**
  * Unit Test for TaskServiceImpl.
@@ -27,13 +22,15 @@ class TaskServiceImplTest {
 
   @Test
   void testTaskSummaryEqualsHashCode() throws InterruptedException {
-    Classification classification = createDummyClassification();
-    Workbasket wb = createWorkbasket("WB-ID", "WB-Key");
+    Classification classification = CreateTaskModelHelper.createDummyClassification();
+    Workbasket wb = CreateTaskModelHelper.createWorkbasket("WB-ID", "WB-Key");
     ObjectReference objectReference = JunitHelper.createDefaultObjRef();
-    TaskImpl taskBefore = createUnitTestTask("ID", "taskName", wb.getKey(), classification);
+    TaskImpl taskBefore =
+        CreateTaskModelHelper.createUnitTestTask("ID", "taskName", wb.getKey(), classification);
     taskBefore.setPrimaryObjRef(objectReference);
     Thread.sleep(10);
-    TaskImpl taskAfter = createUnitTestTask("ID", "taskName", wb.getKey(), classification);
+    TaskImpl taskAfter =
+        CreateTaskModelHelper.createUnitTestTask("ID", "taskName", wb.getKey(), classification);
     taskAfter.setPrimaryObjRef(objectReference);
     TaskSummary summaryBefore = taskBefore.asSummary();
     TaskSummary summaryAfter = taskAfter.asSummary();
@@ -57,7 +54,7 @@ class TaskServiceImplTest {
     assertEquals(summaryBefore, summaryAfter);
     assertEquals(summaryBefore.hashCode(), summaryAfter.hashCode());
   }
-
+  
   static TaskImpl createUnitTestTask(
       String id, String name, String workbasketKey, Classification classification) {
     TaskImpl task = new TaskImpl();
@@ -97,4 +94,5 @@ class TaskServiceImplTest {
     workbasket.setName("Workbasket " + id);
     return workbasket;
   }
+  
 }

--- a/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskServiceImplTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskServiceImplTest.java
@@ -6,12 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.junit.jupiter.api.Test;
 
 import pro.taskana.classification.api.models.Classification;
+import pro.taskana.classification.internal.models.ClassificationImpl;
 import pro.taskana.common.internal.JunitHelper;
-import pro.taskana.task.api.TaskState;
 import pro.taskana.task.api.models.ObjectReference;
 import pro.taskana.task.api.models.TaskSummary;
 import pro.taskana.task.internal.models.TaskImpl;
 import pro.taskana.workbasket.api.models.Workbasket;
+import pro.taskana.workbasket.internal.models.WorkbasketImpl;
 
 /**
  * Unit Test for TaskServiceImpl.
@@ -54,28 +55,6 @@ class TaskServiceImplTest {
     assertEquals(summaryBefore, summaryAfter);
     assertEquals(summaryBefore.hashCode(), summaryAfter.hashCode());
   }
-  
-  static TaskImpl createUnitTestTask(
-      String id, String name, String workbasketKey, Classification classification) {
-    TaskImpl task = new TaskImpl();
-    task.setId(id);
-    task.setExternalId(id);
-    task.setName(name);
-    task.setWorkbasketKey(workbasketKey);
-    task.setDomain("");
-    task.setAttachments(new ArrayList<>());
-    Instant now = Instant.now().minus(Duration.ofMinutes(1L));
-    task.setCreated(now);
-    task.setModified(now);
-    task.setState(TaskState.READY);
-    if (classification == null) {
-      classification = createDummyClassification();
-    }
-    task.setClassificationSummary(classification.asSummary());
-    task.setClassificationKey(classification.getKey());
-    task.setDomain(classification.getDomain());
-    return task;
-  }
 
   static Classification createDummyClassification() {
     ClassificationImpl classification = new ClassificationImpl();
@@ -94,5 +73,4 @@ class TaskServiceImplTest {
     workbasket.setName("Workbasket " + id);
     return workbasket;
   }
-  
 }

--- a/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskTransferrerTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskTransferrerTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
 
 import org.apache.ibatis.session.SqlSession;
 import org.junit.jupiter.api.Test;
@@ -68,9 +67,8 @@ class TaskTransferrerTest {
   void testTransferTaskToDestinationWorkbasketWithoutSecurity()
       throws TaskNotFoundException, WorkbasketNotFoundException, NotAuthorizedException,
           InvalidStateException {
-
-    when(internalTaskanaEngineMock.getEngine()).thenReturn(taskanaEngineMock);
-    when(taskanaEngineMock.getWorkbasketService()).thenReturn(workbasketServiceMock);
+    doReturn(taskanaEngineMock).when(internalTaskanaEngineMock).getEngine();
+    doReturn(workbasketServiceMock).when(taskanaEngineMock).getWorkbasketService();
     cut = new TaskTransferrer(internalTaskanaEngineMock, taskMapperMock, taskServiceImplMock);
 
     final TaskTransferrer cutSpy = Mockito.spy(cut);
@@ -78,12 +76,13 @@ class TaskTransferrerTest {
     Workbasket sourceWorkbasket = CreateTaskModelHelper.createWorkbasket("47", "key47");
     Classification dummyClassification = CreateTaskModelHelper.createDummyClassification();
     TaskImpl task =
-        CreateTaskModelHelper
-            .createUnitTestTask("1", "Unit Test Task 1", "key47", dummyClassification);
+        CreateTaskModelHelper.createUnitTestTask(
+            "1", "Unit Test Task 1", "key47", dummyClassification);
     task.setWorkbasketSummary(sourceWorkbasket.asSummary());
     task.setRead(true);
-    when(workbasketServiceMock.getWorkbasket(destinationWorkbasket.getId()))
-        .thenReturn(destinationWorkbasket);
+    doReturn(destinationWorkbasket)
+        .when(workbasketServiceMock)
+        .getWorkbasket(destinationWorkbasket.getId());
     doReturn(task).when(taskServiceImplMock).getTask(task.getId());
 
     final Task actualTask = cutSpy.transfer(task.getId(), destinationWorkbasket.getId());

--- a/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskTransferrerTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/task/internal/TaskTransferrerTest.java
@@ -74,12 +74,12 @@ class TaskTransferrerTest {
     cut = new TaskTransferrer(internalTaskanaEngineMock, taskMapperMock, taskServiceImplMock);
 
     final TaskTransferrer cutSpy = Mockito.spy(cut);
-    Workbasket destinationWorkbasket = TaskServiceImplTest.createWorkbasket("2", "k1");
-    Workbasket sourceWorkbasket = TaskServiceImplTest.createWorkbasket("47", "key47");
-    Classification dummyClassification = TaskServiceImplTest.createDummyClassification();
+    Workbasket destinationWorkbasket = CreateTaskModelHelper.createWorkbasket("2", "k1");
+    Workbasket sourceWorkbasket = CreateTaskModelHelper.createWorkbasket("47", "key47");
+    Classification dummyClassification = CreateTaskModelHelper.createDummyClassification();
     TaskImpl task =
-        TaskServiceImplTest.createUnitTestTask(
-            "1", "Unit Test Task 1", "key47", dummyClassification);
+        CreateTaskModelHelper
+            .createUnitTestTask("1", "Unit Test Task 1", "key47", dummyClassification);
     task.setWorkbasketSummary(sourceWorkbasket.asSummary());
     task.setRead(true);
     when(workbasketServiceMock.getWorkbasket(destinationWorkbasket.getId()))

--- a/lib/taskana-core/src/test/java/pro/taskana/workbasket/api/models/WorkbasketModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/workbasket/api/models/WorkbasketModelsCloneTest.java
@@ -11,7 +11,7 @@ import pro.taskana.workbasket.internal.models.WorkbasketSummaryImpl;
 class WorkbasketModelsCloneTest {
 
   @Test
-  void testCloneInWorkbasketSummary() {
+  void should_CopyWithoutId_When_WorkbasketSummaryClone() {
     Workbasket dummyWorkbasketForSummaryTest = new WorkbasketImpl();
     dummyWorkbasketForSummaryTest.setCustom1("dummyCustom1");
     dummyWorkbasketForSummaryTest.setCustom2("dummyCustom2");
@@ -28,7 +28,9 @@ class WorkbasketModelsCloneTest {
     WorkbasketSummaryImpl dummyWorkbasketSummary =
         (WorkbasketSummaryImpl) dummyWorkbasketForSummaryTest.asSummary();
     dummyWorkbasketSummary.setId("dummyId");
+
     WorkbasketSummaryImpl dummyWorkbasketSummaryCloned = dummyWorkbasketSummary.copy();
+
     assertThat(dummyWorkbasketSummaryCloned).isNotEqualTo(dummyWorkbasketSummary);
     dummyWorkbasketSummaryCloned.setId(dummyWorkbasketSummary.getId());
     assertThat(dummyWorkbasketSummaryCloned).isEqualTo(dummyWorkbasketSummary);
@@ -36,7 +38,7 @@ class WorkbasketModelsCloneTest {
   }
 
   @Test
-  void testCloneInWorkbasket() {
+  void should_CopyWithoutId_When_WorkbasketClone() {
     WorkbasketImpl dummyWorkbasket = new WorkbasketImpl();
     dummyWorkbasket.setId("dummyId");
     dummyWorkbasket.setCustom1("dummyCustom1");
@@ -51,7 +53,9 @@ class WorkbasketModelsCloneTest {
     dummyWorkbasket.setOrgLevel3("dummyOrgLevel3");
     dummyWorkbasket.setOrgLevel4("dummyOrgLevel4");
     dummyWorkbasket.setOwner("dummyOwner");
-    WorkbasketImpl dummyWorkbasketCloned = dummyWorkbasket.copy();
+
+    WorkbasketImpl dummyWorkbasketCloned = dummyWorkbasket.copy(dummyWorkbasket.getKey());
+
     assertThat(dummyWorkbasketCloned).isNotEqualTo(dummyWorkbasket);
     dummyWorkbasketCloned.setId(dummyWorkbasket.getId());
     assertThat(dummyWorkbasketCloned).isEqualTo(dummyWorkbasket);
@@ -59,7 +63,7 @@ class WorkbasketModelsCloneTest {
   }
 
   @Test
-  void testCloneInWorkbasketAccessItem() {
+  void should_CopyWithoutId_When_WorkbasketAccessItemClone() {
     WorkbasketAccessItemImpl dummyWorkbasketAccessItem = new WorkbasketAccessItemImpl();
     dummyWorkbasketAccessItem.setId("dummyId");
     dummyWorkbasketAccessItem.setAccessName("dummyAccessName");
@@ -80,7 +84,9 @@ class WorkbasketModelsCloneTest {
     dummyWorkbasketAccessItem.setPermOpen(false);
     dummyWorkbasketAccessItem.setPermRead(false);
     dummyWorkbasketAccessItem.setPermTransfer(false);
+
     WorkbasketAccessItemImpl dummyWorkbasketAccessItemCloned = dummyWorkbasketAccessItem.copy();
+
     assertThat(dummyWorkbasketAccessItemCloned).isNotEqualTo(dummyWorkbasketAccessItem);
     dummyWorkbasketAccessItemCloned.setId(dummyWorkbasketAccessItem.getId());
     assertThat(dummyWorkbasketAccessItemCloned).isEqualTo(dummyWorkbasketAccessItem);

--- a/lib/taskana-core/src/test/java/pro/taskana/workbasket/api/models/WorkbasketModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/workbasket/api/models/WorkbasketModelsCloneTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import pro.taskana.workbasket.internal.models.WorkbasketAccessItemImpl;
 import pro.taskana.workbasket.internal.models.WorkbasketImpl;
+import pro.taskana.workbasket.internal.models.WorkbasketSummaryImpl;
 
 class WorkbasketModelsCloneTest {
 
@@ -24,15 +25,20 @@ class WorkbasketModelsCloneTest {
     dummyWorkbasketForSummaryTest.setOrgLevel3("dummyOrgLevel3");
     dummyWorkbasketForSummaryTest.setOrgLevel4("dummyOrgLevel4");
     dummyWorkbasketForSummaryTest.setOwner("dummyOwner");
-    WorkbasketSummary dummyWorkbasketSummary = dummyWorkbasketForSummaryTest.asSummary();
-    WorkbasketSummary dummyWorkbasketSummaryCloned = dummyWorkbasketSummary.copy();
+    WorkbasketSummaryImpl dummyWorkbasketSummary =
+        (WorkbasketSummaryImpl) dummyWorkbasketForSummaryTest.asSummary();
+    dummyWorkbasketSummary.setId("dummyId");
+    WorkbasketSummaryImpl dummyWorkbasketSummaryCloned = dummyWorkbasketSummary.copy();
+    assertThat(dummyWorkbasketSummaryCloned).isNotEqualTo(dummyWorkbasketSummary);
+    dummyWorkbasketSummaryCloned.setId(dummyWorkbasketSummary.getId());
     assertThat(dummyWorkbasketSummaryCloned).isEqualTo(dummyWorkbasketSummary);
     assertThat(dummyWorkbasketSummaryCloned).isNotSameAs(dummyWorkbasketSummary);
   }
 
   @Test
   void testCloneInWorkbasket() {
-    Workbasket dummyWorkbasket = new WorkbasketImpl();
+    WorkbasketImpl dummyWorkbasket = new WorkbasketImpl();
+    dummyWorkbasket.setId("dummyId");
     dummyWorkbasket.setCustom1("dummyCustom1");
     dummyWorkbasket.setCustom2("dummyCustom2");
     dummyWorkbasket.setCustom3("dummyCustom3");
@@ -45,14 +51,17 @@ class WorkbasketModelsCloneTest {
     dummyWorkbasket.setOrgLevel3("dummyOrgLevel3");
     dummyWorkbasket.setOrgLevel4("dummyOrgLevel4");
     dummyWorkbasket.setOwner("dummyOwner");
-    Workbasket dummyWorkbasketCloned = dummyWorkbasket.copy();
+    WorkbasketImpl dummyWorkbasketCloned = dummyWorkbasket.copy();
+    assertThat(dummyWorkbasketCloned).isNotEqualTo(dummyWorkbasket);
+    dummyWorkbasketCloned.setId(dummyWorkbasket.getId());
     assertThat(dummyWorkbasketCloned).isEqualTo(dummyWorkbasket);
     assertThat(dummyWorkbasketCloned).isNotSameAs(dummyWorkbasket);
   }
 
   @Test
   void testCloneInWorkbasketAccessItem() {
-    WorkbasketAccessItem dummyWorkbasketAccessItem = new WorkbasketAccessItemImpl();
+    WorkbasketAccessItemImpl dummyWorkbasketAccessItem = new WorkbasketAccessItemImpl();
+    dummyWorkbasketAccessItem.setId("dummyId");
     dummyWorkbasketAccessItem.setAccessName("dummyAccessName");
     dummyWorkbasketAccessItem.setPermAppend(false);
     dummyWorkbasketAccessItem.setPermCustom1(false);
@@ -71,7 +80,9 @@ class WorkbasketModelsCloneTest {
     dummyWorkbasketAccessItem.setPermOpen(false);
     dummyWorkbasketAccessItem.setPermRead(false);
     dummyWorkbasketAccessItem.setPermTransfer(false);
-    WorkbasketAccessItem dummyWorkbasketAccessItemCloned = dummyWorkbasketAccessItem.copy();
+    WorkbasketAccessItemImpl dummyWorkbasketAccessItemCloned = dummyWorkbasketAccessItem.copy();
+    assertThat(dummyWorkbasketAccessItemCloned).isNotEqualTo(dummyWorkbasketAccessItem);
+    dummyWorkbasketAccessItemCloned.setId(dummyWorkbasketAccessItem.getId());
     assertThat(dummyWorkbasketAccessItemCloned).isEqualTo(dummyWorkbasketAccessItem);
     assertThat(dummyWorkbasketAccessItemCloned).isNotSameAs(dummyWorkbasketAccessItem);
   }

--- a/lib/taskana-core/src/test/java/pro/taskana/workbasket/api/models/WorkbasketModelsCloneTest.java
+++ b/lib/taskana-core/src/test/java/pro/taskana/workbasket/api/models/WorkbasketModelsCloneTest.java
@@ -1,0 +1,78 @@
+package pro.taskana.workbasket.api.models;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import pro.taskana.workbasket.internal.models.WorkbasketAccessItemImpl;
+import pro.taskana.workbasket.internal.models.WorkbasketImpl;
+
+class WorkbasketModelsCloneTest {
+
+  @Test
+  void testCloneInWorkbasketSummary() {
+    Workbasket dummyWorkbasketForSummaryTest = new WorkbasketImpl();
+    dummyWorkbasketForSummaryTest.setCustom1("dummyCustom1");
+    dummyWorkbasketForSummaryTest.setCustom2("dummyCustom2");
+    dummyWorkbasketForSummaryTest.setCustom3("dummyCustom3");
+    dummyWorkbasketForSummaryTest.setCustom4("dummyCustom4");
+    dummyWorkbasketForSummaryTest.setDescription("dummyDescription");
+    dummyWorkbasketForSummaryTest.setMarkedForDeletion(false);
+    dummyWorkbasketForSummaryTest.setName("dummyName");
+    dummyWorkbasketForSummaryTest.setOrgLevel1("dummyOrgLevel1");
+    dummyWorkbasketForSummaryTest.setOrgLevel2("dummyOrgLevel2");
+    dummyWorkbasketForSummaryTest.setOrgLevel3("dummyOrgLevel3");
+    dummyWorkbasketForSummaryTest.setOrgLevel4("dummyOrgLevel4");
+    dummyWorkbasketForSummaryTest.setOwner("dummyOwner");
+    WorkbasketSummary dummyWorkbasketSummary = dummyWorkbasketForSummaryTest.asSummary();
+    WorkbasketSummary dummyWorkbasketSummaryCloned = dummyWorkbasketSummary.copy();
+    assertThat(dummyWorkbasketSummaryCloned).isEqualTo(dummyWorkbasketSummary);
+    assertThat(dummyWorkbasketSummaryCloned).isNotSameAs(dummyWorkbasketSummary);
+  }
+
+  @Test
+  void testCloneInWorkbasket() {
+    Workbasket dummyWorkbasket = new WorkbasketImpl();
+    dummyWorkbasket.setCustom1("dummyCustom1");
+    dummyWorkbasket.setCustom2("dummyCustom2");
+    dummyWorkbasket.setCustom3("dummyCustom3");
+    dummyWorkbasket.setCustom4("dummyCustom4");
+    dummyWorkbasket.setDescription("dummyDescription");
+    dummyWorkbasket.setMarkedForDeletion(false);
+    dummyWorkbasket.setName("dummyName");
+    dummyWorkbasket.setOrgLevel1("dummyOrgLevel1");
+    dummyWorkbasket.setOrgLevel2("dummyOrgLevel2");
+    dummyWorkbasket.setOrgLevel3("dummyOrgLevel3");
+    dummyWorkbasket.setOrgLevel4("dummyOrgLevel4");
+    dummyWorkbasket.setOwner("dummyOwner");
+    Workbasket dummyWorkbasketCloned = dummyWorkbasket.copy();
+    assertThat(dummyWorkbasketCloned).isEqualTo(dummyWorkbasket);
+    assertThat(dummyWorkbasketCloned).isNotSameAs(dummyWorkbasket);
+  }
+
+  @Test
+  void testCloneInWorkbasketAccessItem() {
+    WorkbasketAccessItem dummyWorkbasketAccessItem = new WorkbasketAccessItemImpl();
+    dummyWorkbasketAccessItem.setAccessName("dummyAccessName");
+    dummyWorkbasketAccessItem.setPermAppend(false);
+    dummyWorkbasketAccessItem.setPermCustom1(false);
+    dummyWorkbasketAccessItem.setPermCustom2(false);
+    dummyWorkbasketAccessItem.setPermCustom3(false);
+    dummyWorkbasketAccessItem.setPermCustom4(false);
+    dummyWorkbasketAccessItem.setPermCustom5(false);
+    dummyWorkbasketAccessItem.setPermCustom6(false);
+    dummyWorkbasketAccessItem.setPermCustom7(false);
+    dummyWorkbasketAccessItem.setPermCustom8(false);
+    dummyWorkbasketAccessItem.setPermCustom9(false);
+    dummyWorkbasketAccessItem.setPermCustom10(false);
+    dummyWorkbasketAccessItem.setPermCustom11(false);
+    dummyWorkbasketAccessItem.setPermCustom12(false);
+    dummyWorkbasketAccessItem.setPermDistribute(false);
+    dummyWorkbasketAccessItem.setPermOpen(false);
+    dummyWorkbasketAccessItem.setPermRead(false);
+    dummyWorkbasketAccessItem.setPermTransfer(false);
+    WorkbasketAccessItem dummyWorkbasketAccessItemCloned = dummyWorkbasketAccessItem.copy();
+    assertThat(dummyWorkbasketAccessItemCloned).isEqualTo(dummyWorkbasketAccessItem);
+    assertThat(dummyWorkbasketAccessItemCloned).isNotSameAs(dummyWorkbasketAccessItem);
+  }
+}


### PR DESCRIPTION
Added a clone method to the interfaces and implementations of the models workbasket, task, classification and all their associated models.
Added 3 new testclasses, one for each package of connected models.
Each testclass serves as a unittest for the clone method of the implementation classes.
The constructors are filled with dummy data then cloned and compared. 
The first comparison compares the original object with its clone and asserts that they equal one another.
The second comparison asserts that the 2 objects are different by asserting that they do not share a reference.