### PR TITLE
TSK-1448: Expand workbasket path with selected tab

### DIFF
--- a/web/src/app/administration/components/workbasket-access-items/workbasket-access-items.component.ts
+++ b/web/src/app/administration/components/workbasket-access-items/workbasket-access-items.component.ts
@@ -51,9 +51,6 @@ export class WorkbasketAccessItemsComponent implements OnInit, OnChanges, OnDest
   @Input()
   action: ACTION;
 
-  @Input()
-  active: string;
-
   @ViewChildren('htmlInputElement')
   inputs: QueryList<ElementRef>;
 
@@ -142,14 +139,6 @@ export class WorkbasketAccessItemsComponent implements OnInit, OnChanges, OnDest
   }
 
   ngOnChanges(changes?: SimpleChanges) {
-    if (!this.initialized && changes.active && changes.active.currentValue === 'accessItems') {
-      this.init();
-    }
-    if (this.initialized && typeof changes.workbasket !== 'undefined') {
-      if (changes.workbasket.currentValue.workbasketId !== changes.workbasket.previousValue.workbasketId) {
-        this.init();
-      }
-    }
     if (changes.action) {
       this.setBadge();
     }

--- a/web/src/app/administration/components/workbasket-details/workbasket-details.component.html
+++ b/web/src/app/administration/components/workbasket-details/workbasket-details.component.html
@@ -37,7 +37,7 @@
       </button>
     </mat-menu>
   </mat-toolbar>
-  <mat-tab-group animationDuration="0ms" (selectedIndexChange)="selectComponent($event)" [(selectedIndex)]="selectedTab">
+  <mat-tab-group animationDuration="0ms" (selectedIndexChange)="selectComponent($event)" [selectedIndex]="selectedTab$ | async">
     <mat-tab label="Information">
       <taskana-administration-workbasket-information [workbasket]="workbasket" [action]="action"></taskana-administration-workbasket-information>
     </mat-tab>

--- a/web/src/app/administration/components/workbasket-details/workbasket-details.component.html
+++ b/web/src/app/administration/components/workbasket-details/workbasket-details.component.html
@@ -37,15 +37,15 @@
       </button>
     </mat-menu>
   </mat-toolbar>
-  <mat-tab-group animationDuration="0ms" (selectedIndexChange)="selectComponent($event)">
+  <mat-tab-group animationDuration="0ms" (selectedIndexChange)="selectComponent($event)" [(selectedIndex)]="selectedTab">
     <mat-tab label="Information">
       <taskana-administration-workbasket-information [workbasket]="workbasket" [action]="action"></taskana-administration-workbasket-information>
     </mat-tab>
     <mat-tab label="Access">
-      <taskana-administration-workbasket-access-items [workbasket]="workbasket" [action]="action" [active]="tabSelected"></taskana-administration-workbasket-access-items>
+      <taskana-administration-workbasket-access-items [workbasket]="workbasket" [action]="action"></taskana-administration-workbasket-access-items>
     </mat-tab>
     <mat-tab label="Distribution Targets">
-      <taskana-administration-workbasket-distribution-targets [workbasket]="workbasket" [action]="action" [active]="tabSelected"></taskana-administration-workbasket-distribution-targets>
+      <taskana-administration-workbasket-distribution-targets [workbasket]="workbasket" [action]="action"></taskana-administration-workbasket-distribution-targets>
     </mat-tab>
   </mat-tab-group>
   <mat-progress-bar mode="query" *ngIf="requestInProgress"></mat-progress-bar>

--- a/web/src/app/administration/components/workbasket-details/workbasket-details.component.spec.ts
+++ b/web/src/app/administration/components/workbasket-details/workbasket-details.component.spec.ts
@@ -15,11 +15,7 @@ import { RequestInProgressService } from '../../../shared/services/request-in-pr
 import { SelectedRouteService } from '../../../shared/services/selected-route/selected-route';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDialogModule } from '@angular/material/dialog';
-import {
-  engineConfigurationMock,
-  selectedWorkbasketMock,
-  workbasketReadStateMock
-} from '../../../shared/store/mock-data/mock-store';
+import { selectedWorkbasketMock, workbasketReadStateMock } from '../../../shared/store/mock-data/mock-store';
 import { StartupService } from '../../../shared/services/startup/startup.service';
 import { TaskanaEngineService } from '../../../shared/services/taskana-engine/taskana-engine.service';
 import { WindowRefService } from '../../../shared/services/window/window.service';
@@ -29,6 +25,8 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { CreateWorkbasket } from '../../../shared/store/workbasket-store/workbasket.actions';
+import { take } from 'rxjs/operators';
 
 @Component({ selector: 'taskana-shared-spinner', template: '' })
 class SpinnerStub {
@@ -140,7 +138,6 @@ describe('WorkbasketDetailsComponent', () => {
       workbasket: workbasketCreateState
     });
     fixture.detectChanges();
-    expect(component.tabSelected).toMatch('information');
     expect(component.selectedId).toBeUndefined();
   });
 
@@ -165,9 +162,13 @@ describe('WorkbasketDetailsComponent', () => {
     expect(component.workbasket).toEqual(selectedWorkbasketMock);
   });
 
-  it('should select information tab when action is CREATE', () => {
-    component.action = ACTION.CREATE;
-    component.selectTab('workbasket');
-    expect(component.tabSelected).toEqual('information');
+  it('should select information tab when action is CREATE', (done) => {
+    component.selectComponent(1);
+    store.dispatch(new CreateWorkbasket());
+    fixture.detectChanges();
+    component.selectedTab$.pipe(take(1)).subscribe((tab) => {
+      expect(tab).toEqual(0);
+      done();
+    });
   });
 });

--- a/web/src/app/administration/components/workbasket-details/workbasket-details.component.ts
+++ b/web/src/app/administration/components/workbasket-details/workbasket-details.component.ts
@@ -30,11 +30,13 @@ export class WorkbasketDetailsComponent implements OnInit, OnDestroy, OnChanges 
   selectedId: string;
   requestInProgress = false;
   action: ACTION;
-  selectedTab = 0;
   badgeMessage = '';
 
   @Select(WorkbasketSelectors.selectedWorkbasket)
   selectedWorkbasket$: Observable<Workbasket>;
+
+  @Select(WorkbasketSelectors.selectedComponent)
+  selectedTab$: Observable<number>;
 
   @Select(WorkbasketSelectors.workbasketActiveAction)
   activeAction$: Observable<ACTION>;
@@ -79,22 +81,6 @@ export class WorkbasketDetailsComponent implements OnInit, OnDestroy, OnChanges 
           this.getWorkbasketInformation(this.workbasket);
         }
       });
-
-    this.route.queryParams.subscribe((params) => {
-      const tab = params.tab;
-
-      if (tab === 'information') {
-        this.selectedTab = WorkbasketComponent.INFORMATION;
-      }
-      if (tab === 'access-items') {
-        this.selectedTab = WorkbasketComponent.ACCESS_ITEMS;
-      }
-      if (tab === 'distribution-targets') {
-        this.selectedTab = WorkbasketComponent.DISTRIBUTION_TARGETS;
-      }
-
-      this.store.dispatch(new SelectComponent(this.selectedTab));
-    });
   }
 
   ngOnChanges(changes?: SimpleChanges) {}

--- a/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.ts
+++ b/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.ts
@@ -42,9 +42,6 @@ export class WorkbasketDistributionTargetsComponent implements OnInit, OnChanges
   @Input()
   action: ACTION;
 
-  @Input()
-  active: string;
-
   badgeMessage = '';
 
   distributionTargetsSelectedResource: WorkbasketDistributionTargets;
@@ -95,9 +92,6 @@ export class WorkbasketDistributionTargetsComponent implements OnInit, OnChanges
   }
 
   ngOnChanges(changes: SimpleChanges) {
-    if (!this.initialized && changes.active && changes.active.currentValue === 'distributionTargets') {
-      this.init();
-    }
     if (changes.action) {
       this.setBadge();
     }

--- a/web/src/app/administration/components/workbasket-information/workbasket-information.component.ts
+++ b/web/src/app/administration/components/workbasket-information/workbasket-information.component.ts
@@ -74,7 +74,6 @@ export class WorkbasketInformationComponent implements OnInit, OnChanges, OnDest
   ) {}
 
   ngOnInit() {
-    this.store.dispatch(new SelectComponent(WorkbasketComponent.INFORMATION));
     this.allTypes = new Map([
       ['PERSONAL', 'Personal'],
       ['GROUP', 'Group'],

--- a/web/src/app/administration/components/workbasket-list-toolbar/workbasket-list-toolbar.component.spec.ts
+++ b/web/src/app/administration/components/workbasket-list-toolbar/workbasket-list-toolbar.component.spec.ts
@@ -16,6 +16,7 @@ import { TaskanaType } from '../../../shared/models/taskana-type';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatDialogModule } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
 
 const getDomainFn = jest.fn().mockReturnValue(true);
 const domainServiceMock = jest.fn().mockImplementation(
@@ -53,6 +54,7 @@ describe('WorkbasketListToolbarComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         HttpClientTestingModule,
+        RouterTestingModule,
         NgxsModule.forRoot([WorkbasketState]),
         BrowserAnimationsModule,
         MatIconModule,

--- a/web/src/app/administration/components/workbasket-list/workbasket-list.component.spec.ts
+++ b/web/src/app/administration/components/workbasket-list/workbasket-list.component.spec.ts
@@ -22,6 +22,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
 import { MatListModule, MatSelectionList } from '@angular/material/list';
 import { DomainService } from '../../../shared/services/domain/domain.service';
+import { RouterTestingModule } from '@angular/router/testing';
 
 const workbasketSavedTriggeredFn = jest.fn().mockReturnValue(of(1));
 const workbasketSummaryFn = jest.fn().mockReturnValue(of({}));
@@ -99,6 +100,7 @@ describe('WorkbasketListComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         NgxsModule.forRoot([WorkbasketState]),
+        RouterTestingModule,
         MatSnackBarModule,
         MatDialogModule,
         FormsModule,

--- a/web/src/app/shared/store/workbasket-store/workbasket.state.ts
+++ b/web/src/app/shared/store/workbasket-store/workbasket.state.ts
@@ -75,7 +75,27 @@ export class WorkbasketState implements NgxsAfterBootstrap {
 
   @Action(SelectWorkbasket)
   selectWorkbasket(ctx: StateContext<WorkbasketStateModel>, action: SelectWorkbasket): Observable<any> {
-    this.location.go(this.location.path().replace(/(workbaskets).*/g, `workbaskets/(detail:${action.workbasketId})`));
+    let selectedComponent;
+    switch (ctx.getState().selectedComponent) {
+      case WorkbasketComponent.INFORMATION:
+        selectedComponent = 'information';
+        break;
+      case WorkbasketComponent.ACCESS_ITEMS:
+        selectedComponent = 'access-items';
+        break;
+      case WorkbasketComponent.DISTRIBUTION_TARGETS:
+        selectedComponent = 'distribution-targets';
+        break;
+      default:
+        selectedComponent = 'information';
+    }
+
+    this.location.go(
+      this.location
+        .path()
+        .replace(/(workbaskets).*/g, `workbaskets/(detail:${action.workbasketId})?tab=${selectedComponent}`)
+    );
+
     const id = action.workbasketId;
     if (typeof id !== 'undefined') {
       return this.workbasketService.getWorkBasket(id).pipe(
@@ -122,12 +142,15 @@ export class WorkbasketState implements NgxsAfterBootstrap {
     switch (action.component) {
       case WorkbasketComponent.INFORMATION:
         ctx.patchState({ selectedComponent: WorkbasketComponent.INFORMATION });
+        this.location.go(this.location.path().replace(/(tab).*/g, 'tab=information'));
         break;
       case WorkbasketComponent.ACCESS_ITEMS:
         ctx.patchState({ selectedComponent: WorkbasketComponent.ACCESS_ITEMS });
+        this.location.go(this.location.path().replace(/(tab).*/g, 'tab=access-items'));
         break;
       case WorkbasketComponent.DISTRIBUTION_TARGETS:
         ctx.patchState({ selectedComponent: WorkbasketComponent.DISTRIBUTION_TARGETS });
+        this.location.go(this.location.path().replace(/(tab).*/g, 'tab=distribution-targets'));
         break;
     }
     return of(null);

--- a/web/src/app/shared/store/workbasket-store/workbasket.state.ts
+++ b/web/src/app/shared/store/workbasket-store/workbasket.state.ts
@@ -31,6 +31,7 @@ import { WorkbasketDistributionTargets } from '../../models/workbasket-distribut
 import { WorkbasketSummary } from '../../models/workbasket-summary';
 import { WorkbasketComponent } from '../../../administration/models/workbasket-component';
 import { ButtonAction } from '../../../administration/models/button-action';
+import { ActivatedRoute } from '@angular/router';
 
 class InitializeStore {
   static readonly type = '[Workbasket] Initializing state';
@@ -41,8 +42,35 @@ export class WorkbasketState implements NgxsAfterBootstrap {
   constructor(
     private workbasketService: WorkbasketService,
     private location: Location,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private route: ActivatedRoute
   ) {}
+
+  @Action(InitializeStore)
+  initializeStore(ctx: StateContext<WorkbasketStateModel>): Observable<any> {
+    // read the selected tab from the route
+    this.route.queryParams.pipe(take(2)).subscribe((params) => {
+      let tabName: string = params.tab;
+      let tab: number;
+
+      switch (tabName) {
+        case 'information':
+          tab = WorkbasketComponent.INFORMATION;
+          break;
+        case 'access-items':
+          tab = WorkbasketComponent.ACCESS_ITEMS;
+          break;
+        case 'distribution-targets':
+          tab = WorkbasketComponent.DISTRIBUTION_TARGETS;
+          break;
+        default:
+          tab = WorkbasketComponent.INFORMATION;
+      }
+
+      ctx.dispatch(new SelectComponent(tab));
+    });
+    return of();
+  }
 
   @Action(GetWorkbasketsSummary)
   getWorkbasketsSummary(ctx: StateContext<WorkbasketStateModel>, action: GetWorkbasketsSummary): Observable<any> {
@@ -86,8 +114,6 @@ export class WorkbasketState implements NgxsAfterBootstrap {
       case WorkbasketComponent.DISTRIBUTION_TARGETS:
         selectedComponent = 'distribution-targets';
         break;
-      default:
-        selectedComponent = 'information';
     }
 
     this.location.go(
@@ -126,6 +152,7 @@ export class WorkbasketState implements NgxsAfterBootstrap {
     this.location.go(this.location.path().replace(/(workbaskets).*/g, 'workbaskets/(detail:new-workbasket)'));
     ctx.patchState({
       selectedWorkbasket: undefined,
+      selectedComponent: WorkbasketComponent.INFORMATION,
       action: ACTION.CREATE
     });
     return of(null);


### PR DESCRIPTION
There are still two commits because in the second commit, I moved the initialization of the store's 'selectedComponent'-attribute from workbasket-details to the store itself. Now, the 'selectedTab'-variable directly depends on the store's variable. For me this improves readability / understanding.
If this is not desired, I will revert the commit. 

sonar: https://sonarcloud.io/dashboard?branch=TSK-1448&id=sofie29_taskana

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [x] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [x] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [x] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [x] Readability
