### PR TITLE
TSK-1784: throw exception while searching for tasks in case some arguments are invalid

### DIFF
--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskQueryFilterParameter.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskQueryFilterParameter.java
@@ -2419,11 +2419,18 @@ public class TaskQueryFilterParameter implements QueryParameter<TaskQuery, Void>
     }
 
     if (workbasketKeyIn != null && domain == null) {
-      throw new InvalidArgumentException("'workbasket-key' requires exactly one domain.");
+      throw new InvalidArgumentException(
+          "'workbasket-key' can only be used together with 'domain'.");
     }
 
     if (workbasketKeyNotIn != null && domain == null) {
-      throw new InvalidArgumentException("'workbasket-key-not-in' requires exactly one domain.");
+      throw new InvalidArgumentException(
+          "'workbasket-key-not' can only be used together with 'domain'.");
+    }
+
+    if (workbasketKeyIn == null && workbasketKeyNotIn == null && domain != null) {
+      throw new InvalidArgumentException(
+          "'domain' can only be used together with 'workbasket-key' or 'workbasket-key-not'.");
     }
 
     if (plannedWithin != null && plannedWithin.length % 2 != 0) {


### PR DESCRIPTION
If domain is specified, but neither workbasket-key nor workbasket-key-not are specified, throw an Exception.

Sonarcloud: https://sonarcloud.io/summary/new_code?branch=TSK-1784&id=ryzheboka_taskana
<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
