### PR TITLE
TSK-1627: Reset selectAll in DistributionTargets when Workbasket changes

### DIFF
--- a/web/src/app/administration/components/workbasket-distribution-targets-list/workbasket-distribution-targets-list.component.html
+++ b/web/src/app/administration/components/workbasket-distribution-targets-list/workbasket-distribution-targets-list.component.html
@@ -18,9 +18,9 @@
     <span style="flex: 1 1 auto"> </span>
 
     <!-- SELECT ALL BUTTON -->
-    <button mat-flat-button class="distribution-targets-list__action-button" (click)="selectAll(allSelected);">
-      <mat-icon class="button-icon" *ngIf="!allSelected" matTooltip="Deselect all items">check_box</mat-icon>
-      <mat-icon class="button-icon" *ngIf="allSelected" matTooltip="Select all items">check_box_outline_blank</mat-icon>
+    <button mat-flat-button class="distribution-targets-list__action-button" (click)="selectAll(!allSelected);">
+      <mat-icon class="button-icon" *ngIf="allSelected" matTooltip="Deselect all items">check_box</mat-icon>
+      <mat-icon class="button-icon" *ngIf="!allSelected" matTooltip="Select all items">check_box_outline_blank</mat-icon>
     </button>
   </mat-toolbar>
 

--- a/web/src/app/administration/components/workbasket-distribution-targets-list/workbasket-distribution-targets-list.component.spec.ts
+++ b/web/src/app/administration/components/workbasket-distribution-targets-list/workbasket-distribution-targets-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { Component, DebugElement, EventEmitter, Input, Output, Pipe, PipeTransform } from '@angular/core';
+import { Component, DebugElement, Input, Pipe, PipeTransform } from '@angular/core';
 import { WorkbasketDistributionTargetsListComponent } from './workbasket-distribution-targets-list.component';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { WorkbasketType } from '../../../shared/models/workbasket-type';
@@ -67,13 +67,6 @@ describe('WorkbasketDistributionTargetsListComponent', () => {
   it('should set sideNumber to 0 when side is Side.AVAILABLE', () => {
     fixture.detectChanges();
     expect(component.side).toBe(Side.AVAILABLE);
-  });
-
-  it('should select all distribution targets', () => {
-    component.selectAll(true);
-    component.distributionTargets.forEach((element) => {
-      expect(element['selected']).toBe(true);
-    });
   });
 
   it('should change toolbar state', () => {

--- a/web/src/app/administration/components/workbasket-distribution-targets-list/workbasket-distribution-targets-list.component.ts
+++ b/web/src/app/administration/components/workbasket-distribution-targets-list/workbasket-distribution-targets-list.component.ts
@@ -1,7 +1,17 @@
-import { Component, OnInit, Input, AfterContentChecked, ChangeDetectorRef, ViewChild } from '@angular/core';
+import {
+  Component,
+  Input,
+  AfterContentChecked,
+  ChangeDetectorRef,
+  ViewChild,
+  Output,
+  EventEmitter,
+  OnChanges,
+  SimpleChanges
+} from '@angular/core';
 import { WorkbasketSummary } from 'app/shared/models/workbasket-summary';
 import { expandDown } from 'app/shared/animations/expand.animation';
-import { Side } from '../workbasket-distribution-targets/workbasket-distribution-targets.component';
+import { AllSelected, Side } from '../workbasket-distribution-targets/workbasket-distribution-targets.component';
 import { MatSelectionList } from '@angular/material/list';
 
 @Component({
@@ -10,32 +20,38 @@ import { MatSelectionList } from '@angular/material/list';
   styleUrls: ['./workbasket-distribution-targets-list.component.scss'],
   animations: [expandDown]
 })
-export class WorkbasketDistributionTargetsListComponent implements OnInit, AfterContentChecked {
+export class WorkbasketDistributionTargetsListComponent implements AfterContentChecked, OnChanges {
   @Input() distributionTargets: WorkbasketSummary[];
   @Input() side: Side;
   @Input() header: string;
   @Input() allSelected;
   @Input() component;
 
+  @Output() allSelectedEmitter = new EventEmitter<AllSelected>();
+
   toolbarState = false;
   @ViewChild('workbasket') distributionTargetsList: MatSelectionList;
 
   constructor(private changeDetector: ChangeDetectorRef) {}
 
-  ngOnInit() {
-    this.allSelected = !this.allSelected;
-  }
-
   ngAfterContentChecked(): void {
     this.changeDetector.detectChanges();
   }
 
+  ngOnChanges(changes: SimpleChanges) {
+    if (typeof changes.allSelected?.currentValue !== 'undefined') {
+      this.selectAll(changes.allSelected.currentValue);
+    }
+  }
+
   selectAll(selected: boolean) {
     if (typeof this.distributionTargetsList !== 'undefined') {
-      this.allSelected = !this.allSelected;
+      this.allSelected = selected;
       this.distributionTargetsList.options.map((item) => (item['selected'] = selected));
+      this.distributionTargets.map((item) => (item['selected'] = selected));
+
+      this.allSelectedEmitter.emit({ value: this.allSelected, side: this.side });
     }
-    this.distributionTargets.map((item) => (item['selected'] = selected));
   }
 
   changeToolbarState(state: boolean) {

--- a/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.html
+++ b/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.html
@@ -91,6 +91,7 @@
       [allSelected]="selectAllLeft"
       *ngIf="displayingDistributionTargetsPicker"
       [component]="'availableDistributionTargets'"
+      (allSelectedEmitter)="setAllSelected($event)"
     >
     </taskana-administration-workbasket-distribution-targets-list>
 
@@ -101,6 +102,7 @@
       [allSelected]="selectAllRight"
       [hidden]="displayingDistributionTargetsPicker && !sideBySide"
       [component]="'selectedDistributionTargets'"
+      (allSelectedEmitter)="setAllSelected($event)"
     >
     </taskana-administration-workbasket-distribution-targets-list>
   </div>

--- a/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.spec.ts
+++ b/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.spec.ts
@@ -151,12 +151,14 @@ describe('WorkbasketDistributionTargetsComponent', () => {
     expect(removeSelectedItems).toHaveBeenCalled();
   });
 
-  it('should set selectAll checkboxes to true when moving a workbasket', () => {
-    [Side.SELECTED, Side.AVAILABLE].forEach((side) => {
-      component.moveDistributionTargets(side);
-      expect(component.selectAllRight).toBeTruthy();
-      expect(component.selectAllLeft).toBeTruthy();
-    });
+  it('should set selectAll checkboxes to false when moving a workbasket', () => {
+    component.selectAllRight = true;
+    component.moveDistributionTargets(Side.SELECTED);
+    expect(component.selectAllRight).toBeFalsy();
+
+    component.selectAllLeft = true;
+    component.moveDistributionTargets(Side.AVAILABLE);
+    expect(component.selectAllLeft).toBeFalsy();
   });
 
   it('should call unselectItems() when moving a workbasket', () => {


### PR DESCRIPTION
... and reverted the logic of the boolean allSelected. The checkbox is selected when allSelected is true.

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [x] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [x] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [x] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [x] Readability
