### PR TITLE
TSK-1300: Updated the autocomment bot

### DIFF
--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,16 +1,18 @@
 pullRequestOpened: |
   ### For the submitter:
-  - [ ] In case it's necessary, update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
-  - [ ] Include link of [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
-  - [ ] Add description of changes in the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) if necessary
-  - [ ] Put ticket in review
-  - [ ] After integration of the pull request, verify bluemix test environment is not broken
+  - [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
+  - [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
+  - [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
+  - [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
+  - [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
+  - [ ] I put the ticket in review
+  - [ ] After integration of the pull request, i verified our [bluemix test environment] (http://taskana.mybluemix.net/taskana/) is not broken
 
-  ### For the reviewer:
-  - [ ] Check commit message format → TSK-XXX: Your commit message.
-  - [ ] Check the submitter's answer to the updated documentation
-  - [ ] Check the SonarCloud analysis link for new issues
-  - [ ] Check the update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
-  - [ ] Check that the PR fulfills the ticket
-  - [ ] Check for edge cases and unwanted side effects
-  - [ ] Check for readability
+  ### Verified by the reviewer:
+  - [ ] Commit message format → TSK-XXX: Your commit message.
+  - [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
+  - [ ] SonarCloud analysis meets our standards
+  - [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
+  - [ ] PR fulfills the ticket
+  - [ ] Edge cases and unwanted side effects are tested
+  - [ ] Readability


### PR DESCRIPTION
Updated the autocomment bot, to provide answers for "no update needed" for documentation and release notes. Small rewording of most of the answers.