### PR TITLE
TSK-1333: Add history events for cancelled/terminated tasks

### DIFF
--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCancelClaimAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCancelClaimAccTest.java
@@ -6,7 +6,6 @@ import acceptance.AbstractAccTest;
 import acceptance.security.JaasExtension;
 import acceptance.security.WithAccessId;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -19,23 +18,16 @@ import pro.taskana.task.api.TaskState;
 import pro.taskana.task.api.models.Task;
 
 @ExtendWith(JaasExtension.class)
-class CreateHistoryEventOnCompletionAccTest extends AbstractAccTest {
+class CreateHistoryEventOnTaskCancelClaimAccTest extends AbstractAccTest {
 
-  private TaskService taskService;
-  private SimpleHistoryServiceImpl historyService;
-
-  @BeforeEach
-  public void setUp() {
-
-    taskService = taskanaEngine.getTaskService();
-    historyService = getHistoryService();
-  }
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
 
   @WithAccessId(user = "admin")
   @Test
-  void should_CreateCompletedHistoryEvent_When_TaskIsCompleted() throws Exception {
+  void should_CreateCancelClaimedHistoryEvent_When_TaskIsCancelClaimed() throws Exception {
 
-    final String taskId = "TKI:000000000000000000000000000000000001";
+    final String taskId = "TKI:000000000000000000000000000000000043";
 
     HistoryQueryMapper historyQueryMapper = getHistoryQueryMapper();
 
@@ -46,8 +38,8 @@ class CreateHistoryEventOnCompletionAccTest extends AbstractAccTest {
     assertThat(listEvents).isEmpty();
 
     assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.CLAIMED);
-    Task task = taskService.forceCompleteTask(taskId);
-    assertThat(task.getState()).isEqualTo(TaskState.COMPLETED);
+    Task task = taskService.forceCancelClaim(taskId);
+    assertThat(task.getState()).isEqualTo(TaskState.READY);
 
     listEvents =
         historyQueryMapper.queryHistoryEvent(
@@ -55,6 +47,6 @@ class CreateHistoryEventOnCompletionAccTest extends AbstractAccTest {
 
     assertThat(listEvents).hasSize(1);
     assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
-        .isEqualTo("TASK_COMPLETED");
+        .isEqualTo("TASK_CLAIM_CANCELLED");
   }
 }

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCancellationAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCancellationAccTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import pro.taskana.simplehistory.impl.HistoryEventImpl;
 import pro.taskana.simplehistory.impl.SimpleHistoryServiceImpl;
 import pro.taskana.task.api.TaskService;
-import pro.taskana.task.api.TaskState;
-import pro.taskana.task.api.models.Task;
 
 @ExtendWith(JaasExtension.class)
 class CreateHistoryEventOnTaskCancellationAccTest extends AbstractAccTest {
@@ -23,7 +21,7 @@ class CreateHistoryEventOnTaskCancellationAccTest extends AbstractAccTest {
 
   @Test
   @WithAccessId(user = "admin")
-  void should_CreateCancelledHistoryEvent_When_TaskIsCancelled() throws Exception {
+  void should_CreateCancelledHistoryEvent_When_CancelTaskInStateClaimed() throws Exception {
 
     final String taskId = "TKI:000000000000000000000000000000000001";
 
@@ -31,15 +29,35 @@ class CreateHistoryEventOnTaskCancellationAccTest extends AbstractAccTest {
 
     assertThat(listEvents).isEmpty();
 
-    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.CLAIMED);
-
-    Task task = taskService.cancelTask(taskId);
-    assertThat(task.getState()).isEqualTo(TaskState.CANCELLED);
+    taskService.cancelTask(taskId);
 
     listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
 
     assertThat(listEvents).hasSize(1);
-    assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
-        .isEqualTo("TASK_CANCELLED");
+
+    String eventType = historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType();
+
+    assertThat(eventType).isEqualTo("TASK_CANCELLED");
+  }
+
+  @Test
+  @WithAccessId(user = "admin")
+  void should_CreateCancelledHistoryEvent_When_CancelTaskInStateReady() throws Exception {
+
+    final String taskId = "TKI:000000000000000000000000000000000003";
+
+    List<HistoryEventImpl> listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).isEmpty();
+
+    taskService.cancelTask(taskId);
+
+    listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).hasSize(1);
+
+    String eventType = historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType();
+
+    assertThat(eventType).isEqualTo("TASK_CANCELLED");
   }
 }

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCancellationAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCancellationAccTest.java
@@ -1,0 +1,45 @@
+package acceptance.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import acceptance.AbstractAccTest;
+import acceptance.security.JaasExtension;
+import acceptance.security.WithAccessId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import pro.taskana.simplehistory.impl.HistoryEventImpl;
+import pro.taskana.simplehistory.impl.SimpleHistoryServiceImpl;
+import pro.taskana.task.api.TaskService;
+import pro.taskana.task.api.TaskState;
+import pro.taskana.task.api.models.Task;
+
+@ExtendWith(JaasExtension.class)
+class CreateHistoryEventOnTaskCancellationAccTest extends AbstractAccTest {
+
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
+
+  @Test
+  @WithAccessId(user = "admin")
+  void should_CreateCancelledHistoryEvent_When_TaskIsCancelled() throws Exception {
+
+    final String taskId = "TKI:000000000000000000000000000000000001";
+
+    List<HistoryEventImpl> listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).isEmpty();
+
+    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.CLAIMED);
+
+    Task task = taskService.cancelTask(taskId);
+    assertThat(task.getState()).isEqualTo(TaskState.CANCELLED);
+
+    listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).hasSize(1);
+    assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
+        .isEqualTo("TASK_CANCELLED");
+  }
+}

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskClaimAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskClaimAccTest.java
@@ -6,7 +6,6 @@ import acceptance.AbstractAccTest;
 import acceptance.security.JaasExtension;
 import acceptance.security.WithAccessId;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -15,25 +14,20 @@ import pro.taskana.simplehistory.impl.HistoryQueryImpl;
 import pro.taskana.simplehistory.impl.SimpleHistoryServiceImpl;
 import pro.taskana.simplehistory.impl.mappings.HistoryQueryMapper;
 import pro.taskana.task.api.TaskService;
+import pro.taskana.task.api.TaskState;
+import pro.taskana.task.api.models.Task;
 
 @ExtendWith(JaasExtension.class)
-class CreateHistoryEventOnTransferAccTest extends AbstractAccTest {
+class CreateHistoryEventOnTaskClaimAccTest extends AbstractAccTest {
 
-  private TaskService taskService;
-  private SimpleHistoryServiceImpl historyService;
-
-  @BeforeEach
-  public void setUp() {
-
-    taskService = taskanaEngine.getTaskService();
-    historyService = getHistoryService();
-  }
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
 
   @WithAccessId(user = "admin")
   @Test
-  void should_CreateTransferredHistoryEvent_When_TaskIstransferred() throws Exception {
+  void should_CreateClaimedHistoryEvent_When_TaskIsClaimed() throws Exception {
 
-    final String taskId = "TKI:000000000000000000000000000000000003";
+    final String taskId = "TKI:000000000000000000000000000000000047";
 
     HistoryQueryMapper historyQueryMapper = getHistoryQueryMapper();
 
@@ -43,7 +37,9 @@ class CreateHistoryEventOnTransferAccTest extends AbstractAccTest {
 
     assertThat(listEvents).isEmpty();
 
-    taskService.transfer(taskId, "WBI:100000000000000000000000000000000006");
+    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.READY);
+    Task task = taskService.claim(taskId);
+    assertThat(task.getState()).isEqualTo(TaskState.CLAIMED);
 
     listEvents =
         historyQueryMapper.queryHistoryEvent(
@@ -51,6 +47,6 @@ class CreateHistoryEventOnTransferAccTest extends AbstractAccTest {
 
     assertThat(listEvents).hasSize(1);
     assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
-        .isEqualTo("TASK_TRANSFERRED");
+        .isEqualTo("TASK_CLAIMED");
   }
 }

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCompletionAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCompletionAccTest.java
@@ -6,7 +6,6 @@ import acceptance.AbstractAccTest;
 import acceptance.security.JaasExtension;
 import acceptance.security.WithAccessId;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -19,23 +18,16 @@ import pro.taskana.task.api.TaskState;
 import pro.taskana.task.api.models.Task;
 
 @ExtendWith(JaasExtension.class)
-class CreateHistoryEventOnClaimAccTest extends AbstractAccTest {
+class CreateHistoryEventOnTaskCompletionAccTest extends AbstractAccTest {
 
-  private TaskService taskService;
-  private SimpleHistoryServiceImpl historyService;
-
-  @BeforeEach
-  public void setUp() {
-
-    taskService = taskanaEngine.getTaskService();
-    historyService = getHistoryService();
-  }
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
 
   @WithAccessId(user = "admin")
   @Test
-  void should_CreateClaimedHistoryEvent_When_TaskIsClaimed() throws Exception {
+  void should_CreateCompletedHistoryEvent_When_TaskIsCompleted() throws Exception {
 
-    final String taskId = "TKI:000000000000000000000000000000000047";
+    final String taskId = "TKI:000000000000000000000000000000000001";
 
     HistoryQueryMapper historyQueryMapper = getHistoryQueryMapper();
 
@@ -45,9 +37,9 @@ class CreateHistoryEventOnClaimAccTest extends AbstractAccTest {
 
     assertThat(listEvents).isEmpty();
 
-    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.READY);
-    Task task = taskService.claim(taskId);
-    assertThat(task.getState()).isEqualTo(TaskState.CLAIMED);
+    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.CLAIMED);
+    Task task = taskService.forceCompleteTask(taskId);
+    assertThat(task.getState()).isEqualTo(TaskState.COMPLETED);
 
     listEvents =
         historyQueryMapper.queryHistoryEvent(
@@ -55,6 +47,6 @@ class CreateHistoryEventOnClaimAccTest extends AbstractAccTest {
 
     assertThat(listEvents).hasSize(1);
     assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
-        .isEqualTo("TASK_CLAIMED");
+        .isEqualTo("TASK_COMPLETED");
   }
 }

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCreationAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskCreationAccTest.java
@@ -6,7 +6,6 @@ import acceptance.AbstractAccTest;
 import acceptance.security.JaasExtension;
 import acceptance.security.WithAccessId;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -21,15 +20,8 @@ import pro.taskana.task.internal.models.TaskImpl;
 @ExtendWith(JaasExtension.class)
 class CreateHistoryEventOnTaskCreationAccTest extends AbstractAccTest {
 
-  private TaskService taskService;
-  private SimpleHistoryServiceImpl historyService;
-
-  @BeforeEach
-  public void setUp() {
-
-    taskService = taskanaEngine.getTaskService();
-    historyService = getHistoryService();
-  }
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
 
   @Test
   @WithAccessId(user = "admin")

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskTerminationAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskTerminationAccTest.java
@@ -12,8 +12,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import pro.taskana.simplehistory.impl.HistoryEventImpl;
 import pro.taskana.simplehistory.impl.SimpleHistoryServiceImpl;
 import pro.taskana.task.api.TaskService;
-import pro.taskana.task.api.TaskState;
-import pro.taskana.task.api.models.Task;
 
 @ExtendWith(JaasExtension.class)
 class CreateHistoryEventOnTaskTerminationAccTest extends AbstractAccTest {
@@ -23,7 +21,7 @@ class CreateHistoryEventOnTaskTerminationAccTest extends AbstractAccTest {
 
   @Test
   @WithAccessId(user = "admin")
-  void should_CreateTerminatedHistoryEvent_When_TaskIsTerminated() throws Exception {
+  void should_CreateTerminatedHistoryEvent_When_TerminatingTaskInStateClaimed() throws Exception {
 
     final String taskId = "TKI:000000000000000000000000000000000001";
 
@@ -31,15 +29,35 @@ class CreateHistoryEventOnTaskTerminationAccTest extends AbstractAccTest {
 
     assertThat(listEvents).isEmpty();
 
-    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.CLAIMED);
-
-    Task task = taskService.terminateTask(taskId);
-    assertThat(task.getState()).isEqualTo(TaskState.TERMINATED);
+    taskService.terminateTask(taskId);
 
     listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
 
     assertThat(listEvents).hasSize(1);
-    assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
-        .isEqualTo("TASK_TERMINATED");
+
+    String eventType = historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType();
+
+    assertThat(eventType).isEqualTo("TASK_TERMINATED");
+  }
+
+  @Test
+  @WithAccessId(user = "admin")
+  void should_CreateTerminatedHistoryEvent_When_TerminatingTaskInStateReady() throws Exception {
+
+    final String taskId = "TKI:000000000000000000000000000000000003";
+
+    List<HistoryEventImpl> listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).isEmpty();
+
+    taskService.terminateTask(taskId);
+
+    listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).hasSize(1);
+
+    String eventType = historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType();
+
+    assertThat(eventType).isEqualTo("TASK_TERMINATED");
   }
 }

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskTerminationAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskTerminationAccTest.java
@@ -1,0 +1,45 @@
+package acceptance.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import acceptance.AbstractAccTest;
+import acceptance.security.JaasExtension;
+import acceptance.security.WithAccessId;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import pro.taskana.simplehistory.impl.HistoryEventImpl;
+import pro.taskana.simplehistory.impl.SimpleHistoryServiceImpl;
+import pro.taskana.task.api.TaskService;
+import pro.taskana.task.api.TaskState;
+import pro.taskana.task.api.models.Task;
+
+@ExtendWith(JaasExtension.class)
+class CreateHistoryEventOnTaskTerminationAccTest extends AbstractAccTest {
+
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
+
+  @Test
+  @WithAccessId(user = "admin")
+  void should_CreateTerminatedHistoryEvent_When_TaskIsTerminated() throws Exception {
+
+    final String taskId = "TKI:000000000000000000000000000000000001";
+
+    List<HistoryEventImpl> listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).isEmpty();
+
+    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.CLAIMED);
+
+    Task task = taskService.terminateTask(taskId);
+    assertThat(task.getState()).isEqualTo(TaskState.TERMINATED);
+
+    listEvents = historyService.createHistoryQuery().taskIdIn(taskId).list();
+
+    assertThat(listEvents).hasSize(1);
+    assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
+        .isEqualTo("TASK_TERMINATED");
+  }
+}

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskTransferAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskTransferAccTest.java
@@ -6,7 +6,6 @@ import acceptance.AbstractAccTest;
 import acceptance.security.JaasExtension;
 import acceptance.security.WithAccessId;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -15,27 +14,18 @@ import pro.taskana.simplehistory.impl.HistoryQueryImpl;
 import pro.taskana.simplehistory.impl.SimpleHistoryServiceImpl;
 import pro.taskana.simplehistory.impl.mappings.HistoryQueryMapper;
 import pro.taskana.task.api.TaskService;
-import pro.taskana.task.api.TaskState;
-import pro.taskana.task.api.models.Task;
 
 @ExtendWith(JaasExtension.class)
-class CreateHistoryEventOnCancelClaimAccTest extends AbstractAccTest {
+class CreateHistoryEventOnTaskTransferAccTest extends AbstractAccTest {
 
-  private TaskService taskService;
-  private SimpleHistoryServiceImpl historyService;
-
-  @BeforeEach
-  public void setUp() {
-
-    taskService = taskanaEngine.getTaskService();
-    historyService = getHistoryService();
-  }
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
 
   @WithAccessId(user = "admin")
   @Test
-  void should_CreateCancelClaimedHistoryEvent_When_TaskIsCancelClaimed() throws Exception {
+  void should_CreateTransferredHistoryEvent_When_TaskIstransferred() throws Exception {
 
-    final String taskId = "TKI:000000000000000000000000000000000043";
+    final String taskId = "TKI:000000000000000000000000000000000003";
 
     HistoryQueryMapper historyQueryMapper = getHistoryQueryMapper();
 
@@ -45,9 +35,7 @@ class CreateHistoryEventOnCancelClaimAccTest extends AbstractAccTest {
 
     assertThat(listEvents).isEmpty();
 
-    assertThat(taskService.getTask(taskId).getState()).isEqualTo(TaskState.CLAIMED);
-    Task task = taskService.forceCancelClaim(taskId);
-    assertThat(task.getState()).isEqualTo(TaskState.READY);
+    taskService.transfer(taskId, "WBI:100000000000000000000000000000000006");
 
     listEvents =
         historyQueryMapper.queryHistoryEvent(
@@ -55,6 +43,6 @@ class CreateHistoryEventOnCancelClaimAccTest extends AbstractAccTest {
 
     assertThat(listEvents).hasSize(1);
     assertThat(historyService.getHistoryEvent(listEvents.get(0).getId()).getEventType())
-        .isEqualTo("TASK_CLAIM_CANCELLED");
+        .isEqualTo("TASK_TRANSFERRED");
   }
 }

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskUpdateAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/CreateHistoryEventOnTaskUpdateAccTest.java
@@ -6,7 +6,6 @@ import acceptance.AbstractAccTest;
 import acceptance.security.JaasExtension;
 import acceptance.security.WithAccessId;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -20,15 +19,8 @@ import pro.taskana.task.api.models.Task;
 @ExtendWith(JaasExtension.class)
 class CreateHistoryEventOnTaskUpdateAccTest extends AbstractAccTest {
 
-  private TaskService taskService;
-  private SimpleHistoryServiceImpl historyService;
-
-  @BeforeEach
-  public void setUp() {
-
-    taskService = taskanaEngine.getTaskService();
-    historyService = getHistoryService();
-  }
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
 
   @Test
   @WithAccessId(user = "admin")

--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/events/DeleteHistoryEventsOnTaskDeletionAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/events/DeleteHistoryEventsOnTaskDeletionAccTest.java
@@ -9,7 +9,6 @@ import acceptance.security.WithAccessId;
 import java.util.Arrays;
 import java.util.List;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -23,15 +22,8 @@ import pro.taskana.task.api.exceptions.TaskNotFoundException;
 @ExtendWith(JaasExtension.class)
 class DeleteHistoryEventsOnTaskDeletionAccTest extends AbstractAccTest {
 
-  private TaskService taskService;
-  private SimpleHistoryServiceImpl historyService;
-
-  @BeforeEach
-  public void setUp() {
-
-    taskService = taskanaEngine.getTaskService();
-    historyService = getHistoryService();
-  }
+  private final TaskService taskService = taskanaEngine.getTaskService();
+  private final SimpleHistoryServiceImpl historyService = getHistoryService();
 
   @Test
   @WithAccessId(user = "admin")

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/CancelledEvent.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/CancelledEvent.java
@@ -1,0 +1,13 @@
+package pro.taskana.spi.history.api.events.task;
+
+import pro.taskana.task.api.models.Task;
+
+/** Event fired if a task is cancelled. */
+public class CancelledEvent extends TaskEvent {
+
+  public CancelledEvent(String id, Task task, String userId) {
+    super(id, task, userId, null);
+    eventType = "TASK_CANCELLED";
+    created = task.getModified();
+  }
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/CancelledEvent.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/CancelledEvent.java
@@ -8,6 +8,6 @@ public class CancelledEvent extends TaskEvent {
   public CancelledEvent(String id, Task task, String userId) {
     super(id, task, userId, null);
     eventType = "TASK_CANCELLED";
-    created = task.getModified();
+    created = task.getCompleted();
   }
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/TerminatedEvent.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/TerminatedEvent.java
@@ -8,6 +8,6 @@ public class TerminatedEvent extends TaskEvent {
   public TerminatedEvent(String id, Task task, String userId) {
     super(id, task, userId, null);
     eventType = "TASK_TERMINATED";
-    created = task.getModified();
+    created = task.getCompleted();
   }
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/TerminatedEvent.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/history/api/events/task/TerminatedEvent.java
@@ -1,0 +1,13 @@
+package pro.taskana.spi.history.api.events.task;
+
+import pro.taskana.task.api.models.Task;
+
+/** Event fired if a task is terminated. */
+public class TerminatedEvent extends TaskEvent {
+
+  public TerminatedEvent(String id, Task task, String userId) {
+    super(id, task, userId, null);
+    eventType = "TASK_TERMINATED";
+    created = task.getModified();
+  }
+}


### PR DESCRIPTION
Sonarcloud: https://sonarcloud.io/dashboard?branch=TSK-1333&id=gitgoodjhe_taskana

NOTE:

The test coverage is once again not correct. it should be 100%, since it says the uncovered lines are the constructors of the 2 new events as well as the creation in the terminate/cancel methods of the TaskServiceImpl. These clearly actually get tested in the PR.



