### PR TITLE
TSK-1641: Modify pagination behavior when input is out of range

### DIFF
--- a/web/src/app/shared/components/pagination/pagination.component.html
+++ b/web/src/app/shared/components/pagination/pagination.component.html
@@ -1,13 +1,13 @@
 <div class="pagination" #pagination>
-  <mat-paginator class="pagination__mat-paginator" [length]="page?.totalElements" [pageIndex]="pageSelected - 1 "
+  <mat-paginator class="pagination__mat-paginator" [length]="page?.totalElements"
     hidePageSize="true" [pageSize]="page?.size" (page)="changeToPage($event)" [showFirstLastButtons]="true" [ngClass]="
                  {'pagination__mat-paginator--expanded': expanded,
                  'pagination__mat-paginator--collapsed': !expanded }"></mat-paginator>
   <div class="pagination__go-to" *ngIf="expanded">
     <div class="pagination__go-to-label">Page:</div>
     <mat-form-field>
-      <input #inputTypeAhead matInput type="text" [matAutocomplete]="auto" [(ngModel)]="pageSelected" name="accessId"
-        (ngModelChange)="filter(pageSelected)" (focus)="filter(pageSelected)" />
+      <input id="inputTypeAhead" matInput type="text" [matAutocomplete]="auto" [(ngModel)]="pageSelected" name="accessId"
+        (ngModelChange)="filter(pageSelected)" (focus)="filter(pageSelected)" (click)="onSelectText()" />
       <mat-autocomplete #autoComplete autoActiveFirstOption (optionSelected)="goToPage($event.option.value)"
         #auto="matAutocomplete">
         <mat-option *ngFor="let pageNumber of filteredPages" [value]="pageNumber">{{ pageNumber }}</mat-option>

--- a/web/src/app/shared/components/pagination/pagination.component.spec.ts
+++ b/web/src/app/shared/components/pagination/pagination.component.spec.ts
@@ -1,0 +1,64 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { PaginationComponent } from './pagination.component';
+import { DebugElement } from '@angular/core';
+import { MatPaginatorModule } from '@angular/material/paginator';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { FormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('PaginationComponent', () => {
+  let fixture: ComponentFixture<PaginationComponent>;
+  let debugElement: DebugElement;
+  let component: PaginationComponent;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        MatPaginatorModule,
+        MatAutocompleteModule,
+        FormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        BrowserAnimationsModule
+      ],
+      declarations: [PaginationComponent],
+      providers: []
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PaginationComponent);
+    debugElement = fixture.debugElement;
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    component.page = { totalPages: 10 };
+    component.pageNumbers = [];
+    for (let i = 1; i <= component.page.totalPages; i++) {
+      component.pageNumbers.push(i);
+    }
+  }));
+
+  it('should create component', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should suggest page 3 when filter() is called with 3', () => {
+    component.filter(3);
+    expect(component.filteredPages).toEqual(['3']);
+  });
+
+  it('should suggest all pages when input of filter() is out of range', () => {
+    component.filter(11);
+    expect(component.filteredPages).toEqual(component.pageNumbers.map(String));
+    component.filter(-1);
+    expect(component.filteredPages).toEqual(component.pageNumbers.map(String));
+  });
+
+  it('should suggest all pages when input of filter() is not a number', () => {
+    component.filter('abc');
+    expect(component.filteredPages).toEqual(component.pageNumbers.map(String));
+    component.filter('');
+    expect(component.filteredPages).toEqual(component.pageNumbers.map(String));
+  });
+});

--- a/web/src/app/shared/components/pagination/pagination.component.ts
+++ b/web/src/app/shared/components/pagination/pagination.component.ts
@@ -110,8 +110,17 @@ export class PaginationComponent implements OnInit, OnChanges {
     this.changePage.emit(page);
   }
 
-  filter(filterVal) {
-    const filterValue = filterVal.toString();
-    this.filteredPages = this.pageNumbers.map(String).filter((value) => value.includes(filterValue));
+  filter(filterValue) {
+    const pageNumbers = this.pageNumbers.map(String);
+    this.filteredPages = pageNumbers.filter((value) => value.includes(filterValue.toString()));
+    if (this.filteredPages.length === 0) {
+      this.filteredPages = pageNumbers;
+    }
+  }
+
+  onSelectText() {
+    const input = document.getElementById('inputTypeAhead') as HTMLInputElement;
+    input.focus();
+    input.select();
   }
 }


### PR DESCRIPTION
When the input is out of range or doesn't contain numbers, the whole list of suggestions is displayed. Additionally, the input is selected when the user clicks into the input field in order to make it easier to type in new values.

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [x] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [x] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [x] Readability
