### PR TITLE
TSK-1239: Assertj use in every module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <!-- spring dependencies -->
         <version.javax.annotation-api>1.3.2</version.javax.annotation-api>
         <version.spring.core>2.0.0.RELEASE</version.spring.core>
-        <version.spring.boot>2.3.5.RELEASE</version.spring.boot>
+        <version.spring.boot>2.4.0</version.spring.boot>
         <version.spring.mybatis>2.0.6</version.spring.mybatis>
 
         <!-- wildfly dependencies -->

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/TestSchemaNameCustomizable.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/TestSchemaNameCustomizable.java
@@ -8,7 +8,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Locale;
 import javax.sql.DataSource;
-import org.junit.Assume;
+import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -44,7 +44,8 @@ class TestSchemaNameCustomizable {
   @Test
   void checkCustomSchemaNameIsDefined_Postgres() throws SQLException {
     resetDb();
-    Assume.assumeTrue("Test only executed with Postgres database", isPostgres);
+    Assumptions.assumeThat(isPostgres).isTrue();
+    ;
     try (Connection connection = dataSource.getConnection()) {
 
       try (PreparedStatement preparedStatement =
@@ -66,7 +67,7 @@ class TestSchemaNameCustomizable {
   @Test
   void checkCustomSchemaNameIsDefined_OtherDb() throws SQLException {
     resetDb();
-    Assume.assumeFalse("Test only executed if NOT Postgres", isPostgres);
+    Assumptions.assumeThat(isPostgres).isTrue();
     try (Connection connection = dataSource.getConnection()) {
 
       try (PreparedStatement preparedStatement =

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/ClassificationControllerRestDocumentation.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/ClassificationControllerRestDocumentation.java
@@ -1,7 +1,7 @@
 package pro.taskana.doc.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -333,7 +333,7 @@ class ClassificationControllerRestDocumentation extends BaseRestDocumentation {
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
     con.setRequestMethod("GET");
     con.setRequestProperty("Authorization", TEAMLEAD_1_CREDENTIALS);
-    assertEquals(200, con.getResponseCode());
+    assertThat(con.getResponseCode()).isEqualTo(200);
 
     BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream(), UTF_8));
     String inputLine;

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/TaskCommentControllerRestDocumentation.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/TaskCommentControllerRestDocumentation.java
@@ -1,7 +1,7 @@
 package pro.taskana.doc.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -132,7 +132,7 @@ class TaskCommentControllerRestDocumentation extends BaseRestDocumentation {
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
     con.setRequestMethod("GET");
     con.setRequestProperty("Authorization", ADMIN_CREDENTIALS);
-    assertEquals(200, con.getResponseCode());
+    assertThat(con.getResponseCode()).isEqualTo(200);
 
     BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream(), UTF_8));
     String inputLine;

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/TaskControllerRestDocumentation.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/TaskControllerRestDocumentation.java
@@ -1,7 +1,7 @@
 package pro.taskana.doc.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -514,7 +514,7 @@ class TaskControllerRestDocumentation extends BaseRestDocumentation {
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
     con.setRequestMethod("GET");
     con.setRequestProperty("Authorization", ADMIN_CREDENTIALS);
-    assertEquals(200, con.getResponseCode());
+    assertThat(con.getResponseCode()).isEqualTo(200);
 
     BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream(), UTF_8));
     String inputLine;

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/WorkbasketControllerRestDocumentation.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/doc/api/WorkbasketControllerRestDocumentation.java
@@ -1,8 +1,8 @@
 package pro.taskana.doc.api;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -466,7 +466,7 @@ class WorkbasketControllerRestDocumentation extends BaseRestDocumentation {
     HttpURLConnection con = (HttpURLConnection) url.openConnection();
     con.setRequestMethod("GET");
     con.setRequestProperty("Authorization", ADMIN_CREDENTIALS);
-    assertEquals(200, con.getResponseCode());
+    assertThat(con.getResponseCode()).isEqualTo(200);
 
     String modifiedWorkbasket;
     try (BufferedReader in =

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/monitor/rest/models/ReportRepresentationModelTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/monitor/rest/models/ReportRepresentationModelTest.java
@@ -1,9 +1,6 @@
 package pro.taskana.monitor.rest.models;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -60,24 +57,24 @@ class ReportRepresentationModelTest {
 
     // meta
     ReportRepresentationModel.MetaInformation meta = resource.getMeta();
-    assertEquals("WorkbasketReport", meta.getName());
-    assertEquals("2019-01-02T00:00:00Z", meta.getDate());
-    assertArrayEquals(new String[] {"WORKBASKET"}, meta.getRowDesc());
-    assertArrayEquals(
-        headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray(), meta.getHeader());
-    assertEquals("Total", meta.getTotalDesc());
+    assertThat(meta.getName()).isEqualTo("WorkbasketReport");
+    assertThat(meta.getDate()).isEqualTo("2019-01-02T00:00:00Z");
+    assertThat(meta.getRowDesc()).isEqualTo(new String[] {"WORKBASKET"});
+    assertThat(meta.getHeader())
+        .isEqualTo(headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray());
+    assertThat(meta.getTotalDesc()).isEqualTo("Total");
 
     // rows
-    assertTrue(resource.getRows().isEmpty());
+    assertThat(resource.getRows()).isEmpty();
 
     // sumRow
-    assertEquals(1, resource.getSumRow().size());
+    assertThat(resource.getSumRow()).hasSize(1);
     ReportRepresentationModel.RowResource sumRow = resource.getSumRow().get(0);
-    assertArrayEquals(new String[] {"Total"}, sumRow.getDesc());
-    assertTrue(sumRow.isDisplay());
-    assertEquals(0, sumRow.getDepth());
-    assertEquals(0, sumRow.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 0}, sumRow.getCells());
+    assertThat(sumRow.getDesc()).isEqualTo(new String[] {"Total"});
+    assertThat(sumRow.isDisplay()).isTrue();
+    assertThat(sumRow.getDepth()).isZero();
+    assertThat(sumRow.getTotal()).isZero();
+    assertThat(sumRow.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 0});
   }
 
   @Test
@@ -96,32 +93,32 @@ class ReportRepresentationModelTest {
 
     // meta
     ReportRepresentationModel.MetaInformation meta = resource.getMeta();
-    assertEquals("ClassificationReport", meta.getName());
-    assertEquals("2019-01-02T00:00:00Z", meta.getDate());
-    assertArrayEquals(new String[] {"CLASSIFICATION"}, meta.getRowDesc());
-    assertArrayEquals(
-        headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray(), meta.getHeader());
-    assertEquals("Total", meta.getTotalDesc());
+    assertThat(meta.getName()).isEqualTo("ClassificationReport");
+    assertThat(meta.getDate()).isEqualTo("2019-01-02T00:00:00Z");
+    assertThat(meta.getRowDesc()).isEqualTo(new String[] {"CLASSIFICATION"});
+    assertThat(meta.getHeader())
+        .isEqualTo(headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray());
+    assertThat(meta.getTotalDesc()).isEqualTo("Total");
 
     // rows
     List<ReportRepresentationModel.RowResource> rows = resource.getRows();
-    assertEquals(1, rows.size());
+    assertThat(rows.size()).isEqualTo(1);
     ReportRepresentationModel.RowResource row = rows.get(0);
-    assertArrayEquals(new String[] {"key"}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertEquals(2, row.getTotal());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key"});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.getTotal()).isEqualTo(2);
 
-    assertTrue(row.isDisplay());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     // sumRow
-    assertEquals(1, resource.getSumRow().size());
+    assertThat(resource.getSumRow().size()).isEqualTo(1);
     ReportRepresentationModel.RowResource sumRow = resource.getSumRow().get(0);
-    assertArrayEquals(new String[] {"Total"}, sumRow.getDesc());
-    assertTrue(sumRow.isDisplay());
-    assertEquals(0, sumRow.getDepth());
-    assertEquals(2, sumRow.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, sumRow.getCells());
+    assertThat(sumRow.getDesc()).isEqualTo(new String[] {"Total"});
+    assertThat(sumRow.isDisplay()).isTrue();
+    assertThat(sumRow.getDepth()).isZero();
+    assertThat(sumRow.getTotal()).isEqualTo(2);
+    assertThat(sumRow.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
   }
 
   @Test
@@ -142,39 +139,39 @@ class ReportRepresentationModelTest {
 
     // meta
     ReportRepresentationModel.MetaInformation meta = resource.getMeta();
-    assertEquals("ClassificationReport", meta.getName());
-    assertEquals("2019-01-02T00:00:00Z", meta.getDate());
-    assertArrayEquals(new String[] {"CLASSIFICATION"}, meta.getRowDesc());
-    assertArrayEquals(
-        headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray(), meta.getHeader());
-    assertEquals("Total", meta.getTotalDesc());
+    assertThat(meta.getName()).isEqualTo("ClassificationReport");
+    assertThat(meta.getDate()).isEqualTo("2019-01-02T00:00:00Z");
+    assertThat(meta.getRowDesc()).isEqualTo(new String[] {"CLASSIFICATION"});
+    assertThat(meta.getHeader())
+        .isEqualTo(headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray());
+    assertThat(meta.getTotalDesc()).isEqualTo("Total");
 
     // rows
     List<ReportRepresentationModel.RowResource> rows = resource.getRows();
-    assertEquals(2, rows.size());
+    assertThat(rows.size()).isEqualTo(2);
 
     ReportRepresentationModel.RowResource row = rows.get(0);
-    assertArrayEquals(new String[] {"key"}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertTrue(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key"});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     row = rows.get(1);
-    assertArrayEquals(new String[] {"key2"}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertTrue(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key2"});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     // sumRow
-    assertEquals(1, resource.getSumRow().size());
+    assertThat(resource.getSumRow()).hasSize(1);
     ReportRepresentationModel.RowResource sumRow = resource.getSumRow().get(0);
-    assertArrayEquals(new String[] {"Total"}, sumRow.getDesc());
-    assertEquals(0, sumRow.getDepth());
-    assertTrue(sumRow.isDisplay());
-    assertEquals(4, sumRow.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 4}, sumRow.getCells());
+    assertThat(sumRow.getDesc()).isEqualTo(new String[] {"Total"});
+    assertThat(sumRow.getDepth()).isZero();
+    assertThat(sumRow.isDisplay()).isTrue();
+    assertThat(sumRow.getTotal()).isEqualTo(4);
+    assertThat(sumRow.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 4});
   }
 
   @Test
@@ -197,62 +194,62 @@ class ReportRepresentationModelTest {
 
     // meta
     ReportRepresentationModel.MetaInformation meta = resource.getMeta();
-    assertEquals("DetailedClassificationReport", meta.getName());
-    assertEquals("2019-01-02T00:00:00Z", meta.getDate());
-    assertArrayEquals(new String[] {"TASK CLASSIFICATION", "ATTACHMENT"}, meta.getRowDesc());
-    assertArrayEquals(
-        headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray(), meta.getHeader());
-    assertEquals("Total", meta.getTotalDesc());
+    assertThat(meta.getName()).isEqualTo("DetailedClassificationReport");
+    assertThat(meta.getDate()).isEqualTo("2019-01-02T00:00:00Z");
+    assertThat(meta.getRowDesc()).isEqualTo(new String[] {"TASK CLASSIFICATION", "ATTACHMENT"});
+    assertThat(meta.getHeader())
+        .isEqualTo(headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray());
+    assertThat(meta.getTotalDesc()).isEqualTo("Total");
 
     // rows
     List<ReportRepresentationModel.RowResource> rows = resource.getRows();
-    assertEquals(1 + 2, rows.size());
+    assertThat(rows).hasSize(1 + 2);
 
     ReportRepresentationModel.RowResource row = rows.get(0);
-    assertArrayEquals(new String[] {"key", null}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertTrue(row.isDisplay());
-    assertEquals(4, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 4}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key", null});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getTotal()).isEqualTo(4);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 4});
 
     row = rows.get(1);
-    assertArrayEquals(new String[] {"key", "attachment"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key", "attachment"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     row = rows.get(2);
-    assertArrayEquals(new String[] {"key", "N/A"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key", "N/A"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     // sumRow
     List<ReportRepresentationModel.RowResource> sumRow = resource.getSumRow();
-    assertEquals(1 + 2, sumRow.size());
+    assertThat(sumRow).hasSize(1 + 2);
 
     row = sumRow.get(0);
-    assertArrayEquals(new String[] {"Total", null}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertTrue(row.isDisplay());
-    assertEquals(4, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 4}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"Total", null});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getTotal()).isEqualTo(4);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 4});
 
     row = sumRow.get(1);
-    assertArrayEquals(new String[] {"Total", "attachment"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"Total", "attachment"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     row = sumRow.get(2);
-    assertArrayEquals(new String[] {"Total", "N/A"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"Total", "N/A"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
   }
 
   @Test
@@ -277,76 +274,76 @@ class ReportRepresentationModelTest {
 
     // meta
     ReportRepresentationModel.MetaInformation meta = resource.getMeta();
-    assertEquals("DetailedClassificationReport", meta.getName());
-    assertEquals("2019-01-02T00:00:00Z", meta.getDate());
-    assertArrayEquals(new String[] {"TASK CLASSIFICATION", "ATTACHMENT"}, meta.getRowDesc());
-    assertArrayEquals(
-        headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray(), meta.getHeader());
-    assertEquals("Total", meta.getTotalDesc());
+    assertThat(meta.getName()).isEqualTo("DetailedClassificationReport");
+    assertThat(meta.getDate()).isEqualTo("2019-01-02T00:00:00Z");
+    assertThat(meta.getRowDesc()).isEqualTo(new String[] {"TASK CLASSIFICATION", "ATTACHMENT"});
+    assertThat(meta.getHeader())
+        .isEqualTo(headers.stream().map(TimeIntervalColumnHeader::getDisplayName).toArray());
+    assertThat(meta.getTotalDesc()).isEqualTo("Total");
 
     // rows
     List<ReportRepresentationModel.RowResource> rows = resource.getRows();
-    assertEquals((1 + 2) + (1 + 1), rows.size());
+    assertThat(rows).hasSize((1 + 2) + (1 + 1));
 
     ReportRepresentationModel.RowResource row = rows.get(0);
-    assertArrayEquals(new String[] {"key", null}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertTrue(row.isDisplay());
-    assertEquals(4, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 4}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key", null});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getTotal()).isEqualTo(4);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 4});
 
     row = rows.get(1);
-    assertArrayEquals(new String[] {"key", "attachment"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key", "attachment"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     row = rows.get(2);
-    assertArrayEquals(new String[] {"key", "N/A"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key", "N/A"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     row = rows.get(3);
-    assertArrayEquals(new String[] {"key2", null}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertTrue(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key2", null});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     row = rows.get(4);
-    assertArrayEquals(new String[] {"key2", "N/A"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"key2", "N/A"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     // sumRow
 
     List<ReportRepresentationModel.RowResource> sumRow = resource.getSumRow();
-    assertEquals(1 + 2, sumRow.size());
+    assertThat(sumRow).hasSize(1 + 2);
 
     row = sumRow.get(0);
-    assertArrayEquals(new String[] {"Total", null}, row.getDesc());
-    assertEquals(0, row.getDepth());
-    assertTrue(row.isDisplay());
-    assertEquals(6, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 6}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"Total", null});
+    assertThat(row.getDepth()).isZero();
+    assertThat(row.isDisplay()).isTrue();
+    assertThat(row.getTotal()).isEqualTo(6);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 6});
 
     row = sumRow.get(1);
-    assertArrayEquals(new String[] {"Total", "attachment"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(2, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 2}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"Total", "attachment"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(2);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 2});
 
     row = sumRow.get(2);
-    assertArrayEquals(new String[] {"Total", "N/A"}, row.getDesc());
-    assertEquals(1, row.getDepth());
-    assertFalse(row.isDisplay());
-    assertEquals(4, row.getTotal());
-    assertArrayEquals(new int[] {0, 0, 0, 0, 4}, row.getCells());
+    assertThat(row.getDesc()).isEqualTo(new String[] {"Total", "N/A"});
+    assertThat(row.getDepth()).isEqualTo(1);
+    assertThat(row.isDisplay()).isFalse();
+    assertThat(row.getTotal()).isEqualTo(4);
+    assertThat(row.getCells()).isEqualTo(new int[] {0, 0, 0, 0, 4});
   }
 }

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/workbasket/rest/WorkbasketAccessItemControllerIntTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/workbasket/rest/WorkbasketAccessItemControllerIntTest.java
@@ -28,7 +28,7 @@ import pro.taskana.common.test.rest.TaskanaSpringBootTest;
 import pro.taskana.workbasket.rest.models.WorkbasketAccessItemRepresentationModel;
 
 /** Test WorkbasketAccessItemController. */
-@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@TestMethodOrder(MethodOrderer.MethodName.class)
 @TaskanaSpringBootTest
 class WorkbasketAccessItemControllerIntTest {
 

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/workbasket/rest/assembler/WorkbasketSummaryRepresentationModelAssemblerTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/workbasket/rest/assembler/WorkbasketSummaryRepresentationModelAssemblerTest.java
@@ -6,7 +6,6 @@ import static pro.taskana.workbasket.api.WorkbasketCustomField.CUSTOM_2;
 import static pro.taskana.workbasket.api.WorkbasketCustomField.CUSTOM_3;
 import static pro.taskana.workbasket.api.WorkbasketCustomField.CUSTOM_4;
 
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -113,21 +112,21 @@ class WorkbasketSummaryRepresentationModelAssemblerTest {
       WorkbasketSummary summary, WorkbasketSummaryRepresentationModel repModel) {
     assertThat(summary).hasNoNullFieldsOrProperties();
     assertThat(repModel).hasNoNullFieldsOrProperties();
-    Assert.assertEquals(summary.getDescription(), repModel.getDescription());
-    Assert.assertEquals(summary.getDomain(), repModel.getDomain());
-    Assert.assertEquals(summary.getId(), repModel.getWorkbasketId());
-    Assert.assertEquals(summary.getKey(), repModel.getKey());
-    Assert.assertEquals(summary.getName(), repModel.getName());
-    Assert.assertEquals(summary.getCustomAttribute(CUSTOM_1), repModel.getCustom1());
-    Assert.assertEquals(summary.getCustomAttribute(CUSTOM_2), repModel.getCustom2());
-    Assert.assertEquals(summary.getCustomAttribute(CUSTOM_3), repModel.getCustom3());
-    Assert.assertEquals(summary.getCustomAttribute(CUSTOM_4), repModel.getCustom4());
-    Assert.assertEquals(summary.getOrgLevel1(), repModel.getOrgLevel1());
-    Assert.assertEquals(summary.getOrgLevel2(), repModel.getOrgLevel2());
-    Assert.assertEquals(summary.getOrgLevel3(), repModel.getOrgLevel3());
-    Assert.assertEquals(summary.getOrgLevel4(), repModel.getOrgLevel4());
-    Assert.assertEquals(summary.getOwner(), repModel.getOwner());
-    Assert.assertEquals(summary.getType(), repModel.getType());
+    assertThat(summary.getDescription()).isEqualTo(repModel.getDescription());
+    assertThat(summary.getDomain()).isEqualTo(repModel.getDomain());
+    assertThat(summary.getId()).isEqualTo(repModel.getWorkbasketId());
+    assertThat(summary.getKey()).isEqualTo(repModel.getKey());
+    assertThat(summary.getName()).isEqualTo(repModel.getName());
+    assertThat(summary.getCustomAttribute(CUSTOM_1)).isEqualTo(repModel.getCustom1());
+    assertThat(summary.getCustomAttribute(CUSTOM_2)).isEqualTo(repModel.getCustom2());
+    assertThat(summary.getCustomAttribute(CUSTOM_3)).isEqualTo(repModel.getCustom3());
+    assertThat(summary.getCustomAttribute(CUSTOM_4)).isEqualTo(repModel.getCustom4());
+    assertThat(summary.getOrgLevel1()).isEqualTo(repModel.getOrgLevel1());
+    assertThat(summary.getOrgLevel2()).isEqualTo(repModel.getOrgLevel2());
+    assertThat(summary.getOrgLevel3()).isEqualTo(repModel.getOrgLevel3());
+    assertThat(summary.getOrgLevel4()).isEqualTo(repModel.getOrgLevel4());
+    assertThat(summary.getOwner()).isEqualTo(repModel.getOwner());
+    assertThat(summary.getType()).isEqualTo(repModel.getType());
   }
 
   private void testLinks(WorkbasketSummaryRepresentationModel repModel) {}


### PR DESCRIPTION
Update of Spring Boot version to 2.4.0
Thus and because it is a rule in our guidelines I exchanged all remaining Assertion (junit) uses with the Assertj framework. Moreover Alphanumeric is deprecated since that version, thus change to MethodName.

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [x] Commit message format → TSK-XXX: Your commit message.
- [x] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [x] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [x] PR fulfills the ticket
- [x] Edge cases and unwanted side effects are tested
- [x] Readability
