### PR TITLE
Tsk-1998 use db enum to determine sql scripts

### DIFF
--- a/common/taskana-common/src/main/java/pro/taskana/common/internal/configuration/DB.java
+++ b/common/taskana-common/src/main/java/pro/taskana/common/internal/configuration/DB.java
@@ -9,17 +9,29 @@ import pro.taskana.common.api.exceptions.UnsupportedDatabaseException;
 
 /** Supported versions of databases. */
 public enum DB {
-  H2("H2", "h2"),
-  DB2("DB2", "db2"),
-  ORACLE("Oracle", "oracle"),
-  POSTGRES("PostgreSQL", "postgres");
+  H2("H2", "h2", "/sql/h2/schema-detection-h2.sql", "/sql/h2/taskana-schema-h2.sql"),
+  DB2("DB2", "db2", "/sql/db2/schema-detection-db2.sql", "/sql/db2/taskana-schema-db2.sql"),
+  ORACLE(
+      "Oracle",
+      "oracle",
+      "/sql/oracle/schema-detection-oracle.sql",
+      "/sql/oracle/taskana-schema-oracle.sql"),
+  POSTGRES(
+      "PostgreSQL",
+      "postgres",
+      "/sql/postgres/schema-detection-postgres.sql",
+      "/sql/postgres/taskana-schema-postgres.sql");
 
   public final String dbProductName;
   public final String dbProductId;
+  public final String detectionScript;
+  public final String schemaScript;
 
-  DB(String dbProductName, String dbProductId) {
+  DB(String dbProductName, String dbProductId, String detectionScript, String schemaScript) {
     this.dbProductName = dbProductName;
     this.dbProductId = dbProductId;
+    this.detectionScript = detectionScript;
+    this.schemaScript = schemaScript;
   }
 
   public static DB getDB(String dbProductId) {

--- a/common/taskana-common/src/main/java/pro/taskana/common/internal/configuration/DbSchemaCreator.java
+++ b/common/taskana-common/src/main/java/pro/taskana/common/internal/configuration/DbSchemaCreator.java
@@ -24,19 +24,6 @@ import pro.taskana.common.internal.util.ComparableVersion;
 public class DbSchemaCreator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DbSchemaCreator.class);
-  private static final String SQL = "/sql";
-
-  private static final String DB_SCHEMA_H2 = SQL + "/h2/taskana-schema-h2.sql";
-  private static final String DB_SCHEMA_DETECTION_H2 = SQL + "/h2/schema-detection-h2.sql";
-  private static final String DB_SCHEMA_DB2 = SQL + "/db2/taskana-schema-db2.sql";
-  private static final String DB_SCHEMA_DETECTION_DB2 = SQL + "/db2/schema-detection-db2.sql";
-  private static final String DB_SCHEMA_ORACLE = SQL + "/oracle/taskana-schema-oracle.sql";
-  private static final String DB_SCHEMA_DETECTION_ORACLE =
-      SQL + "/oracle/schema-detection-oracle.sql";
-  private static final String DB_SCHEMA_POSTGRES = SQL + "/postgres/taskana-schema-postgres.sql";
-  private static final String DB_SCHEMA_DETECTION_POSTGRES =
-      SQL + "/postgres/schema-detection-postgres.sql";
-
   private final String schemaName;
   private final StringWriter outWriter = new StringWriter();
   private final PrintWriter logWriter = new PrintWriter(outWriter);
@@ -68,7 +55,7 @@ public class DbSchemaCreator {
       ScriptRunner runner = getScriptRunnerInstance(connection);
 
       if (!isSchemaPreexisting(connection, db)) {
-        String scriptPath = selectDbScriptFileName(db);
+        String scriptPath = db.schemaScript;
         InputStream resourceAsStream = DbSchemaCreator.class.getResourceAsStream(scriptPath);
         BufferedReader reader =
             new BufferedReader(new InputStreamReader(resourceAsStream, StandardCharsets.UTF_8));
@@ -132,34 +119,6 @@ public class DbSchemaCreator {
     this.dataSource = dataSource;
   }
 
-  private static String selectDbScriptFileName(DB db) {
-
-    switch (db) {
-      case DB2:
-        return DB_SCHEMA_DB2;
-      case ORACLE:
-        return DB_SCHEMA_ORACLE;
-      case POSTGRES:
-        return DB_SCHEMA_POSTGRES;
-      default:
-        return DB_SCHEMA_H2;
-    }
-  }
-
-  private static String selectDbSchemaDetectionScript(DB db) {
-
-    switch (db) {
-      case DB2:
-        return DB_SCHEMA_DETECTION_DB2;
-      case ORACLE:
-        return DB_SCHEMA_DETECTION_ORACLE;
-      case POSTGRES:
-        return DB_SCHEMA_DETECTION_POSTGRES;
-      default:
-        return DB_SCHEMA_DETECTION_H2;
-    }
-  }
-
   private ScriptRunner getScriptRunnerInstance(Connection connection) {
     ScriptRunner runner = new ScriptRunner(connection);
     runner.setStopOnError(true);
@@ -172,7 +131,7 @@ public class DbSchemaCreator {
     ScriptRunner runner = getScriptRunnerInstance(connection);
     runner.setErrorLogWriter(errorLogWriter);
 
-    String scriptPath = selectDbSchemaDetectionScript(db);
+    String scriptPath = db.detectionScript;
     try (InputStream resource = DbSchemaCreator.class.getResourceAsStream(scriptPath);
         InputStreamReader inputReader = new InputStreamReader(resource, StandardCharsets.UTF_8);
         BufferedReader reader = new BufferedReader(inputReader)) {


### PR DESCRIPTION

[SonarCloud](https://sonarcloud.io/summary/new_code?id=arolfes_taskana&branch=TSK-1998-Use-DB-Enum-to-determine-SQL-Scripts)

Must be reviewed and merged after [TSK-1995 refactoring DB Enum](https://github.com/Taskana/taskana/pull/2100)

---
Release Notes:
<!-- Please write your release notes between ```-->
```
Tsk-1998 use db enum to determine sql scripts
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [X] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [X] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [X] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [X] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
