### PR TITLE
TSK-2013 selectAndClaim TasK return Optional and does not throw Exception if Task is notFound

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskService.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskService.java
@@ -3,6 +3,7 @@ package pro.taskana.task.api;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import pro.taskana.classification.api.exceptions.ClassificationNotFoundException;
 import pro.taskana.classification.api.models.Classification;
@@ -190,7 +191,7 @@ public interface TaskService {
    * @throws NotAuthorizedOnWorkbasketException if the current user has no {@linkplain
    *     WorkbasketPermission#READ} for the {@linkplain Workbasket} the {@linkplain Task} is in
    */
-  Task selectAndClaim(TaskQuery taskQuery)
+  Optional<Task> selectAndClaim(TaskQuery taskQuery)
       throws InvalidOwnerException, NotAuthorizedOnWorkbasketException;
 
   /**

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskController.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskController.java
@@ -5,6 +5,7 @@ import static java.util.function.Predicate.not;
 import java.beans.ConstructorProperties;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -233,7 +234,7 @@ public class TaskController {
    * @param filterCustomFields the filter parameters regarding TaskCustomFields
    * @param filterCustomIntFields the filter parameters regarding TaskCustomIntFields
    * @param sortParameter the sort parameters
-   * @return the claimed Task
+   * @return the claimed Task or 404 if no Task is found
    * @throws InvalidOwnerException if the Task is already claimed by someone else
    * @throws NotAuthorizedOnWorkbasketException if the current user has no read permission for the
    *     Workbasket the Task is in
@@ -254,9 +255,11 @@ public class TaskController {
     filterCustomIntFields.apply(query);
     sortParameter.apply(query);
 
-    Task selectedAndClaimedTask = taskService.selectAndClaim(query);
+    Optional<Task> selectedAndClaimedTask = taskService.selectAndClaim(query);
 
-    return ResponseEntity.ok(taskRepresentationModelAssembler.toModel(selectedAndClaimedTask));
+    return selectedAndClaimedTask
+        .map(task -> ResponseEntity.ok(taskRepresentationModelAssembler.toModel(task)))
+        .orElseGet(() -> ResponseEntity.notFound().build());
   }
 
   /**

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/assembler/TaskRepresentationModelAssembler.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/assembler/TaskRepresentationModelAssembler.java
@@ -51,7 +51,7 @@ public class TaskRepresentationModelAssembler
 
   @NonNull
   @Override
-  public TaskRepresentationModel toModel(@NonNull Task task) {
+  public TaskRepresentationModel toModel(Task task) {
     TaskRepresentationModel repModel = new TaskRepresentationModel();
     repModel.setTaskId(task.getId());
     repModel.setExternalId(task.getExternalId());


### PR DESCRIPTION


[SonarCloud](https://sonarcloud.io/summary/new_code?id=arolfes_taskana&branch=TSK-2013-selectAndClaim-returns-Optional)


---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
