### PR TITLE
TSK-1039: Autofocus AccessID field after adding a new AccessID in Workbasket

### DIFF
--- a/web/src/app/administration/components/workbasket-access-items/workbasket-access-items.component.html
+++ b/web/src/app/administration/components/workbasket-access-items/workbasket-access-items.component.html
@@ -42,7 +42,7 @@
 							'has-warning': (accessItemsClone[index].accessId !== accessItem.value.accessId),
 							'has-error': !accessItem.value.accessId }">
 							<taskana-type-ahead formControlName="accessId" placeHolderMessage="* Access id is required" [validationValue]="toogleValidationAccessIdMap.get(index)"
-							 [displayError]="!isFieldValid('accessItem.value.accessId', index)" (selectedItem)="accessItemSelected($event, index)"></taskana-type-ahead>
+							 [displayError]="!isFieldValid('accessItem.value.accessId', index)" (selectedItem)="accessItemSelected($event, index)" (inputField)="focusNewInput($event)"></taskana-type-ahead>
 						</td>
 						<ng-template #accessIdInput>
 							<td class="input-group text-align text-width">
@@ -50,7 +50,7 @@
 							 !accessItem.value.accessId && formSubmitAttempt}">
 									<input type="text" class="form-control" formControlName="accessId" placeholder="{{accessItem.invalid?
 							 '* Access id is required': ''}}"
-									 [@validation]="toogleValidationAccessIdMap.get(index)">
+									 [@validation]="toogleValidationAccessIdMap.get(index)" #htmlInputElement>
 								</div>
 							</td>
 						</ng-template>

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.ts
@@ -1,4 +1,11 @@
-import { Component, OnInit, Input, ViewChild, forwardRef, Output, EventEmitter } from '@angular/core';
+import { Component,
+  OnInit,
+  Input,
+  ViewChild,
+  forwardRef,
+  Output,
+  EventEmitter,
+  OnChanges, ElementRef, AfterViewInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 
@@ -21,7 +28,7 @@ import { AccessIdDefinition } from 'app/shared/models/access-id';
     }
   ]
 })
-export class TypeAheadComponent implements OnInit, ControlValueAccessor {
+export class TypeAheadComponent implements AfterViewInit, ControlValueAccessor {
   dataSource: any;
   typing = false;
 
@@ -45,6 +52,9 @@ export class TypeAheadComponent implements OnInit, ControlValueAccessor {
 
   @Output()
   selectedItem = new EventEmitter<AccessIdDefinition>();
+
+  @Output()
+  inputField = new EventEmitter<ElementRef>();
 
   @ViewChild('inputTypeAhead', { static: false })
   private inputTypeAhead;
@@ -96,7 +106,8 @@ export class TypeAheadComponent implements OnInit, ControlValueAccessor {
   constructor(private accessIdsService: AccessIdsService) {
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
+    this.inputField.emit(this.inputTypeAhead);
   }
 
   initializeDataSource() {


### PR DESCRIPTION
> When administrating taskana accessIDs for a workbasket:
> 
> Given I want to create a new accessID
> When I click on the `+ Add new access` button
> Then I expect an empty accesItem entry (row) to be created AND I expect that the cursor is within the accessID so that I can immediately start typing the accessId after clicking the button.

This expected behaviour is now implemented.