### PR TITLE
TSK-1331: allowed multiple sortBy declarations in REST api

### DIFF
--- a/history/taskana-simplehistory-rest-spring/src/main/java/pro/taskana/simplehistory/rest/TaskHistoryEventController.java
+++ b/history/taskana-simplehistory-rest-spring/src/main/java/pro/taskana/simplehistory/rest/TaskHistoryEventController.java
@@ -6,6 +6,7 @@ import java.time.ZoneId;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.PagedModel.PageMetadata;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.http.HttpStatus;
@@ -19,10 +20,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import pro.taskana.TaskanaEngineConfiguration;
-import pro.taskana.common.api.BaseQuery;
 import pro.taskana.common.api.TimeInterval;
 import pro.taskana.common.api.exceptions.InvalidArgumentException;
 import pro.taskana.common.rest.AbstractPagingController;
+import pro.taskana.common.rest.QueryHelper;
 import pro.taskana.simplehistory.impl.HistoryEventImpl;
 import pro.taskana.simplehistory.impl.SimpleHistoryServiceImpl;
 import pro.taskana.simplehistory.query.HistoryQuery;
@@ -42,97 +43,53 @@ public class TaskHistoryEventController extends AbstractPagingController {
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskHistoryEventController.class);
 
   private static final String LIKE = "%";
-
   private static final String BUSINESS_PROCESS_ID = "business-process-id";
-
   private static final String BUSINESS_PROCESS_ID_LIKE = "business-process-id-like";
-
   private static final String PARENT_BUSINESS_PROCESS_ID = "parent-business-process-id";
-
   private static final String PARENT_BUSINESS_PROCESS_ID_LIKE = "parent-business-process-id-like";
-
   private static final String TASK_ID = "task-id";
-
   private static final String TASK_ID_LIKE = "task-id-like";
-
   private static final String EVENT_TYPE = "event-type";
-
   private static final String EVENT_TYPE_LIKE = "event-type-like";
-
   private static final String CREATED = "created";
-
   private static final String USER_ID = "user-id";
-
   private static final String USER_ID_LIKE = "user-id-like";
-
   private static final String DOMAIN = "domain";
-
   private static final String WORKBASKET_KEY = "workbasket-key";
-
   private static final String WORKBASKET_KEY_LIKE = "workbasket-key-like";
-
   private static final String POR_COMPANY = "por-company";
-
   private static final String POR_COMPANY_LIKE = "por-company-like";
-
   private static final String POR_SYSTEM = "por-system";
-
   private static final String POR_SYSTEM_LIKE = "por-system-like";
-
   private static final String POR_INSTANCE = "por-instance";
-
   private static final String POR_INSTANCE_LIKE = "por-instance-like";
-
   private static final String POR_TYPE = "por-type";
-
   private static final String POR_TYPE_LIKE = "por-type-like";
-
   private static final String POR_VALUE = "por-value";
-
   private static final String POR_VALUE_LIKE = "por-value-like";
-
   private static final String TASK_CLASSIFICATION_KEY = "task-classification-key";
-
   private static final String TASK_CLASSIFICATION_KEY_LIKE = "task-classification-key-like";
-
   private static final String TASK_CLASSIFICATION_CATEGORY = "task-classification-category";
-
   private static final String TASK_CLASSIFICATION_CATEGORY_LIKE =
       "task-classification-category-like";
-
   private static final String ATTACHMENT_CLASSIFICATION_KEY = "attachment-classification-key";
-
   private static final String ATTACHMENT_CLASSIFICATION_KEY_LIKE =
       "attachment-classification-key-like";
-
   private static final String CUSTOM_1 = "custom-1";
-
   private static final String CUSTOM_1_LIKE = "custom-1-like";
-
   private static final String CUSTOM_2 = "custom-2";
-
   private static final String CUSTOM_2_LIKE = "custom-2-like";
-
   private static final String CUSTOM_3 = "custom-3";
-
   private static final String CUSTOM_3_LIKE = "custom-3-like";
-
   private static final String CUSTOM_4 = "custom-4";
-
   private static final String CUSTOM_4_LIKE = "custom-4-like";
-
-  private static final String SORT_BY = "sort-by";
-
-  private static final String SORT_DIRECTION = "order";
-
   private static final String PAGING_PAGE = "page";
-
   private static final String PAGING_PAGE_SIZE = "page-size";
 
   private final SimpleHistoryServiceImpl simpleHistoryService;
-
   private final TaskHistoryEventResourceAssembler taskHistoryEventResourceAssembler;
 
+  @Autowired
   public TaskHistoryEventController(
       TaskanaEngineConfiguration taskanaEngineConfiguration,
       SimpleHistoryServiceImpl simpleHistoryServiceImpl,
@@ -153,7 +110,7 @@ public class TaskHistoryEventController extends AbstractPagingController {
 
     HistoryQuery query = simpleHistoryService.createHistoryQuery();
     query = applySortingParams(query, params);
-    applyFilterParams(query, params);
+    query = applyFilterParams(query, params);
 
     PageMetadata pageMetadata = null;
     List<HistoryEventImpl> historyEvents;
@@ -214,90 +171,83 @@ public class TaskHistoryEventController extends AbstractPagingController {
       LOGGER.debug("Entry to applySortingParams(params= {})", params);
     }
 
-    String sortBy = params.getFirst(SORT_BY);
-    if (sortBy != null) {
-      BaseQuery.SortDirection sortDirection;
-      if (params.getFirst(SORT_DIRECTION) != null
-          && "desc".equals(params.getFirst(SORT_DIRECTION))) {
-        sortDirection = BaseQuery.SortDirection.DESCENDING;
-      } else {
-        sortDirection = BaseQuery.SortDirection.ASCENDING;
-      }
-      switch (sortBy) {
-        case (BUSINESS_PROCESS_ID):
-          query = query.orderByBusinessProcessId(sortDirection);
-          break;
-        case (PARENT_BUSINESS_PROCESS_ID):
-          query = query.orderByParentBusinessProcessId(sortDirection);
-          break;
-        case (TASK_ID):
-          query = query.orderByTaskId(sortDirection);
-          break;
-        case (EVENT_TYPE):
-          query = query.orderByEventType(sortDirection);
-          break;
-        case (CREATED):
-          query = query.orderByCreated(sortDirection);
-          break;
-        case (USER_ID):
-          query = query.orderByUserId(sortDirection);
-          break;
-        case (DOMAIN):
-          query = query.orderByDomain(sortDirection);
-          break;
-        case (WORKBASKET_KEY):
-          query = query.orderByWorkbasketKey(sortDirection);
-          break;
-        case (POR_COMPANY):
-          query = query.orderByPorCompany(sortDirection);
-          break;
-        case (POR_SYSTEM):
-          query = query.orderByPorSystem(sortDirection);
-          break;
-        case (POR_INSTANCE):
-          query = query.orderByPorInstance(sortDirection);
-          break;
-        case (POR_TYPE):
-          query = query.orderByPorType(sortDirection);
-          break;
-        case (POR_VALUE):
-          query = query.orderByPorValue(sortDirection);
-          break;
-        case (TASK_CLASSIFICATION_KEY):
-          query = query.orderByTaskClassificationKey(sortDirection);
-          break;
-        case (TASK_CLASSIFICATION_CATEGORY):
-          query = query.orderByTaskClassificationCategory(sortDirection);
-          break;
-        case (ATTACHMENT_CLASSIFICATION_KEY):
-          query = query.orderByAttachmentClassificationKey(sortDirection);
-          break;
-        case (CUSTOM_1):
-          query = query.orderByCustomAttribute(1, sortDirection);
-          break;
-        case (CUSTOM_2):
-          query = query.orderByCustomAttribute(2, sortDirection);
-          break;
-        case (CUSTOM_3):
-          query = query.orderByCustomAttribute(3, sortDirection);
-          break;
-        case (CUSTOM_4):
-          query = query.orderByCustomAttribute(4, sortDirection);
-          break;
-        default:
-          throw new IllegalArgumentException("Unknown order '" + sortBy + "'");
-      }
-    }
-    params.remove(SORT_BY);
-    params.remove(SORT_DIRECTION);
+    QueryHelper.applyAndRemoveSortingParams(
+        params,
+        (sortBy, sortDirection) -> {
+          switch (sortBy) {
+            case (BUSINESS_PROCESS_ID):
+              query.orderByBusinessProcessId(sortDirection);
+              break;
+            case (PARENT_BUSINESS_PROCESS_ID):
+              query.orderByParentBusinessProcessId(sortDirection);
+              break;
+            case (TASK_ID):
+              query.orderByTaskId(sortDirection);
+              break;
+            case (EVENT_TYPE):
+              query.orderByEventType(sortDirection);
+              break;
+            case (CREATED):
+              query.orderByCreated(sortDirection);
+              break;
+            case (USER_ID):
+              query.orderByUserId(sortDirection);
+              break;
+            case (DOMAIN):
+              query.orderByDomain(sortDirection);
+              break;
+            case (WORKBASKET_KEY):
+              query.orderByWorkbasketKey(sortDirection);
+              break;
+            case (POR_COMPANY):
+              query.orderByPorCompany(sortDirection);
+              break;
+            case (POR_SYSTEM):
+              query.orderByPorSystem(sortDirection);
+              break;
+            case (POR_INSTANCE):
+              query.orderByPorInstance(sortDirection);
+              break;
+            case (POR_TYPE):
+              query.orderByPorType(sortDirection);
+              break;
+            case (POR_VALUE):
+              query.orderByPorValue(sortDirection);
+              break;
+            case (TASK_CLASSIFICATION_KEY):
+              query.orderByTaskClassificationKey(sortDirection);
+              break;
+            case (TASK_CLASSIFICATION_CATEGORY):
+              query.orderByTaskClassificationCategory(sortDirection);
+              break;
+            case (ATTACHMENT_CLASSIFICATION_KEY):
+              query.orderByAttachmentClassificationKey(sortDirection);
+              break;
+            case (CUSTOM_1):
+              query.orderByCustomAttribute(1, sortDirection);
+              break;
+            case (CUSTOM_2):
+              query.orderByCustomAttribute(2, sortDirection);
+              break;
+            case (CUSTOM_3):
+              query.orderByCustomAttribute(3, sortDirection);
+              break;
+            case (CUSTOM_4):
+              query.orderByCustomAttribute(4, sortDirection);
+              break;
+            default:
+              throw new IllegalArgumentException("Unknown order '" + sortBy + "'");
+          }
+        });
+
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Exit from applySortingParams(), returning {}", query);
+      LOGGER.debug("Exit from applySortingParams(), returning: {}", query);
     }
 
     return query;
   }
 
-  private void applyFilterParams(HistoryQuery query, MultiValueMap<String, String> params) {
+  private HistoryQuery applyFilterParams(HistoryQuery query, MultiValueMap<String, String> params) {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Entry to applyFilterParams(query= {}, params= {})", query, params);
     }
@@ -485,6 +435,8 @@ public class TaskHistoryEventController extends AbstractPagingController {
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Exit from applyFilterParams(), returning {}", query);
     }
+
+    return query;
   }
 
   private TimeInterval getTimeIntervalOf(String[] created) {

--- a/lib/taskana-core/src/main/java/pro/taskana/common/internal/util/CheckedBiConsumer.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/common/internal/util/CheckedBiConsumer.java
@@ -1,0 +1,8 @@
+package pro.taskana.common.internal.util;
+
+@FunctionalInterface
+public interface CheckedBiConsumer<T, U, E extends Throwable> {
+
+  void accept(T t, U u) throws E;
+
+}

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/QueryHelper.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/QueryHelper.java
@@ -1,0 +1,80 @@
+package pro.taskana.common.rest;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.MultiValueMap;
+
+import pro.taskana.common.api.BaseQuery.SortDirection;
+import pro.taskana.common.api.exceptions.InvalidArgumentException;
+import pro.taskana.common.internal.util.CheckedBiConsumer;
+
+public class QueryHelper {
+
+  public static final String SORT_BY = "sort-by";
+  public static final String ORDER_DIRECTION = "order";
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryHelper.class);
+
+  private QueryHelper() {
+    // no op
+  }
+
+  public static void applyAndRemoveSortingParams(
+      MultiValueMap<String, String> params,
+      CheckedBiConsumer<String, SortDirection, InvalidArgumentException> consumer)
+      throws InvalidArgumentException {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Entry to applyAndRemoveSortingParams(params= {})", params);
+    }
+
+    if (params == null || consumer == null) {
+      throw new InvalidArgumentException("params or consumer can't be null!");
+    }
+    List<String> allSortBy = params.remove(SORT_BY);
+    List<String> allOrderBy = params.remove(ORDER_DIRECTION);
+
+    verifyNotOnlyOrderByExists(allSortBy, allOrderBy);
+    verifyAmountOfSortByAndOrderByMatches(allSortBy, allOrderBy);
+
+    if (allSortBy != null) {
+      for (int i = 0; i < allSortBy.size(); i++) {
+        consumer.accept(allSortBy.get(i), getSortDirectionForIndex(allOrderBy, i));
+      }
+    }
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Exit from applyAndRemoveSortingParams()");
+    }
+  }
+
+  private static SortDirection getSortDirectionForIndex(List<String> allOrderBy, int i) {
+    SortDirection sortDirection = SortDirection.ASCENDING;
+    if (allOrderBy != null && !allOrderBy.isEmpty() && "desc".equalsIgnoreCase(allOrderBy.get(i))) {
+      sortDirection = SortDirection.DESCENDING;
+    }
+    return sortDirection;
+  }
+
+  private static void verifyNotOnlyOrderByExists(List<String> allSortBy, List<String> allOrderBy)
+      throws InvalidArgumentException {
+    if (allSortBy == null && allOrderBy != null) {
+      throw new InvalidArgumentException(
+          String.format(
+              "Only '%s' were provided. Please also provide '%s' parameter(s)",
+              ORDER_DIRECTION, SORT_BY));
+    }
+  }
+
+  private static void verifyAmountOfSortByAndOrderByMatches(
+      List<String> allSortBy, List<String> allOrderBy) throws InvalidArgumentException {
+    if (allSortBy != null
+        && allOrderBy != null
+        && allSortBy.size() != allOrderBy.size()
+        && !allOrderBy.isEmpty()) {
+      throw new InvalidArgumentException(
+          String.format(
+              "The amount of '%s' and '%s' does not match. "
+                  + "Please specify an '%s' for each '%s' or no '%s' parameters at all.",
+              SORT_BY, ORDER_DIRECTION, ORDER_DIRECTION, SORT_BY, ORDER_DIRECTION));
+    }
+  }
+}

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/TaskanaRestExceptionHandler.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/TaskanaRestExceptionHandler.java
@@ -36,106 +36,112 @@ import pro.taskana.workbasket.api.exceptions.WorkbasketInUseException;
 public class TaskanaRestExceptionHandler extends ResponseEntityExceptionHandler {
 
   @ExceptionHandler(InvalidArgumentException.class)
-  protected ResponseEntity<Object> handleInvalidArgument(
+  protected ResponseEntity<TaskanaErrorData> handleInvalidArgument(
       InvalidArgumentException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.BAD_REQUEST, false);
   }
 
   @ExceptionHandler(NotAuthorizedException.class)
-  protected ResponseEntity<Object> handleNotAuthorized(NotAuthorizedException ex, WebRequest req) {
+  protected ResponseEntity<TaskanaErrorData> handleNotAuthorized(
+      NotAuthorizedException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler(NotFoundException.class)
-  protected ResponseEntity<Object> handleTaskNotFound(NotFoundException ex, WebRequest req) {
+  protected ResponseEntity<TaskanaErrorData> handleTaskNotFound(
+      NotFoundException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.NOT_FOUND);
   }
 
   @ExceptionHandler(TaskAlreadyExistException.class)
-  protected ResponseEntity<Object> handleTaskAlreadyExist(
+  protected ResponseEntity<TaskanaErrorData> handleTaskAlreadyExist(
       TaskAlreadyExistException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(NotAuthorizedToQueryWorkbasketException.class)
-  protected ResponseEntity<Object> handleNotAuthorizedToQueryWorkbasket(
+  protected ResponseEntity<TaskanaErrorData> handleNotAuthorizedToQueryWorkbasket(
       NotAuthorizedToQueryWorkbasketException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.FORBIDDEN);
   }
 
   @ExceptionHandler(InvalidStateException.class)
-  protected ResponseEntity<Object> handleInvalidState(InvalidStateException ex, WebRequest req) {
+  protected ResponseEntity<TaskanaErrorData> handleInvalidState(
+      InvalidStateException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(InvalidOwnerException.class)
-  protected ResponseEntity<Object> handleInvalidOwner(InvalidOwnerException ex, WebRequest req) {
+  protected ResponseEntity<TaskanaErrorData> handleInvalidOwner(
+      InvalidOwnerException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(ClassificationAlreadyExistException.class)
-  protected ResponseEntity<Object> handleClassificationAlreadyExist(
+  protected ResponseEntity<TaskanaErrorData> handleClassificationAlreadyExist(
       ClassificationAlreadyExistException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(DuplicateKeyException.class)
-  protected ResponseEntity<Object> handleDuplicateKey(DuplicateKeyException ex, WebRequest req) {
+  protected ResponseEntity<TaskanaErrorData> handleDuplicateKey(
+      DuplicateKeyException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(ConcurrencyException.class)
-  protected ResponseEntity<Object> handleConcurrencyException(
+  protected ResponseEntity<TaskanaErrorData> handleConcurrencyException(
       ConcurrencyException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(WorkbasketInUseException.class)
-  protected ResponseEntity<Object> handleWorkbasketInUse(
+  protected ResponseEntity<TaskanaErrorData> handleWorkbasketInUse(
       WorkbasketInUseException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.LOCKED);
   }
 
   @ExceptionHandler(WorkbasketAlreadyExistException.class)
-  protected ResponseEntity<Object> handleWorkbasketAlreadyExist(
+  protected ResponseEntity<TaskanaErrorData> handleWorkbasketAlreadyExist(
       WorkbasketAlreadyExistException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(WorkbasketAccessItemAlreadyExistException.class)
-  protected ResponseEntity<Object> handleWorkbasketAccessItemAlreadyExist(
+  protected ResponseEntity<TaskanaErrorData> handleWorkbasketAccessItemAlreadyExist(
       WorkbasketAccessItemAlreadyExistException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.CONFLICT);
   }
 
   @ExceptionHandler(InvalidWorkbasketException.class)
-  protected ResponseEntity<Object> handleInvalidWorkbasket(
+  protected ResponseEntity<TaskanaErrorData> handleInvalidWorkbasket(
       InvalidWorkbasketException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(DomainNotFoundException.class)
-  protected ResponseEntity<Object> handleDomainNotFound(
+  protected ResponseEntity<TaskanaErrorData> handleDomainNotFound(
       DomainNotFoundException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(MaxUploadSizeExceededException.class)
-  protected ResponseEntity<Object> handleMaxUploadSizeExceededException(
+  protected ResponseEntity<TaskanaErrorData> handleMaxUploadSizeExceededException(
       MaxUploadSizeExceededException ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.PAYLOAD_TOO_LARGE);
   }
 
   @ExceptionHandler(Exception.class)
-  protected ResponseEntity<Object> handleGeneralException(Exception ex, WebRequest req) {
+  protected ResponseEntity<TaskanaErrorData> handleGeneralException(Exception ex, WebRequest req) {
     return buildResponse(ex, req, HttpStatus.BAD_REQUEST);
   }
 
-  private ResponseEntity<Object> buildResponse(Exception ex, WebRequest req, HttpStatus status) {
+  private ResponseEntity<TaskanaErrorData> buildResponse(
+      Exception ex, WebRequest req, HttpStatus status) {
     return buildResponse(ex, req, status, true);
   }
 
-  private ResponseEntity<Object> buildResponse(
+  private ResponseEntity<TaskanaErrorData> buildResponse(
       Exception ex, WebRequest req, HttpStatus status, boolean logExceptionOnError) {
     TaskanaErrorData errorData = new TaskanaErrorData(status, ex, req);
     if (logExceptionOnError) {

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/QueryHelperTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/QueryHelperTest.java
@@ -1,0 +1,177 @@
+package pro.taskana.common.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static pro.taskana.common.rest.QueryHelper.applyAndRemoveSortingParams;
+
+import java.util.AbstractMap.SimpleEntry;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.mockito.InOrder;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import pro.taskana.common.api.BaseQuery.SortDirection;
+import pro.taskana.common.api.exceptions.InvalidArgumentException;
+import pro.taskana.common.internal.util.CheckedBiConsumer;
+
+class QueryHelperTest {
+
+  @Test
+  void should_removeSortByAndOrderDirection_When_ApplyingSortingParams() throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.SORT_BY, Collections.singletonList("sort-by"));
+    map.put(QueryHelper.ORDER_DIRECTION, Collections.singletonList("order"));
+
+    applyAndRemoveSortingParams(map, mock(MockBiConsumer.class));
+    assertThat(map).isEmpty();
+  }
+
+  @Test
+  void should_ignoreMapContent_When_ApplyingSortingParams() throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    String key = "unknown";
+    List<String> value = Collections.singletonList("sort-by");
+    map.put(key, value);
+    map.put(QueryHelper.SORT_BY, Collections.singletonList("sort-by"));
+
+    applyAndRemoveSortingParams(map, mock(MockBiConsumer.class));
+    assertThat(map).containsExactly(new SimpleEntry<>(key, value));
+  }
+
+  @Test
+  void should_NotCallConsumer_When_MapDoesNotContainSortBy() throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    MockBiConsumer consumer = mock(MockBiConsumer.class);
+
+    applyAndRemoveSortingParams(map, consumer);
+
+    verifyNoInteractions(consumer);
+  }
+
+  @Test
+  void should_CallConsumerWithSortByValue_When_MapContainsOneSortBy() throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.SORT_BY, Collections.singletonList("sort-by-value"));
+    MockBiConsumer consumer = mock(MockBiConsumer.class);
+
+    applyAndRemoveSortingParams(map, consumer);
+    verify(consumer).accept(eq("sort-by-value"), any());
+    verifyNoMoreInteractions(consumer);
+  }
+
+  @Test
+  void should_CallConsumerWithAscSortDirection_When_MapDoesNotContainSortDirection()
+      throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.SORT_BY, Collections.singletonList("sort-by-value"));
+    MockBiConsumer consumer = mock(MockBiConsumer.class);
+
+    applyAndRemoveSortingParams(map, consumer);
+    verify(consumer).accept(any(), eq(SortDirection.ASCENDING));
+    verifyNoMoreInteractions(consumer);
+  }
+
+  @TestFactory
+  Stream<DynamicTest>
+      should_CallConsumerWithDescSortDirection_When_MapDoesContainsDescSortDirection() {
+    Iterator<String> testCases = Arrays.asList("desc", "DESC", "Desc", "desC", "DeSc").iterator();
+    ThrowingConsumer<String> test =
+        desc -> {
+          MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+          map.put(QueryHelper.SORT_BY, Collections.singletonList("sort-by-value"));
+          map.put(QueryHelper.ORDER_DIRECTION, Collections.singletonList(desc));
+          MockBiConsumer consumer = mock(MockBiConsumer.class);
+
+          applyAndRemoveSortingParams(map, consumer);
+          verify(consumer).accept(any(), eq(SortDirection.DESCENDING));
+          verifyNoMoreInteractions(consumer);
+        };
+
+    return DynamicTest.stream(testCases, s -> "Order by: " + s, test);
+  }
+
+  @Test
+  void should_callConsumerMultipleTimes_When_MapContainsMultipleSortBy() throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.SORT_BY, Arrays.asList("sort-by-value1", "sort-by-value2"));
+    MockBiConsumer consumer = mock(MockBiConsumer.class);
+
+    applyAndRemoveSortingParams(map, consumer);
+    InOrder inOrder = inOrder(consumer);
+    inOrder.verify(consumer).accept(eq("sort-by-value1"), any());
+    inOrder.verify(consumer).accept(eq("sort-by-value2"), any());
+    verifyNoMoreInteractions(consumer);
+  }
+
+  @Test
+  void should_matchSortDirectionForEachSortBy_When_MapContainsMultipleSortByAndOrderBy()
+      throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.SORT_BY, Arrays.asList("sort-by-value1", "sort-by-value2"));
+    map.put(QueryHelper.ORDER_DIRECTION, Arrays.asList("desc", "asc"));
+    MockBiConsumer consumer = mock(MockBiConsumer.class);
+
+    applyAndRemoveSortingParams(map, consumer);
+    verify(consumer).accept("sort-by-value1", SortDirection.DESCENDING);
+    verify(consumer).accept("sort-by-value2", SortDirection.ASCENDING);
+    verifyNoMoreInteractions(consumer);
+  }
+
+  @Test
+  void should_throwError_When_MapContainsOrderByButNoSortBy() {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.ORDER_DIRECTION, Collections.singletonList("desc"));
+    assertThatThrownBy(() -> applyAndRemoveSortingParams(map, mock(MockBiConsumer.class)))
+        .isInstanceOf(InvalidArgumentException.class);
+  }
+
+  @Test
+  void should_throwError_When_SortByAndOrderByCountDoesNotMatch() {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.SORT_BY, Arrays.asList("1", "2"));
+    map.put(QueryHelper.ORDER_DIRECTION, Collections.singletonList("desc"));
+    assertThatThrownBy(() -> applyAndRemoveSortingParams(map, mock(MockBiConsumer.class)))
+        .isInstanceOf(InvalidArgumentException.class);
+  }
+
+  @Test
+  void should_throwError_When_ConsumerRaisesException() throws Exception {
+    MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+    map.put(QueryHelper.SORT_BY, Collections.singletonList("1"));
+    MockBiConsumer consumer = mock(MockBiConsumer.class);
+    doThrow(new InvalidArgumentException("")).when(consumer).accept(any(), any());
+    assertThatThrownBy(() -> applyAndRemoveSortingParams(map, consumer))
+        .isInstanceOf(InvalidArgumentException.class);
+  }
+
+  @Test
+  void should_throwError_When_ConsumerIsNull() {
+    assertThatThrownBy(() -> applyAndRemoveSortingParams(new LinkedMultiValueMap<>(), null))
+        .isInstanceOf(InvalidArgumentException.class);
+  }
+
+  @Test
+  void should_throwError_When_MapIsNull() {
+    assertThatThrownBy(() -> applyAndRemoveSortingParams(null, mock(MockBiConsumer.class)))
+        .isInstanceOf(InvalidArgumentException.class);
+  }
+
+  private abstract static class MockBiConsumer
+      implements CheckedBiConsumer<String, SortDirection, InvalidArgumentException> {}
+}


### PR DESCRIPTION
I couldn't find a spot in our `rest-api` where query parameters were documented.
Since I don't have the time to document all query parameters I didn't document the new behaviour.

https://sonarcloud.io/dashboard?branch=task%2F1331&id=mustaphazorgati_taskana
Code Coverage: I have no idea why it dropped. I tested the addition of new code. 
Probably because the other methods I refactored were not tested in the first place

Code Smells: 

- [code smell 1](https://sonarcloud.io/project/issues?branch=task%2F1331&id=mustaphazorgati_taskana&open=AXM1aKBdrgK0Yoghlb9G&resolved=false&types=CODE_SMELL ): Was there before, won't fix

- [code smell 2](https://sonarcloud.io/project/issues?branch=task%2F1331&id=mustaphazorgati_taskana&open=AXM1aKDfrgK0Yoghlb9H&resolved=false&types=CODE_SMELL): Will be fixed shortly (whenever travis runs again)



