### PR TITLE
TSK-1638: Make Comparator for AccessIds in LdapClient NULL-safe

### DIFF
--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/ldap/LdapClient.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/ldap/LdapClient.java
@@ -351,7 +351,8 @@ public class LdapClient {
   void sortListOfAccessIdResources(List<AccessIdRepresentationModel> accessIds) {
     accessIds.sort(
         Comparator.comparing(
-            AccessIdRepresentationModel::getAccessId, String.CASE_INSENSITIVE_ORDER));
+            AccessIdRepresentationModel::getAccessId,
+            Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)));
   }
 
   String getNameWithoutBaseDn(String name) {

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/ldap/LdapClientTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/ldap/LdapClientTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -63,6 +64,30 @@ class LdapClientTest {
         .thenReturn(List.of(user));
 
     assertThat(cut.searchUsersAndGroups("test")).hasSize(2).containsExactlyInAnyOrder(user, group);
+  }
+
+  @Test
+  void should_CorrectlySortAccessIds_When_ContainingNullAccessId() throws Exception {
+
+    List<AccessIdRepresentationModel> accessIds = new ArrayList<>();
+    AccessIdRepresentationModel model1 = new AccessIdRepresentationModel("name1", "user-1");
+    AccessIdRepresentationModel model2 = new AccessIdRepresentationModel("name2", "user-2");
+    AccessIdRepresentationModel model3 = new AccessIdRepresentationModel("name3", null);
+    AccessIdRepresentationModel model4 = new AccessIdRepresentationModel("name4", "user-4");
+
+    // Can't use List.of because it returns an ImmutableCollection
+    accessIds.add(model4);
+    accessIds.add(model3);
+    accessIds.add(model2);
+    accessIds.add(model1);
+
+    LdapClient ldapClient = new LdapClient(environment, ldapTemplate);
+    ldapClient.sortListOfAccessIdResources(accessIds);
+
+    assertThat(accessIds.get(0).getAccessId()).isEqualTo("user-1");
+    assertThat(accessIds.get(1).getAccessId()).isEqualTo("user-2");
+    assertThat(accessIds.get(2).getAccessId()).isEqualTo("user-4");
+    assertThat(accessIds.get(3).getAccessId()).isNull();
   }
 
   @Test


### PR DESCRIPTION
<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
