### PR TITLE
TSK-1205 Fixed problem with the callback of confirmation dialogs

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7017,11 +7017,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
-    "hammerjs": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
-      "integrity": "sha1-BO93hiz/K7edMPdpIJWTAiK/YPE="
-    },
     "handle-thing": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",

--- a/web/src/app/shared/components/popup/dialog-pop-up.component.html
+++ b/web/src/app/shared/components/popup/dialog-pop-up.component.html
@@ -10,7 +10,7 @@
   <button mat-dialog-close mat-stroked-button data-dismiss="modal" type="button">
     <span data-toggle="tooltip" class="material-icons md-20 red">cancel</span>
   </button>
-  <button *ngIf="isDialog" mat-dialog-close="callback" mat-raised-button color="primary"
+  <button *ngIf="isDialog" [mat-dialog-close]="callback" mat-raised-button color="primary"
           data-dismiss="modal" type="button">
     <span data-toggle="tooltip" class="material-icons md-20 white">done</span>
   </button>

--- a/web/src/app/shared/components/popup/dialog-pop-up.component.spec.ts
+++ b/web/src/app/shared/components/popup/dialog-pop-up.component.spec.ts
@@ -1,5 +1,8 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { MAT_DIALOG_DATA, MAT_DIALOG_SCROLL_STRATEGY, MatDialog } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA,
+  MAT_DIALOG_SCROLL_STRATEGY,
+  MatDialog,
+  MatDialogClose, MatDialogModule } from '@angular/material/dialog';
 
 import { DialogPopUpComponent } from './dialog-pop-up.component';
 
@@ -10,7 +13,8 @@ describe('PopupComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [DialogPopUpComponent],
-      providers: [MatDialog, { provide: MAT_DIALOG_SCROLL_STRATEGY }, { provide: MAT_DIALOG_DATA }]
+      providers: [{ provide: MAT_DIALOG_SCROLL_STRATEGY }, { provide: MAT_DIALOG_DATA }],
+      imports: [MatDialogModule]
     }).compileComponents();
   }));
 


### PR DESCRIPTION
The removal of classifications and workbaskets did not work, because the confirmation did not return the correct callback, but instead the string "callback".
This has been fixed now.