### PR TITLE
TSK-1533: configured  spring-auto-rest-docks JacksonModelAttributeSnippet

### DIFF
--- a/common/taskana-common-test/src/main/java/pro/taskana/common/test/BaseRestDocTest.java
+++ b/common/taskana-common-test/src/main/java/pro/taskana/common/test/BaseRestDocTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.web.servlet.setup.ConfigurableMockMvcBuilder;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcConfigurerAdapter;
 import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter;
 
 import pro.taskana.common.test.rest.RestHelper;
 import pro.taskana.common.test.rest.TaskanaSpringBootTest;
@@ -39,6 +40,7 @@ public class BaseRestDocTest {
   protected MockMvc mockMvc;
   @Autowired protected ObjectMapper objectMapper;
   @Autowired protected RestHelper restHelper;
+  @Autowired private RequestMappingHandlerAdapter requestMappingHandlerAdapter;
 
   @BeforeEach
   public void setUp(
@@ -64,11 +66,14 @@ public class BaseRestDocTest {
                         AutoDocumentation.requestParameters().failOnUndocumentedParams(true),
                         AutoDocumentation.description(),
                         AutoDocumentation.methodAndPath(),
+                        AutoDocumentation.modelAttribute(
+                            requestMappingHandlerAdapter.getArgumentResolvers()),
                         AutoDocumentation.sectionBuilder()
                             .snippetNames(
                                 SnippetRegistry.AUTO_AUTHORIZATION,
                                 SnippetRegistry.AUTO_PATH_PARAMETERS,
                                 SnippetRegistry.AUTO_REQUEST_PARAMETERS,
+                                SnippetRegistry.AUTO_MODELATTRIBUTE,
                                 SnippetRegistry.AUTO_REQUEST_FIELDS,
                                 SnippetRegistry.AUTO_RESPONSE_FIELDS,
                                 SnippetRegistry.AUTO_LINKS,


### PR DESCRIPTION
in order to automatically generate the documentation for our ModelAttribute request types

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
