### PR TITLE
TSK-1327, TSK-1328: Fixed accessItemManagement

### DIFF
--- a/web/src/app/administration/components/access-items-management/access-items-management.component.html
+++ b/web/src/app/administration/components/access-items-management/access-items-management.component.html
@@ -1,18 +1,23 @@
 <div class="panel panel-default">
+
   <div class="panel-heading">
     <h4 class="panel-header">Access items management</h4>
   </div>
+
   <div class="panel-body">
     <div class="col-md-6 col-md-offset-3 margin">
       <taskana-shared-type-ahead #accesId="ngModel" name="accessIdSelected" [(ngModel)]="accessIdSelected" placeHolderMessage="Search for access id..."
                                  (selectedItem)="onSelectAccessId($event)" displayError=true></taskana-shared-type-ahead>
     </div>
-    <div *ngIf="!AccessItemsForm" class="center-block no-detail col-xs-12">
+    <!--No Id Placeholder-->
+    <div *ngIf="!accessItemsForm" class="center-block no-detail col-xs-12">
       <h3 class="grey">Select an access id</h3>
       <svg-icon class="empty-icon" src="./assets/icons/users.svg"></svg-icon>
     </div>
-    <div *ngIf="AccessItemsForm" class="row col-xs-12">
-      <form [formGroup]="AccessItemsForm">
+    <!--Content-->
+    <div *ngIf="accessItemsForm" class="row col-xs-12">
+      <form [formGroup]="accessItemsForm">
+        <!--Table With AccessIds-->
         <table id="table-access-items" class="table table-striped table-center">
           <thead>
             <tr>
@@ -33,10 +38,14 @@
               </ng-container>
             </tr>
             <tr>
-              <th colspan="2" class="text-align"><input type="text" formControlName="workbasketKeyFilter" (keyup.enter)="searchForAccessItemsWorkbaskets()"
-                  class="form-control" placeholder="Workbasket filter"></th>
-              <th class="text-align"><input type="text" formControlName="accessIdFilter" (keyup.enter)="searchForAccessItemsWorkbaskets()"
-                  class="form-control" placeholder="Access id filter"></th>
+              <th colspan="2" class="text-align"><label>
+                <input type="text" formControlName="workbasketKeyFilter" (keyup.enter)="searchForAccessItemsWorkbaskets()"
+                    class="form-control" placeholder="Workbasket filter">
+              </label></th>
+              <th class="text-align"><label>
+                <input type="text" formControlName="accessIdFilter" (keyup.enter)="searchForAccessItemsWorkbaskets()"
+                    class="form-control" placeholder="Access id filter">
+              </label></th>
               <th>
                 <button type="button" (click)="searchForAccessItemsWorkbaskets()" class="btn btn-default" data-toggle="tooltip"
                   title="Search">
@@ -63,7 +72,7 @@
             </tr>
           </thead>
           <tbody formArrayName="accessItemsGroups">
-            <tr *ngFor="let accessItem of accessItemsGroups.controls; let index = index;" [formGroupName]="index">
+            <tr *ngFor="let accessItem of accessItemsGroups.controls; let index = index;" [formGroupName]="index.toString()">
               <td colspan="2">
                 <label class="wrap">{{accessItem.value.workbasketKey}}</label>
               </td>
@@ -77,8 +86,10 @@
               <ng-template #accessIdInput>
                 <td colspan="2" class="text-align text-width">
                   <div>
-                    <input type="text" class="form-control" formControlName="accessId" placeholder="{{accessItem.invalid?
-                     '* Access id is required': ''}}">
+                    <label>
+                      <input type="text" class="form-control" formControlName="accessId" placeholder="{{accessItem.invalid?
+                       '* Access id is required': ''}}">
+                    </label>
                   </div>
                 </td>
               </ng-template>
@@ -111,39 +122,41 @@
             </tr>
           </tbody>
         </table>
-
-        <button *ngIf="!isGroup" class="btn btn-primary pull-left btn-group" type="button"
+        <!--Belonging Groups Button-->
+        <button class="btn btn-primary pull-left btn-group" type="button"
                 data-toggle="modal"
                 data-target="#myModal">
           Belonging groups
         </button>
-        <div class="modal" id="myModal">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title">Belonging groups</h4>
-                <button type="button" class="close" data-dismiss="modal">&times;</button>
-              </div>
-              <div class="modal-body">
-                <ul *ngIf="belongingGroups && belongingGroups.length > 0 " class="list-group">
-                  <li *ngFor="let group of belongingGroups" class="list-group-item">{{group.name}}</li>
-                </ul>
-                <p *ngIf="!belongingGroups">The user is not associated to
-                  any groups</p>
-              </div>
-              <div class="modal-footer">
-                <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <!--Revoke Access Button-->
         <div class="pull-right btn-group">
-          <button *ngIf="AccessItemsForm" type="button" (click)="revokeAccess()" class="btn btn-default" data-toggle="tooltip"
-            title="Revoke access" [disabled]=isGroup>
+          <button *ngIf="accessItemsForm" type="button" (click)="revokeAccess()" class="btn btn-default" data-toggle="tooltip"
+                  title="Revoke access" [disabled]=isGroup>
             <span class="material-icons md-20 red">clear</span>
           </button>
         </div>
       </form>
+    </div>
+  </div>
+</div>
+
+<div class="modal" id="myModal">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Belonging groups</h4>
+        <button type="button" class="close" data-dismiss="modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <ul *ngIf="groups && groups.length > 0; else no" class="list-group">
+          <li *ngFor="let group of groups" class="list-group-item">{{group.name}}</li>
+        </ul>
+        <ng-template #no>The user is not associated to
+          any groups</ng-template>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-danger" data-dismiss="modal">Close</button>
+      </div>
     </div>
   </div>
 </div>

--- a/web/src/app/administration/components/access-items-management/access-items-management.component.spec.ts
+++ b/web/src/app/administration/components/access-items-management/access-items-management.component.spec.ts
@@ -27,8 +27,9 @@ describe('AccessItemsManagementComponent', () => {
       fixture = testBed.createComponent(AccessItemsManagementComponent);
       component = fixture.componentInstance;
       accessIdsService = testBed.get(AccessIdsService);
-      spyOn(accessIdsService, 'getAccessItemsPermissions').and.returnValue(of(new Array<AccessIdDefinition>()));
-      spyOn(accessIdsService, 'getAccessItemsInformation').and.returnValue(of(new AccessItemWorkbasketResource()));
+      spyOn(accessIdsService, 'getAccessItems').and.returnValue(of(new Array<AccessIdDefinition>()));
+      spyOn(accessIdsService, 'searchForAccessId').and.returnValue(of(new AccessItemWorkbasketResource()));
+      spyOn(accessIdsService, 'getGroupsByAccessId').and.returnValue(of(new AccessItemWorkbasketResource()));
       fixture.detectChanges();
       done();
     });

--- a/web/src/app/administration/components/workbasket-access-items/workbasket-access-items.component.spec.ts
+++ b/web/src/app/administration/components/workbasket-access-items/workbasket-access-items.component.spec.ts
@@ -21,6 +21,7 @@ import { EngineConfigurationSelectors } from 'app/shared/store/engine-configurat
 import { WorkbasketAccessItemsComponent } from './workbasket-access-items.component';
 import { NotificationService } from '../../../shared/services/notifications/notification.service';
 import { NOTIFICATION_TYPES } from '../../../shared/models/notifications';
+import { AccessItemWorkbasketResource } from '../../../shared/models/access-item-workbasket-resource';
 
 describe('WorkbasketAccessItemsComponent', () => {
   let component: WorkbasketAccessItemsComponent;
@@ -78,9 +79,8 @@ describe('WorkbasketAccessItemsComponent', () => {
       spyOn(notificationsService, 'showToast').and.returnValue(of(true));
       debugElement = fixture.debugElement.nativeElement;
       accessIdsService = testBed.get(AccessIdsService);
-      spyOn(accessIdsService, 'getAccessItemsInformation').and.returnValue(of(new Array<string>(
-        'accessID1', 'accessID2'
-      )));
+      spyOn(accessIdsService, 'searchForAccessId').and.returnValue(of(['accessID1', 'accessID2']));
+      spyOn(accessIdsService, 'getGroupsByAccessId').and.returnValue(of(['accessID1', 'accessID2']));
       formsValidatorService = testBed.get(FormsValidatorService);
       component.ngOnChanges({
         active: new SimpleChange(undefined, 'accessItems', true)

--- a/web/src/app/shared/components/type-ahead/type-ahead.component.ts
+++ b/web/src/app/shared/components/type-ahead/type-ahead.component.ts
@@ -1,11 +1,10 @@
 import { Component,
-  OnInit,
   Input,
   ViewChild,
   forwardRef,
   Output,
   EventEmitter,
-  OnChanges, ElementRef, AfterViewInit } from '@angular/core';
+  ElementRef, AfterViewInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { TypeaheadMatch } from 'ngx-bootstrap/typeahead';
 
@@ -114,15 +113,15 @@ export class TypeAheadComponent implements AfterViewInit, ControlValueAccessor {
     this.dataSource = new Observable((observer: any) => {
       observer.next(this.value);
     }).pipe(mergeMap((token: string) => this.getUsersAsObservable(token)));
-    this.accessIdsService.getAccessItemsInformation(this.value).subscribe(items => {
+    this.accessIdsService.searchForAccessId(this.value).subscribe(items => {
       if (items.length > 0) {
         this.dataSource.selected = items.find(item => item.accessId.toLowerCase() === this.value.toLowerCase());
       }
     });
   }
 
-  getUsersAsObservable(token: string): Observable<any> {
-    return this.accessIdsService.getAccessItemsInformation(token);
+  getUsersAsObservable(accessId: string): Observable<any> {
+    return this.accessIdsService.searchForAccessId(accessId);
   }
 
   typeaheadOnSelect(event: TypeaheadMatch): void {

--- a/web/src/app/shared/services/access-ids/access-ids.service.ts
+++ b/web/src/app/shared/services/access-ids/access-ids.service.ts
@@ -13,39 +13,38 @@ import { QueryParameters } from 'app/shared/models/query-parameters';
 })
 export class AccessIdsService {
   private url = `${environment.taskanaRestUrl}/v1/access-ids`;
-  private accessItemsRef: Observable<AccessItemWorkbasketResource> = new Observable();
   constructor(
     private httpClient: HttpClient
   ) { }
 
-  getAccessItemsInformation(token: string, searchInGroups = false): Observable<Array<AccessIdDefinition>> {
-    if (!token || token.length < 3) {
+  searchForAccessId(accessId: string): Observable<AccessIdDefinition[]> {
+    if (!accessId || accessId.length < 3) {
       return of([]);
     }
-    if (searchInGroups) {
-      return this.httpClient.get<Array<AccessIdDefinition>>(`${this.url}/groups?access-id=${token}`);
-    }
-    return this.httpClient.get<Array<AccessIdDefinition>>(`${this.url}?search-for=${token}`);
+    return this.httpClient.get<AccessIdDefinition[]>(`${this.url}?search-for=${accessId}`);
   }
 
-  getAccessItemsPermissions(
-    accessIds: Array<AccessIdDefinition>,
+  getGroupsByAccessId(accessId: string): Observable<AccessIdDefinition[]> {
+    if (!accessId || accessId.length < 3) {
+      return of([]);
+    }
+    return this.httpClient.get<AccessIdDefinition[]>(`${this.url}/groups?access-id=${accessId}`);
+  }
+
+  getAccessItems(
+    accessIds: AccessIdDefinition[],
     accessIdLike?: string,
     workbasketKeyLike?: string,
-    sortModel: Sorting = new Sorting('workbasket-key'),
-    forceRequest: boolean = false
+    sortModel: Sorting = new Sorting('workbasket-key')
   ): Observable<AccessItemWorkbasketResource> {
-    if (forceRequest || !this.accessItemsRef) {
-      this.accessItemsRef = this.httpClient.get<AccessItemWorkbasketResource>(encodeURI(
-        `${environment.taskanaRestUrl}/v1/workbasket-access-items/${TaskanaQueryParameters.getQueryParameters(
-          this.accessIdsParameters(sortModel,
-            accessIds,
-            accessIdLike,
-            workbasketKeyLike)
-        )}`
-      ));
-    }
-    return this.accessItemsRef;
+    return this.httpClient.get<AccessItemWorkbasketResource>(encodeURI(
+      `${environment.taskanaRestUrl}/v1/workbasket-access-items/${TaskanaQueryParameters.getQueryParameters(
+        AccessIdsService.accessIdsParameters(sortModel,
+          accessIds,
+          accessIdLike,
+          workbasketKeyLike)
+      )}`
+    ));
   }
 
   removeAccessItemsPermissions(accessId: string) {
@@ -53,12 +52,12 @@ export class AccessIdsService {
       .delete<AccessItemWorkbasketResource>(`${environment.taskanaRestUrl}/v1/workbasket-access-items/?access-id=${accessId}`);
   }
 
-  private accessIdsParameters(
+  private static accessIdsParameters(
     sortModel: Sorting,
-    accessIds: Array<AccessIdDefinition>,
+    accessIds: AccessIdDefinition[],
     accessIdLike?: string,
     workbasketKeyLike?: string
-  ): QueryParameters {
+  ): QueryParameters { // TODO extend this query for support of multiple sortbys
     const parameters = new QueryParameters();
     parameters.SORTBY = sortModel.sortBy;
     parameters.SORTDIRECTION = sortModel.sortDirection;

--- a/web/src/app/shared/services/forms-validator/forms-validator.service.ts
+++ b/web/src/app/shared/services/forms-validator/forms-validator.service.ts
@@ -20,7 +20,7 @@ export class FormsValidatorService {
     if (!form) {
       return false;
     }
-    const forFieldsPromise = new Promise((resolve, reject) => {
+    const forFieldsPromise = new Promise(resolve => {
       Object.keys(form.form.controls).forEach(control => {
         if (control.indexOf('owner') === -1 && form.form.controls[control].invalid) {
           const validationState = toogleValidationMap.get(control);
@@ -31,10 +31,10 @@ export class FormsValidatorService {
       resolve(validSync);
     });
 
-    const ownerPromise = new Promise((resolve, reject) => {
+    const ownerPromise = new Promise(resolve => {
       const ownerString = 'owner';
       if (form.form.controls[this.workbasketOwner]) {
-        this.accessIdsService.getAccessItemsInformation(form.form.controls[this.workbasketOwner].value).subscribe(items => {
+        this.accessIdsService.searchForAccessId(form.form.controls[this.workbasketOwner].value).subscribe(items => {
           const validationState = toogleValidationMap.get(this.workbasketOwner);
           toogleValidationMap.set(this.workbasketOwner, !validationState);
           const valid = items.find(item => item.accessId === form.form.controls[this.workbasketOwner].value);
@@ -66,10 +66,10 @@ export class FormsValidatorService {
     const ownerPromise: Array<Promise<boolean>> = new Array<Promise<boolean>>();
 
     for (let i = 0; i < form.length; i++) {
-      ownerPromise.push(new Promise((resolve, reject) => {
+      ownerPromise.push(new Promise(resolve => {
         const validationState = toogleValidationAccessIdMap.get(i);
         toogleValidationAccessIdMap.set(i, !validationState);
-        this.accessIdsService.getAccessItemsInformation(form.controls[i].value.accessId).subscribe(items => {
+        this.accessIdsService.searchForAccessId(form.controls[i].value.accessId).subscribe(items => {
           resolve(new ResponseOwner({ valid: items.length > 0, field: 'access id' }));
         });
       }));
@@ -85,7 +85,7 @@ export class FormsValidatorService {
     if (!result) {
       this.notificationsService.showToast(
         NOTIFICATION_TYPES.WARNING_ALERT_2,
-        new Map<string, string>([['owner', responseOwner.field]])
+        new Map<string, string>([['owner', responseOwner ? responseOwner.field : 'owner']])
       );
     }
     return result;
@@ -103,7 +103,7 @@ export class FormsValidatorService {
   }
 }
 
-function ResponseOwner(obj) {
-  this.valid = obj.valid;
-  this.field = obj.field;
+function ResponseOwner(owner) {
+  this.valid = owner.valid;
+  this.field = owner.field;
 }


### PR DESCRIPTION
The AccessItemManagemant previously did not correctly display the accessItems of the requested accessId. It either showed only the accessItems of the groups the id belonged to, or it showed every item, when the id did not belong to another group. This happened, because the id itself, has not been added to the request. 
Currently there is no real way, to know if the searched for id is a group. Therefore the revokeAccessButton is always enabled, but will throw an error, when trying to remove the accesses of a group.
The belongingGroupsButton now also correctly shows the groups.

https://sonarcloud.io/dashboard?branch=TSK-1328&id=Tristan2357_taskana