### PR TITLE
TSK-1457: Fix timing issue in initializeSchedule tests for cleanupjobs

### DIFF
--- a/history/taskana-simplehistory-provider/src/test/java/acceptance/jobs/HistoryCleanupJobAccTest.java
+++ b/history/taskana-simplehistory-provider/src/test/java/acceptance/jobs/HistoryCleanupJobAccTest.java
@@ -6,6 +6,7 @@ import acceptance.AbstractAccTest;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -382,14 +383,15 @@ class HistoryCleanupJobAccTest extends AbstractAccTest {
 
     assertThat(jobsToRun).hasSize(30);
 
+    List<ScheduledJob> historyCleanupJobs =
+        jobsToRun.stream()
+            .filter(scheduledJob -> scheduledJob.getType().equals(Type.HISTORYCLEANUPJOB))
+            .collect(Collectors.toList());
+
     HistoryCleanupJob.initializeSchedule(taskanaEngine);
 
     jobsToRun = getJobMapper().findJobsToRun();
 
-    assertThat(jobsToRun).hasSize(20);
-
-    assertThat(jobsToRun)
-        .extracting(ScheduledJob::getType)
-        .containsOnly(Type.CLASSIFICATIONCHANGEDJOB, Type.UPDATETASKSJOB);
+    assertThat(jobsToRun).doesNotContainAnyElementsOf(historyCleanupJobs);
   }
 }

--- a/lib/taskana-core/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/jobs/TaskCleanupJobAccTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import acceptance.AbstractAccTest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -105,15 +106,16 @@ class TaskCleanupJobAccTest extends AbstractAccTest {
 
     assertThat(jobsToRun).hasSize(30);
 
+    List<ScheduledJob> taskCleanupJobs =
+        jobsToRun.stream()
+            .filter(scheduledJob -> scheduledJob.getType().equals(Type.TASKCLEANUPJOB))
+            .collect(Collectors.toList());
+
     TaskCleanupJob.initializeSchedule(taskanaEngine);
 
     jobsToRun = getJobMapper().findJobsToRun();
 
-    assertThat(jobsToRun).hasSize(20);
-
-    assertThat(jobsToRun)
-        .extracting(ScheduledJob::getType)
-        .containsOnly(Type.CLASSIFICATIONCHANGEDJOB, Type.UPDATETASKSJOB);
+    assertThat(jobsToRun).doesNotContainAnyElementsOf(taskCleanupJobs);
   }
 
   private Task createAndCompleteTask() throws Exception {

--- a/lib/taskana-core/src/test/java/acceptance/jobs/WorkbasketCleanupJobAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/jobs/WorkbasketCleanupJobAccTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import acceptance.AbstractAccTest;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -105,15 +106,16 @@ class WorkbasketCleanupJobAccTest extends AbstractAccTest {
 
     assertThat(jobsToRun).hasSize(30);
 
+    List<ScheduledJob> workbasketCleanupJobs =
+        jobsToRun.stream()
+            .filter(scheduledJob -> scheduledJob.getType().equals(Type.WORKBASKETCLEANUPJOB))
+            .collect(Collectors.toList());
+
     WorkbasketCleanupJob.initializeSchedule(taskanaEngine);
 
     jobsToRun = getJobMapper().findJobsToRun();
 
-    assertThat(jobsToRun).hasSize(20);
-
-    assertThat(jobsToRun)
-        .extracting(ScheduledJob::getType)
-        .containsOnly(Type.CLASSIFICATIONCHANGEDJOB, Type.UPDATETASKSJOB);
+    assertThat(jobsToRun).doesNotContainAnyElementsOf(workbasketCleanupJobs);
   }
 
   private long getNumberTaskNotCompleted(String workbasketId) {


### PR DESCRIPTION
<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
