### PR TITLE
TSK-1069 The number picker now only accepts numbers and can be made required

### DIFF
--- a/web/src/app/administration/components/classification-details/classification-details.component.html
+++ b/web/src/app/administration/components/classification-details/classification-details.component.html
@@ -65,9 +65,12 @@
                 </a>
               </div>
               <div class="row">
-                <div class="form-group col-xs-6">
+                <div class="form-group required col-xs-6">
                   <label for="classification-priority" class="control-label">Priority</label>
-                  <taskana-number-picker [(ngModel)]="classification.priority" name="classification.priority" id="classification-priority"></taskana-number-picker>
+                  <taskana-number-picker [(ngModel)]="classification.priority" name="classification.priority" id="classification-priority" [required]="true"></taskana-number-picker>
+                  <taskana-field-error-display [displayError]="!isFieldValid('classification.priority')" [validationTrigger]="this.toogleValidationMap.get('classification.priority')"
+                                               errorMessage="* Priority is required">
+                  </taskana-field-error-display>
                 </div>
                 <div class="form-group required btn-group col-xs-6">
                   <label for="classification-category" class="control-label">Category</label>

--- a/web/src/app/shared/components/number-picker/number-picker.component.html
+++ b/web/src/app/shared/components/number-picker/number-picker.component.html
@@ -1,5 +1,5 @@
 <div class="input-group">
-  <input class="form-control input-text" name="number" [(ngModel)]="value">
+  <input class="form-control input-text" name="number" type="number" [(ngModel)]="value" [required]="required">
   <div class="input-group-btn-vertical">
     <button type="button" (click)="increase()" data-toggle="tooltip" title="increase value" class="btn btn-default">
       <span class="material-icons md-14 green-blue">arrow_drop_up</span>

--- a/web/src/app/shared/components/number-picker/number-picker.component.scss
+++ b/web/src/app/shared/components/number-picker/number-picker.component.scss
@@ -33,3 +33,14 @@ input{
   margin-top: -3px;
   border-bottom-right-radius: 4px;
 }
+
+// small "hack" to remove the arrows in the input fields of type numbers
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type='number'] {
+  -moz-appearance:textfield;
+}

--- a/web/src/app/shared/components/number-picker/number-picker.component.ts
+++ b/web/src/app/shared/components/number-picker/number-picker.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, forwardRef } from '@angular/core';
+import { Component, OnInit, forwardRef, Input } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({
@@ -14,6 +14,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
   ]
 })
 export class NumberPickerComponent implements OnInit, ControlValueAccessor {
+  @Input() required = false;
+
   // The internal data model
   private innerValue: any = 0;
 
@@ -21,6 +23,9 @@ export class NumberPickerComponent implements OnInit, ControlValueAccessor {
   // by the Control Value Accessor
   private onTouchedCallback: () => {};
   private onChangeCallback: (_: any) => {};
+
+  ngOnInit() {
+  }
 
   // get accessor
   get value(): any {
@@ -52,14 +57,17 @@ export class NumberPickerComponent implements OnInit, ControlValueAccessor {
     this.onTouchedCallback = fn;
   }
 
-  ngOnInit() {
-  }
-
   increase() {
+    if (!this.value) {
+      this.value = 0;
+    }
     this.value += 1;
   }
 
   decrease() {
+    if (!this.value) {
+      this.value = 0;
+    }
     this.value -= 1;
   }
 }

--- a/web/src/theme/_forms.scss
+++ b/web/src/theme/_forms.scss
@@ -1,4 +1,4 @@
-.ng-invalid:not(form)  {
+.ng-invalid.ng-touched:not(form)  {
     border-color: $invalid;
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
     box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);


### PR DESCRIPTION
Please use a priority of 0 as default instead of leaving that field empty. Was what the issue called for
My solution is different:
The buttons now work as expected: even when there is no value assigned the buttons initialize it and count up/down from 0. Additionally the input for the priority now only accepts numbers  and is required for every classification.