### PR TITLE
TSK-1980 Bump maven-surefire-plugin from 3.0.0-M5 to 3.0.0-M8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -57,7 +57,7 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           ./mvnw -B dependency:go-offline
-          ./mvnw -B test -Dtest=GibtEsNet -DfailIfNoTests=false
+          ./mvnw -B test -Dtest=GibtEsNet -Dsurefire.failIfNoSpecifiedTests=false
       - name: Upload taskana artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <version.maven.source>3.2.1</version.maven.source>
     <version.maven.javadoc>3.4.1</version.maven.javadoc>
     <version.maven.resources>3.3.0</version.maven.resources>
-    <version.maven.surefire>3.0.0-M5</version.maven.surefire>
+    <version.maven.surefire>3.0.0-M8</version.maven.surefire>
     <version.maven.asciidoctor>2.2.2</version.maven.asciidoctor>
     <version.maven.clean>3.2.0</version.maven.clean>
     <version.maven.dependency>3.5.0</version.maven.dependency>


### PR DESCRIPTION
https://sonarcloud.io/summary/new_code?id=arolfes_taskana&branch=TSK-1980-bump-surefire-plugin

---
Release Notes:
```
TSK-1980 Bump maven-surefire-plugin from 3.0.0-M5 to 3.0.0-M8
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
