### PR TITLE
TSK-1707: Performance optimization for TaskService#getTask and TaskQuery#list

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/AttachmentMapper.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/AttachmentMapper.java
@@ -1,6 +1,7 @@
 package pro.taskana.task.internal;
 
 import java.time.Instant;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.apache.ibatis.annotations.Delete;
@@ -81,7 +82,7 @@ public interface AttachmentMapper {
   @Result(property = "channel", column = "CHANNEL")
   @Result(property = "received", column = "RECEIVED")
   List<AttachmentSummaryImpl> findAttachmentSummariesByTaskIds(
-      @Param("taskIds") List<String> taskIds);
+      @Param("taskIds") Collection<String> taskIds);
 
   @Delete("DELETE FROM ATTACHMENT WHERE ID=#{attachmentId}")
   void delete(@Param("attachmentId") String attachmentId);


### PR DESCRIPTION
The execution time has been reduced from O(n²) to O(n)

https://sonarcloud.io/dashboard?branch=task%2F1707&id=mustaphazorgati_taskana

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [x] Commit message format → TSK-XXX: Your commit message.
- [x] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [x] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [x] PR fulfills the ticket
- [x] Edge cases and unwanted side effects are tested
- [x] Readability
