### PR TITLE
TSK-1806: Bug fixes for Workbasket Distribution Targets

### DIFF
--- a/web/cypress/integration/workbaskets/workbaskets.spec.js
+++ b/web/cypress/integration/workbaskets/workbaskets.spec.js
@@ -197,11 +197,6 @@ context('TASKANA Workbaskets', () => {
     cy.get('#wb-custom-4').should('have.value', Cypress.env('testValueWorkbaskets'));
   });
 
-  it('should be possible', () => {
-    cy.visitTestWorkbasket();
-    cy.visitWorkbasketsDistributionTargetsPage();
-  });
-
   it('should be possible to remove all distribution targets', () => {
     cy.visitTestWorkbasket();
     cy.visitWorkbasketsDistributionTargetsPage();
@@ -216,5 +211,54 @@ context('TASKANA Workbaskets', () => {
       .should('have.length', 0);
 
     cy.undoWorkbaskets();
+  });
+
+  it('should filter selected distribution targets including newly transferred targets', () => {
+    cy.visitTestWorkbasket();
+    cy.visitWorkbasketsDistributionTargetsPage();
+
+    cy.get('#dual-list-Right > .distribution-targets-list > .mat-toolbar > :nth-child(2)').click();
+    cy.get(
+      '#dual-list-Right > .distribution-targets-list > taskana-shared-workbasket-filter > .filter > .filter__expanded-filter > .filter__text-input > :nth-child(1) > :nth-child(2) > .mat-form-field-wrapper > .mat-form-field-flex > .mat-form-field-infix > .mat-input-element'
+    )
+      .clear()
+      .type('002');
+    cy.get('.filter__action-buttons > .filter__search-button').click();
+
+    cy.get(
+      '#dual-list-Right > .distribution-targets-list > .mat-selection-list > .cdk-virtual-scroll-viewport > .cdk-virtual-scroll-content-wrapper > :nth-child(1)'
+    ).should('contain.text', 'Basxet1');
+
+    cy.get('.filter__action-buttons > [mattooltip="Clear Workbasket filter"]').click();
+
+    cy.get(
+      '#dual-list-Right > .distribution-targets-list > .mat-selection-list > .cdk-virtual-scroll-viewport > .cdk-virtual-scroll-content-wrapper'
+    )
+      .children()
+      .should('have.length', 2);
+  });
+
+  it('should filter available distribution targets', () => {
+    cy.visitTestWorkbasket();
+    cy.visitWorkbasketsDistributionTargetsPage();
+
+    cy.get('#dual-list-Left > .distribution-targets-list > .mat-toolbar > :nth-child(2)').click();
+    cy.get(
+      '#dual-list-Left > .distribution-targets-list > taskana-shared-workbasket-filter > .filter > .filter__expanded-filter > .filter__text-input > :nth-child(1) > :nth-child(2) > .mat-form-field-wrapper > .mat-form-field-flex > .mat-form-field-infix > .mat-input-element'
+    )
+      .clear()
+      .type('008');
+
+    cy.get('.filter__action-buttons > .filter__search-button').click();
+
+    cy.get(
+      '#dual-list-Left > .distribution-targets-list > .mat-selection-list > .cdk-virtual-scroll-viewport > .cdk-virtual-scroll-content-wrapper'
+    )
+      .children()
+      .should('have.length', 1);
+
+    cy.get(
+      '#dual-list-Left > .distribution-targets-list > .mat-selection-list > .cdk-virtual-scroll-viewport > .cdk-virtual-scroll-content-wrapper > :nth-child(1)'
+    ).should('contain.text', 'BAsxet7');
   });
 });

--- a/web/src/app/administration/components/workbasket-details/workbasket-details.component.ts
+++ b/web/src/app/administration/components/workbasket-details/workbasket-details.component.ts
@@ -15,6 +15,7 @@ import {
   CopyWorkbasket,
   DeselectWorkbasket,
   OnButtonPressed,
+  SaveNewWorkbasket,
   SelectComponent,
   UpdateWorkbasket,
   UpdateWorkbasketDistributionTargets
@@ -83,6 +84,22 @@ export class WorkbasketDetailsComponent implements OnInit, OnDestroy {
 
     // c) saving the workbasket
     this.ngxsActions$.pipe(ofActionSuccessful(UpdateWorkbasket), takeUntil(this.destroy$)).subscribe(() => {
+      this.store
+        .dispatch(new UpdateWorkbasketDistributionTargets())
+        .pipe(takeUntil(this.destroy$))
+        .subscribe(() => {
+          this.selectedWorkbasket$
+            .pipe(
+              take(5),
+              timeout(250),
+              catchError(() => of(null)),
+              filter((val) => val !== null)
+            )
+            .subscribe((wb) => (this.workbasket = wb));
+        });
+    });
+
+    this.ngxsActions$.pipe(ofActionSuccessful(SaveNewWorkbasket), takeUntil(this.destroy$)).subscribe(() => {
       this.store
         .dispatch(new UpdateWorkbasketDistributionTargets())
         .pipe(takeUntil(this.destroy$))

--- a/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.ts
+++ b/web/src/app/administration/components/workbasket-distribution-targets/workbasket-distribution-targets.component.ts
@@ -3,14 +3,12 @@ import { forkJoin, Observable, Subject } from 'rxjs';
 
 import { Workbasket } from 'app/shared/models/workbasket';
 import { WorkbasketSummary } from 'app/shared/models/workbasket-summary';
-import { Actions, ofActionCompleted, Select, Store } from '@ngxs/store';
+import { Actions, Select, Store } from '@ngxs/store';
 import { filter, take, takeUntil } from 'rxjs/operators';
 import { NotificationService } from '../../../shared/services/notifications/notification.service';
 import {
   FetchAvailableDistributionTargets,
   FetchWorkbasketDistributionTargets,
-  SaveNewWorkbasket,
-  UpdateWorkbasket,
   UpdateWorkbasketDistributionTargets
 } from '../../../shared/store/workbasket-store/workbasket.actions';
 import { WorkbasketSelectors } from '../../../shared/store/workbasket-store/workbasket.selectors';


### PR DESCRIPTION
Bug fixes:
- Changes no longer get discarded when switching tabs
- Saving of Workbasket Distribution Targets is now possible from all tabs
- Saving of Workbasket Distribution Targets now works correctly and does not throw an error 400
- Removing of Distribution Targets now works correctly
- Removed loading of duplicate distribution targets
- Made filtering work again
- Creating a new Workbasket with distribution targets:
  - Shows Distribution Targets
  - Saves selected Distribution Targets
  - Does not show selected Distribution Targets in available after saving

-   Added E2E tests for most previously mentioned bugs

<!-- if needed please write above the given line -->
---
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [x] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [x] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [x] Readability
