### PR TITLE
TSK-1715: Implemented OwnerNotIn-Filter for TaskQuery.

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskQuery.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskQuery.java
@@ -203,6 +203,14 @@ public interface TaskQuery extends BaseQuery<TaskSummary, TaskQueryColumnName> {
   TaskQuery ownerIn(String... owners);
 
   /**
+   * Filter out owners.
+   *
+   * @param owners the owners as String
+   * @return the query
+   */
+  TaskQuery ownerNotIn(String... owners);
+
+  /**
    * Add the owner for pattern matching to your query. It will be compared in SQL with the LIKE
    * operator. You may use a wildcard like % to specify the pattern.
    *

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQueryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQueryImpl.java
@@ -75,6 +75,7 @@ public class TaskQueryImpl implements TaskQuery {
   private String[] classificationNameIn;
   private String[] classificationNameLike;
   private String[] ownerIn;
+  private String[] ownerNotIn;
   private String[] ownerLike;
   private Boolean isRead;
   private Boolean isTransferred;
@@ -314,6 +315,12 @@ public class TaskQueryImpl implements TaskQuery {
   @Override
   public TaskQuery ownerIn(String... owners) {
     this.ownerIn = owners;
+    return this;
+  }
+
+  @Override
+  public TaskQuery ownerNotIn(String... owners) {
+    this.ownerNotIn = owners;
     return this;
   }
 
@@ -992,7 +999,7 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public List<TaskSummary> list(int offset, int limit) {
-    List<TaskSummary> result = new ArrayList<>();
+    List<TaskSummary> result;
     try {
       taskanaEngine.openConnection();
       checkForIllegalParamCombinations();
@@ -1020,7 +1027,7 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public List<String> listValues(TaskQueryColumnName columnName, SortDirection sortDirection) {
-    List<String> result = new ArrayList<>();
+    List<String> result;
     try {
       taskanaEngine.openConnection();
       this.columnName = columnName;
@@ -1052,7 +1059,7 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public TaskSummary single() {
-    TaskSummary result = null;
+    TaskSummary result;
     try {
       taskanaEngine.openConnection();
       checkOpenAndReadPermissionForSpecifiedWorkbaskets();
@@ -1077,7 +1084,7 @@ public class TaskQueryImpl implements TaskQuery {
 
   @Override
   public long count() {
-    Long rowCount = null;
+    Long rowCount;
     try {
       taskanaEngine.openConnection();
       checkOpenAndReadPermissionForSpecifiedWorkbaskets();
@@ -1184,6 +1191,10 @@ public class TaskQueryImpl implements TaskQuery {
 
   public String[] getOwnerIn() {
     return ownerIn;
+  }
+
+  public String[] getOwnerNotIn() {
+    return ownerNotIn;
   }
 
   public String[] getOwnerLike() {

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQuerySqlProvider.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQuerySqlProvider.java
@@ -321,6 +321,7 @@ public class TaskQuerySqlProvider {
     whereIn("classificationNameIn", "c.NAME", sb);
     whereIn("attachmentClassificationNameIn", "ac.NAME", sb);
     whereIn("ownerIn", "OWNER", sb);
+    whereNotIn("ownerNotIn", "OWNER", sb);
     whereIn("porCompanyIn", "POR_COMPANY", sb);
     whereIn("porSystemIn", "POR_SYSTEM", sb);
     whereIn("porSystemInstanceIn", "POR_INSTANCE", sb);

--- a/lib/taskana-core/src/test/java/acceptance/task/QueryTasksAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/task/QueryTasksAccTest.java
@@ -79,19 +79,20 @@ class QueryTasksAccTest extends AbstractAccTest {
 
   @WithAccessId(user = "admin")
   @Test
-  void testQueryForOwnerLike() {
-
+  void should_ReturnCorrectResults_When_QueryingForOwnerLike() {
     List<TaskSummary> results =
         TASK_SERVICE.createTaskQuery().ownerLike("%a%", "%u%").orderByCreated(ASCENDING).list();
 
-    assertThat(results).hasSize(39);
-    TaskSummary previousSummary = null;
-    for (TaskSummary taskSummary : results) {
-      if (previousSummary != null) {
-        assertThat(previousSummary.getCreated().isAfter(taskSummary.getCreated())).isFalse();
-      }
-      previousSummary = taskSummary;
-    }
+    assertThat(results).hasSize(39).extracting(TaskSummary::getCreated).isSorted();
+  }
+
+  @WithAccessId(user = "admin")
+  @Test
+  void should_FilterOutOwner_When_OwnerNotInIsSet() {
+    List<TaskSummary> results =
+        TASK_SERVICE.createTaskQuery().ownerNotIn("user-1-1", "user-1-2").list();
+
+    assertThat(results).hasSize(3).extracting(TaskSummary::getOwner).containsOnly("user-b-1");
   }
 
   @WithAccessId(user = "admin")


### PR DESCRIPTION
<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
