### PR TITLE
TSK-1127 Changed input of Pagination to type number and removed arrows

### DIFF
--- a/web/src/app/shared/components/pagination/pagination.component.html
+++ b/web/src/app/shared/components/pagination/pagination.component.html
@@ -6,7 +6,7 @@
   <li *ngFor="let pageNumber of page?.totalPages | spreadNumber: page?.number: maxPagesAvailable">
     <a *ngIf="pageNumber + 1 !== page?.number" (click)="changeToPage(pageNumber+1)">{{pageNumber + 1}}</a>
     <a *ngIf="pageNumber + 1 === page?.number" class="pagination">
-      <input [(ngModel)]="pageSelected" (keyup.enter)="changeToPage(pageSelected)" type="text" (blur)="changeToPage(pageSelected)">
+      <input [(ngModel)]="pageSelected" (keyup.enter)="changeToPage(pageSelected)" type="number" (blur)="changeToPage(pageSelected)" >
     </a>
   </li>
   <li>

--- a/web/src/app/shared/components/pagination/pagination.component.scss
+++ b/web/src/app/shared/components/pagination/pagination.component.scss
@@ -34,3 +34,15 @@ ul.pagination{
     margin: 0px 5px 0 0;
     color: $blue;
 }
+
+
+// small "hack" to remove the arrows in the input fields of type numbers
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type='number'] {
+  -moz-appearance:textfield;
+}


### PR DESCRIPTION
After typing other values than numbers into the pagination "select page" function, the page reloads, the workbaskets are gone and the Error message "There was error, please contact with your administrator" with the content "BAD_REQUEST page must be a integer value." appears.

This issue has been fixed by adjusting the input type of the input and then removing of the arrows, because they covered most of the input