### PR TITLE
TSK-1944: Implemented BeforeRequestChanges SPI

### DIFF
--- a/lib/taskana-core-test/src/test/java/acceptance/task/requestchanges/RequestChangesWithAfterSpiAccTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/task/requestchanges/RequestChangesWithAfterSpiAccTest.java
@@ -38,7 +38,7 @@ import pro.taskana.workbasket.api.WorkbasketService;
 import pro.taskana.workbasket.api.models.WorkbasketSummary;
 
 @TaskanaIntegrationTest
-public class RequestChangesWithSpiAccTest {
+public class RequestChangesWithAfterSpiAccTest {
 
   private static final String NEW_WORKBASKET_KEY = "W1000";
   ClassificationSummary defaultClassificationSummary;

--- a/lib/taskana-core-test/src/test/java/acceptance/task/requestchanges/RequestChangesWithBeforeSpiAccTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/task/requestchanges/RequestChangesWithBeforeSpiAccTest.java
@@ -1,0 +1,312 @@
+package acceptance.task.requestchanges;
+
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static pro.taskana.common.internal.util.CheckedSupplier.wrap;
+import static pro.taskana.testapi.DefaultTestEntities.defaultTestClassification;
+import static pro.taskana.testapi.DefaultTestEntities.defaultTestWorkbasket;
+
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.TestInstance.Lifecycle;
+
+import pro.taskana.TaskanaEngineConfiguration;
+import pro.taskana.classification.api.ClassificationService;
+import pro.taskana.classification.api.models.Classification;
+import pro.taskana.classification.api.models.ClassificationSummary;
+import pro.taskana.common.api.TaskanaEngine;
+import pro.taskana.common.api.exceptions.SystemException;
+import pro.taskana.common.internal.jobs.PlainJavaTransactionProvider;
+import pro.taskana.spi.task.api.BeforeRequestChangesProvider;
+import pro.taskana.task.api.TaskCustomField;
+import pro.taskana.task.api.TaskService;
+import pro.taskana.task.api.TaskState;
+import pro.taskana.task.api.exceptions.InvalidOwnerException;
+import pro.taskana.task.api.models.ObjectReference;
+import pro.taskana.task.api.models.Task;
+import pro.taskana.testapi.DefaultTestEntities;
+import pro.taskana.testapi.TaskanaInject;
+import pro.taskana.testapi.TaskanaIntegrationTest;
+import pro.taskana.testapi.WithServiceProvider;
+import pro.taskana.testapi.builder.TaskBuilder;
+import pro.taskana.testapi.builder.WorkbasketAccessItemBuilder;
+import pro.taskana.testapi.security.WithAccessId;
+import pro.taskana.workbasket.api.WorkbasketPermission;
+import pro.taskana.workbasket.api.WorkbasketService;
+import pro.taskana.workbasket.api.models.WorkbasketSummary;
+
+@TaskanaIntegrationTest
+public class RequestChangesWithBeforeSpiAccTest {
+
+  ClassificationSummary defaultClassificationSummary;
+  WorkbasketSummary defaultWorkbasketSummary;
+  ObjectReference defaultObjectReference;
+
+  @WithAccessId(user = "businessadmin")
+  @BeforeAll
+  void setup(ClassificationService classificationService, WorkbasketService workbasketService)
+      throws Exception {
+    defaultClassificationSummary =
+        defaultTestClassification().buildAndStoreAsSummary(classificationService);
+    defaultWorkbasketSummary = defaultTestWorkbasket().buildAndStoreAsSummary(workbasketService);
+
+    WorkbasketAccessItemBuilder.newWorkbasketAccessItem()
+        .workbasketId(defaultWorkbasketSummary.getId())
+        .accessId("user-1-1")
+        .permission(WorkbasketPermission.READ)
+        .permission(WorkbasketPermission.APPEND)
+        .permission(WorkbasketPermission.TRANSFER)
+        .buildAndStore(workbasketService);
+
+    defaultObjectReference = DefaultTestEntities.defaultTestObjectReference().build();
+  }
+
+  private TaskBuilder createTaskInReviewByUser(String owner) {
+    return createDefaultTask().owner(owner).state(TaskState.IN_REVIEW);
+  }
+
+  private TaskBuilder createDefaultTask() {
+    return TaskBuilder.newTask()
+        .classificationSummary(defaultClassificationSummary)
+        .workbasketSummary(defaultWorkbasketSummary)
+        .primaryObjRef(defaultObjectReference);
+  }
+
+  static class ExceptionThrower implements BeforeRequestChangesProvider {
+
+    private TaskanaEngine taskanaEngine;
+
+    @Override
+    public void initialize(TaskanaEngine taskanaEngine) {
+      this.taskanaEngine = taskanaEngine;
+    }
+
+    @Override
+    public Task beforeRequestChanges(Task task) throws Exception {
+      task.setDescription("should not matter. Will get rolled back anyway");
+      taskanaEngine.getTaskService().updateTask(task);
+      throw new SystemException("I AM THE EXCEPTION THROWER (*_*)");
+    }
+  }
+
+  static class TaskModifier implements BeforeRequestChangesProvider {
+    private static final String NEW_CUSTOM_3_VALUE = "bla";
+
+    private TaskanaEngine taskanaEngine;
+
+    @Override
+    public void initialize(TaskanaEngine taskanaEngine) {
+      this.taskanaEngine = taskanaEngine;
+    }
+
+    @Override
+    public Task beforeRequestChanges(Task task) throws Exception {
+      task.setCustomField(TaskCustomField.CUSTOM_3, NEW_CUSTOM_3_VALUE);
+      task = taskanaEngine.getTaskService().updateTask(task);
+      return task;
+    }
+  }
+
+  static class ClassificationUpdater implements BeforeRequestChangesProvider {
+
+    public static final String SPI_CLASSIFICATION_NAME = "Neuer Classification Name";
+
+    private TaskanaEngine taskanaEngine;
+
+    @Override
+    public void initialize(TaskanaEngine taskanaEngine) {
+      this.taskanaEngine = taskanaEngine;
+    }
+
+    @Override
+    public Task beforeRequestChanges(Task task) throws Exception {
+      Classification newClassification =
+          defaultTestClassification().buildAndStore(taskanaEngine.getClassificationService());
+
+      task.setClassificationKey(newClassification.getKey());
+      task = taskanaEngine.getTaskService().updateTask(task);
+
+      newClassification.setName(SPI_CLASSIFICATION_NAME);
+      taskanaEngine.getClassificationService().updateClassification(newClassification);
+
+      return task;
+    }
+  }
+
+  static class SetTaskOwner implements BeforeRequestChangesProvider {
+
+    TaskanaEngine taskanaEngine;
+
+    @Override
+    public void initialize(TaskanaEngine taskanaEngine) {
+      this.taskanaEngine = taskanaEngine;
+    }
+
+    @Override
+    public Task beforeRequestChanges(Task task) throws Exception {
+      task.setOwner("new owner");
+      return taskanaEngine.getTaskService().updateTask(task);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeRequestChangesProvider.class,
+      serviceProviders = TaskModifier.class)
+  class SpiModifiesTask {
+
+    @TaskanaInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_ReturnModifiedTask_When_SpiModifiesAndTransfersTask() throws Exception {
+      Task task = createTaskInReviewByUser("user-1-1").buildAndStore(taskService);
+
+      Task result = taskService.requestChanges(task.getId());
+
+      assertThat(result.getCustomField(TaskCustomField.CUSTOM_3))
+          .isEqualTo(TaskModifier.NEW_CUSTOM_3_VALUE);
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_ReturnPersistentModifiedTask_When_SpiModifiesAndTransfersTask() throws Exception {
+      Task task = createTaskInReviewByUser("user-1-1").buildAndStore(taskService);
+
+      taskService.requestChanges(task.getId());
+      Task result = taskService.getTask(task.getId());
+
+      assertThat(result.getCustomField(TaskCustomField.CUSTOM_3))
+          .isEqualTo(TaskModifier.NEW_CUSTOM_3_VALUE);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeRequestChangesProvider.class,
+      serviceProviders = SetTaskOwner.class)
+  class SpiSetsValuesWhichGetOverridenByTaskana {
+
+    @TaskanaInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_OverrideOwner_When_SpiModifiesOwner() throws Exception {
+      Task task = createTaskInReviewByUser("user-1-1").buildAndStore(taskService);
+
+      taskService.forceRequestChanges(task.getId());
+      Task result = taskService.getTask(task.getId());
+
+      assertThat(result.getOwner()).isNull();
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_ThrowError_When_SpiModifiesOwner() throws Exception {
+      Task task = createTaskInReviewByUser("user-1-1").buildAndStore(taskService);
+
+      ThrowingCallable call = () -> taskService.requestChanges(task.getId());
+
+      InvalidOwnerException ex = catchThrowableOfType(call, InvalidOwnerException.class);
+      assertThat(ex.getTaskId()).isEqualTo(task.getId());
+      assertThat(ex.getCurrentUserId()).isEqualTo("user-1-1");
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeRequestChangesProvider.class,
+      serviceProviders = ClassificationUpdater.class)
+  class SpiModifiesTaskAndClassification {
+
+    @TaskanaInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1", groups = "businessadmin")
+    @Test
+    void should_ChangeMultipleEntities_When_SpiModifiesMoreThanTheTask() throws Exception {
+      Task task = createTaskInReviewByUser("user-1-1").buildAndStore(taskService);
+
+      taskService.requestChanges(task.getId());
+      Task result = taskService.getTask(task.getId());
+
+      assertThat(result.getClassificationSummary().getId())
+          .isNotEqualTo(task.getClassificationSummary().getId());
+      assertThat(result.getClassificationSummary().getName())
+          .isEqualTo(ClassificationUpdater.SPI_CLASSIFICATION_NAME);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeRequestChangesProvider.class,
+      serviceProviders = {TaskModifier.class, ClassificationUpdater.class})
+  class MultipleSpisAreDefined {
+
+    @TaskanaInject TaskService taskService;
+
+    @WithAccessId(user = "user-1-1", groups = "businessadmin")
+    @Test
+    void should_ApplyMultipleChanges_When_MultipleSpisAreChained() throws Exception {
+      Task task = createTaskInReviewByUser("user-1-1").buildAndStore(taskService);
+
+      taskService.requestChanges(task.getId());
+      Task result = taskService.getTask(task.getId());
+
+      // changes from TaskModifier
+      assertThat(result.getCustomField(TaskCustomField.CUSTOM_3))
+          .isEqualTo(TaskModifier.NEW_CUSTOM_3_VALUE);
+      // changes from ClassificationUpdater
+      assertThat(result.getClassificationSummary().getId())
+          .isNotEqualTo(task.getClassificationSummary().getId());
+      assertThat(result.getClassificationSummary().getName())
+          .isEqualTo(ClassificationUpdater.SPI_CLASSIFICATION_NAME);
+    }
+  }
+
+  @Nested
+  @TestInstance(Lifecycle.PER_CLASS)
+  @WithServiceProvider(
+      serviceProviderInterface = BeforeRequestChangesProvider.class,
+      serviceProviders = ExceptionThrower.class)
+  class SpiThrowsException {
+    @TaskanaInject TaskService taskService;
+    @TaskanaInject TaskanaEngine taskanaEngine;
+    PlainJavaTransactionProvider transactionProvider;
+
+    @BeforeAll
+    void setup(TaskanaEngineConfiguration taskanaEngineConfiguration) {
+      transactionProvider =
+          new PlainJavaTransactionProvider(
+              taskanaEngine, taskanaEngineConfiguration.getDatasource());
+    }
+
+    @WithAccessId(user = "user-1-1")
+    @Test
+    void should_RollbackTransaction_When_SpiThrowsAnException() throws Exception {
+      Task task = createTaskInReviewByUser("user-1-1").buildAndStore(taskService);
+
+      ThrowingCallable call =
+          () ->
+              transactionProvider.executeInTransaction(
+                  wrap(() -> taskService.requestChanges(task.getId())));
+
+      assertThatThrownBy(call)
+          .isInstanceOf(SystemException.class)
+          .getCause() // unwrap the "wrap" within "call"
+          .hasMessage("service provider '%s' threw an exception", ExceptionThrower.class.getName())
+          .getCause() // unwrap the "wrap" from the service provider manager
+          .hasMessage("I AM THE EXCEPTION THROWER (*_*)");
+
+      Task persistentTask = taskService.getTask(task.getId());
+      assertThat(persistentTask).isEqualTo(task);
+    }
+  }
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/common/internal/InternalTaskanaEngine.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/common/internal/InternalTaskanaEngine.java
@@ -9,6 +9,7 @@ import pro.taskana.spi.priority.internal.PriorityServiceManager;
 import pro.taskana.spi.routing.internal.TaskRoutingManager;
 import pro.taskana.spi.task.internal.AfterRequestChangesManager;
 import pro.taskana.spi.task.internal.AfterRequestReviewManager;
+import pro.taskana.spi.task.internal.BeforeRequestChangesManager;
 import pro.taskana.spi.task.internal.BeforeRequestReviewManager;
 import pro.taskana.spi.task.internal.CreateTaskPreprocessorManager;
 import pro.taskana.spi.task.internal.ReviewRequiredManager;
@@ -130,6 +131,13 @@ public interface InternalTaskanaEngine {
    * @return the {@linkplain AfterRequestReviewManager} instance
    */
   AfterRequestReviewManager getAfterRequestReviewManager();
+
+  /**
+   * Retrieves the {@linkplain BeforeRequestChangesManager}.
+   *
+   * @return the {@linkplain BeforeRequestChangesManager} instance
+   */
+  BeforeRequestChangesManager getBeforeRequestChangesManager();
 
   /**
    * Retrieves the {@linkplain AfterRequestChangesManager}.

--- a/lib/taskana-core/src/main/java/pro/taskana/common/internal/TaskanaEngineImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/common/internal/TaskanaEngineImpl.java
@@ -55,6 +55,7 @@ import pro.taskana.spi.priority.internal.PriorityServiceManager;
 import pro.taskana.spi.routing.internal.TaskRoutingManager;
 import pro.taskana.spi.task.internal.AfterRequestChangesManager;
 import pro.taskana.spi.task.internal.AfterRequestReviewManager;
+import pro.taskana.spi.task.internal.BeforeRequestChangesManager;
 import pro.taskana.spi.task.internal.BeforeRequestReviewManager;
 import pro.taskana.spi.task.internal.CreateTaskPreprocessorManager;
 import pro.taskana.spi.task.internal.ReviewRequiredManager;
@@ -89,6 +90,7 @@ public class TaskanaEngineImpl implements TaskanaEngine {
   private final ReviewRequiredManager reviewRequiredManager;
   private final BeforeRequestReviewManager beforeRequestReviewManager;
   private final AfterRequestReviewManager afterRequestReviewManager;
+  private final BeforeRequestChangesManager beforeRequestChangesManager;
   private final AfterRequestChangesManager afterRequestChangesManager;
 
   private final InternalTaskanaEngineImpl internalTaskanaEngineImpl;
@@ -129,6 +131,7 @@ public class TaskanaEngineImpl implements TaskanaEngine {
     reviewRequiredManager = new ReviewRequiredManager(this);
     beforeRequestReviewManager = new BeforeRequestReviewManager(this);
     afterRequestReviewManager = new AfterRequestReviewManager(this);
+    beforeRequestChangesManager = new BeforeRequestChangesManager(this);
     afterRequestChangesManager = new AfterRequestChangesManager(this);
   }
 
@@ -548,6 +551,11 @@ public class TaskanaEngineImpl implements TaskanaEngine {
     @Override
     public AfterRequestReviewManager getAfterRequestReviewManager() {
       return afterRequestReviewManager;
+    }
+
+    @Override
+    public BeforeRequestChangesManager getBeforeRequestChangesManager() {
+      return beforeRequestChangesManager;
     }
 
     @Override

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/AfterRequestChangesProvider.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/AfterRequestChangesProvider.java
@@ -23,7 +23,8 @@ public interface AfterRequestChangesProvider {
 
   /**
    * Perform any action after changes have been requested on a {@linkplain Task} through {@linkplain
-   * pro.taskana.task.api.TaskService#requestChanges(String)}.
+   * pro.taskana.task.api.TaskService#requestChanges(String)} or {@linkplain
+   * pro.taskana.task.api.TaskService#forceRequestChanges(String)}.
    *
    * <p>This SPI is executed within the same transaction staple as {@linkplain
    * pro.taskana.task.api.TaskService#requestChanges(String)}.
@@ -34,7 +35,8 @@ public interface AfterRequestChangesProvider {
    * pro.taskana.task.api.TaskService#requestChanges(String)}.
    *
    * @param task the {@linkplain Task} after {@linkplain
-   *     pro.taskana.task.api.TaskService#requestChanges(String)} has completed
+   *     pro.taskana.task.api.TaskService#requestChanges(String)} or {@linkplain
+   *     pro.taskana.task.api.TaskService#forceRequestChanges(String)} has completed
    * @return the modified {@linkplain Task}. <b>IMPORTANT:</b> persistent changes to the {@linkplain
    *     Task} have to be managed by the service provider
    * @throws Exception if the service provider throws any exception

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/AfterRequestReviewProvider.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/AfterRequestReviewProvider.java
@@ -23,7 +23,8 @@ public interface AfterRequestReviewProvider {
 
   /**
    * Perform any action after a review has been requested on a {@linkplain Task} through {@linkplain
-   * pro.taskana.task.api.TaskService#requestReview(String)}.
+   * pro.taskana.task.api.TaskService#requestReview(String)} or {@linkplain
+   * pro.taskana.task.api.TaskService#forceRequestReview(String)}.
    *
    * <p>This SPI is executed within the same transaction staple as {@linkplain
    * pro.taskana.task.api.TaskService#requestReview(String)}.
@@ -34,7 +35,8 @@ public interface AfterRequestReviewProvider {
    * pro.taskana.task.api.TaskService#requestReview(String)}.
    *
    * @param task the {@linkplain Task} after {@linkplain
-   *     pro.taskana.task.api.TaskService#requestReview(String)} has completed
+   *     pro.taskana.task.api.TaskService#requestReview(String)} or {@linkplain
+   *     pro.taskana.task.api.TaskService#forceRequestReview(String)} has completed
    * @return the modified {@linkplain Task}. <b>IMPORTANT:</b> persistent changes to the {@linkplain
    *     Task} have to be managed by the service provider
    * @throws Exception if the service provider throws any exception

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/BeforeRequestChangesProvider.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/BeforeRequestChangesProvider.java
@@ -1,0 +1,43 @@
+package pro.taskana.spi.task.api;
+
+import pro.taskana.common.api.TaskanaEngine;
+import pro.taskana.task.api.models.Task;
+
+/**
+ * The BeforeRequestChangesProvider allows to implement customized behaviour before changes have
+ * been requested on a given {@linkplain Task}.
+ */
+public interface BeforeRequestChangesProvider {
+
+  /**
+   * Provide the active {@linkplain TaskanaEngine} which is initialized for this TASKANA
+   * installation.
+   *
+   * <p>This method is called during TASKANA startup and allows the service provider to store the
+   * active {@linkplain TaskanaEngine} for later usage.
+   *
+   * @param taskanaEngine the active {@linkplain TaskanaEngine} which is initialized for this
+   *     installation
+   */
+  void initialize(TaskanaEngine taskanaEngine);
+
+  /**
+   * Perform any action before changes have been requested on a {@linkplain Task} through
+   * {@linkplain pro.taskana.task.api.TaskService#requestChanges(String)}.
+   *
+   * <p>This SPI is executed within the same transaction staple as {@linkplain
+   * pro.taskana.task.api.TaskService#requestChanges(String)}.
+   *
+   * <p>This SPI is executed with the same {@linkplain
+   * pro.taskana.common.api.security.UserPrincipal} and {@linkplain
+   * pro.taskana.common.api.security.GroupPrincipal} as in {@linkplain
+   * pro.taskana.task.api.TaskService#requestChanges(String)}.
+   *
+   * @param task the {@linkplain Task} before {@linkplain
+   *     pro.taskana.task.api.TaskService#requestChanges(String)} has started
+   * @return the modified {@linkplain Task}. <b>IMPORTANT:</b> persistent changes to the {@linkplain
+   *     Task} have to be managed by the service provider
+   * @throws Exception if the service provider throws any exception
+   */
+  Task beforeRequestChanges(Task task) throws Exception;
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/BeforeRequestChangesProvider.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/BeforeRequestChangesProvider.java
@@ -23,7 +23,8 @@ public interface BeforeRequestChangesProvider {
 
   /**
    * Perform any action before changes have been requested on a {@linkplain Task} through
-   * {@linkplain pro.taskana.task.api.TaskService#requestChanges(String)}.
+   * {@linkplain pro.taskana.task.api.TaskService#requestChanges(String)} or {@linkplain
+   * pro.taskana.task.api.TaskService#forceRequestChanges(String)}.
    *
    * <p>This SPI is executed within the same transaction staple as {@linkplain
    * pro.taskana.task.api.TaskService#requestChanges(String)}.
@@ -34,7 +35,8 @@ public interface BeforeRequestChangesProvider {
    * pro.taskana.task.api.TaskService#requestChanges(String)}.
    *
    * @param task the {@linkplain Task} before {@linkplain
-   *     pro.taskana.task.api.TaskService#requestChanges(String)} has started
+   *     pro.taskana.task.api.TaskService#requestChanges(String)} or {@linkplain
+   *     pro.taskana.task.api.TaskService#forceRequestChanges(String)} has started
    * @return the modified {@linkplain Task}. <b>IMPORTANT:</b> persistent changes to the {@linkplain
    *     Task} have to be managed by the service provider
    * @throws Exception if the service provider throws any exception

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/BeforeRequestReviewProvider.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/BeforeRequestReviewProvider.java
@@ -23,7 +23,8 @@ public interface BeforeRequestReviewProvider {
 
   /**
    * Perform any action before a review has been requested on a {@linkplain Task} through
-   * {@linkplain pro.taskana.task.api.TaskService#requestReview(String)}.
+   * {@linkplain pro.taskana.task.api.TaskService#requestReview(String)} or {@linkplain
+   * pro.taskana.task.api.TaskService#forceRequestReview(String)}.
    *
    * <p>This SPI is executed within the same transaction staple as {@linkplain
    * pro.taskana.task.api.TaskService#requestReview(String)}.
@@ -34,7 +35,8 @@ public interface BeforeRequestReviewProvider {
    * pro.taskana.task.api.TaskService#requestReview(String)}.
    *
    * @param task the {@linkplain Task} before {@linkplain
-   *     pro.taskana.task.api.TaskService#requestReview(String)} has started
+   *     pro.taskana.task.api.TaskService#requestReview(String)} or {@linkplain
+   *     pro.taskana.task.api.TaskService#forceRequestReview(String)} has started
    * @return the modified {@linkplain Task}. <b>IMPORTANT:</b> persistent changes to the {@linkplain
    *     Task} have to be managed by the service provider
    * @throws Exception if the service provider throws any exception

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/AfterRequestChangesManager.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/AfterRequestChangesManager.java
@@ -33,7 +33,7 @@ public class AfterRequestChangesManager {
 
   public Task afterRequestChanges(Task task) {
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Sending Task to AfterRequestChanges service providers: {}", task);
+      LOGGER.debug("Sending Task to AfterRequestChangesProvider service providers: {}", task);
     }
     for (AfterRequestChangesProvider serviceProvider : afterRequestChangesProviders) {
       try {

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/AfterRequestReviewManager.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/AfterRequestReviewManager.java
@@ -33,7 +33,7 @@ public class AfterRequestReviewManager {
 
   public Task afterRequestReview(Task task) {
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Sending Task to AfterRequestReview service providers: {}", task);
+      LOGGER.debug("Sending Task to AfterRequestReviewProvider service providers: {}", task);
     }
     for (AfterRequestReviewProvider serviceProvider : afterRequestReviewProviders) {
       try {

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/BeforeRequestChangesManager.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/BeforeRequestChangesManager.java
@@ -1,0 +1,50 @@
+package pro.taskana.spi.task.internal;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import pro.taskana.common.api.TaskanaEngine;
+import pro.taskana.common.api.exceptions.SystemException;
+import pro.taskana.common.internal.util.SpiLoader;
+import pro.taskana.spi.task.api.BeforeRequestChangesProvider;
+import pro.taskana.task.api.models.Task;
+
+public class BeforeRequestChangesManager {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BeforeRequestChangesManager.class);
+
+  private final List<BeforeRequestChangesProvider> beforeRequestChangesProviders;
+
+  public BeforeRequestChangesManager(TaskanaEngine taskanaEngine) {
+    beforeRequestChangesProviders = SpiLoader.load(BeforeRequestChangesProvider.class);
+    for (BeforeRequestChangesProvider serviceProvider : beforeRequestChangesProviders) {
+      serviceProvider.initialize(taskanaEngine);
+      LOGGER.info(
+          "Registered BeforeRequestChangesProvider service provider: {}",
+          serviceProvider.getClass().getName());
+    }
+    if (beforeRequestChangesProviders.isEmpty()) {
+      LOGGER.info(
+          "No BeforeRequestChangesProvider service provider found. "
+              + "Running without any BeforeRequestChangesProvider implementation.");
+    }
+  }
+
+  public Task beforeRequestChanges(Task task) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Sending Task to BeforeRequestChangesProvider service providers: {}", task);
+    }
+    for (BeforeRequestChangesProvider serviceProvider : beforeRequestChangesProviders) {
+      try {
+        task = serviceProvider.beforeRequestChanges(task);
+      } catch (Exception e) {
+        throw new SystemException(
+            String.format(
+                "service provider '%s' threw an exception", serviceProvider.getClass().getName()),
+            e);
+      }
+    }
+    return task;
+  }
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/BeforeRequestReviewManager.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/BeforeRequestReviewManager.java
@@ -33,7 +33,7 @@ public class BeforeRequestReviewManager {
 
   public Task beforeRequestReview(Task task) {
     if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("Sending Task to BeforeRequestReview service providers: {}", task);
+      LOGGER.debug("Sending Task to BeforeRequestReviewProvider service providers: {}", task);
     }
     for (BeforeRequestReviewProvider serviceProvider : beforeRequestReviewProviders) {
       try {

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskServiceImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskServiceImpl.java
@@ -55,6 +55,7 @@ import pro.taskana.spi.history.internal.HistoryEventManager;
 import pro.taskana.spi.priority.internal.PriorityServiceManager;
 import pro.taskana.spi.task.internal.AfterRequestChangesManager;
 import pro.taskana.spi.task.internal.AfterRequestReviewManager;
+import pro.taskana.spi.task.internal.BeforeRequestChangesManager;
 import pro.taskana.spi.task.internal.BeforeRequestReviewManager;
 import pro.taskana.spi.task.internal.CreateTaskPreprocessorManager;
 import pro.taskana.spi.task.internal.ReviewRequiredManager;
@@ -121,6 +122,7 @@ public class TaskServiceImpl implements TaskService {
   private final ReviewRequiredManager reviewRequiredManager;
   private final BeforeRequestReviewManager beforeRequestReviewManager;
   private final AfterRequestReviewManager afterRequestReviewManager;
+  private final BeforeRequestChangesManager beforeRequestChangesManager;
   private final AfterRequestChangesManager afterRequestChangesManager;
 
   public TaskServiceImpl(
@@ -143,6 +145,7 @@ public class TaskServiceImpl implements TaskService {
     this.reviewRequiredManager = taskanaEngine.getReviewRequiredManager();
     this.beforeRequestReviewManager = taskanaEngine.getBeforeRequestReviewManager();
     this.afterRequestReviewManager = taskanaEngine.getAfterRequestReviewManager();
+    this.beforeRequestChangesManager = taskanaEngine.getBeforeRequestChangesManager();
     this.afterRequestChangesManager = taskanaEngine.getAfterRequestChangesManager();
     this.taskTransferrer = new TaskTransferrer(taskanaEngine, taskMapper, this);
     this.taskCommentService =
@@ -1289,6 +1292,7 @@ public class TaskServiceImpl implements TaskService {
     try {
       taskanaEngine.openConnection();
       task = (TaskImpl) getTask(taskId);
+      task = (TaskImpl) beforeRequestChangesManager.beforeRequestChanges(task);
 
       TaskImpl oldTask = duplicateTaskExactly(task);
 

--- a/lib/taskana-test-api/src/main/java/pro/taskana/testapi/util/ServiceProviderExtractor.java
+++ b/lib/taskana-test-api/src/main/java/pro/taskana/testapi/util/ServiceProviderExtractor.java
@@ -17,6 +17,7 @@ import pro.taskana.spi.priority.api.PriorityServiceProvider;
 import pro.taskana.spi.routing.api.TaskRoutingProvider;
 import pro.taskana.spi.task.api.AfterRequestChangesProvider;
 import pro.taskana.spi.task.api.AfterRequestReviewProvider;
+import pro.taskana.spi.task.api.BeforeRequestChangesProvider;
 import pro.taskana.spi.task.api.BeforeRequestReviewProvider;
 import pro.taskana.spi.task.api.CreateTaskPreprocessor;
 import pro.taskana.spi.task.api.ReviewRequiredProvider;
@@ -33,6 +34,7 @@ public class ServiceProviderExtractor {
           ReviewRequiredProvider.class,
           BeforeRequestReviewProvider.class,
           AfterRequestReviewProvider.class,
+          BeforeRequestChangesProvider.class,
           AfterRequestChangesProvider.class);
 
   private ServiceProviderExtractor() {


### PR DESCRIPTION
sonar: https://sonarcloud.io/summary/new_code?id=mustaphazorgati_taskana&branch=task%2F1944

IMPORTANT: #1990 has to be merged BEFORE this.

<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```
**NEW**
* TSK-1945: added BeforeRequestChangesProvider which allows customized behavior before changes have been requested on a given Task.
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
