### PR TITLE
TSK-1699 - Register CustomEditor for String[]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 ### GENERATED ###
 target/
+routing/taskana-routing-rest/target\\routing.dmn
 .apt_generated/
 .checkstyle
 bin/

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/InitBinderControllerAdvice.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/InitBinderControllerAdvice.java
@@ -2,6 +2,7 @@ package pro.taskana.common.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.propertyeditors.StringArrayPropertyEditor;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.InitBinder;
@@ -11,12 +12,12 @@ import pro.taskana.task.api.models.ObjectReference;
 import pro.taskana.task.internal.models.ObjectReferenceImpl;
 
 @ControllerAdvice
-public class JsonPropertyEditorRegistrator {
+public class InitBinderControllerAdvice {
 
   private final ObjectMapper objectMapper;
 
   @Autowired
-  public JsonPropertyEditorRegistrator(ObjectMapper objectMapper) {
+  public InitBinderControllerAdvice(ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
   }
 
@@ -27,5 +28,6 @@ public class JsonPropertyEditorRegistrator {
         new JsonPropertyEditor(objectMapper, PriorityColumnHeaderRepresentationModel.class));
     binder.registerCustomEditor(
         ObjectReference.class, new JsonPropertyEditor(objectMapper, ObjectReferenceImpl.class));
+    binder.registerCustomEditor(String[].class, new StringArrayPropertyEditor(null));
   }
 }

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/workbasket/rest/WorkbasketAccessItemControllerIntTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/workbasket/rest/WorkbasketAccessItemControllerIntTest.java
@@ -104,6 +104,24 @@ class WorkbasketAccessItemControllerIntTest {
   }
 
   @Test
+  void should_notSplitQueryParameterByComma_When_accessId_containsTwo() {
+    String parameters =
+        "?sort-by=WORKBASKET_KEY&order=ASCENDING&page=1&page-size=9&access-id=user-1-1,user-1-2";
+    String url = restHelper.toUrl(RestEndpoints.URL_WORKBASKET_ACCESS_ITEMS) + parameters;
+    HttpEntity<Object> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ResponseEntity<WorkbasketAccessItemPagedRepresentationModel> response =
+        TEMPLATE.exchange(
+            url, HttpMethod.GET, auth, WORKBASKET_ACCESS_ITEM_PAGED_REPRESENTATION_MODEL_TYPE);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getContent()).hasSize(0);
+    assertThat(response.getBody().getPageMetadata().getSize()).isEqualTo(9);
+    assertThat(response.getBody().getPageMetadata().getTotalElements()).isEqualTo(0);
+    assertThat(response.getBody().getPageMetadata().getTotalPages()).isEqualTo(0);
+    assertThat(response.getBody().getPageMetadata().getNumber()).isEqualTo(1);
+  }
+
+  @Test
   void should_DeleteAllAccessItemForUser_ifValidAccessIdOfUserIsSupplied() {
     String url =
         restHelper.toUrl(RestEndpoints.URL_WORKBASKET_ACCESS_ITEMS) + "?access-id=teamlead-2";


### PR DESCRIPTION
all String[] parameters should not be splitted when only one parameter exists, with values delimited with comma

SonarCloud: https://sonarcloud.io/summary/new_code?id=arolfes_taskana&branch=TSK-1699-query-parameters

Sonar failes but I haven't touched this file at all

<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
