### PR TITLE
Closes #2184 - fix setting ownerLongName during claim

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskServiceImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskServiceImpl.java
@@ -1255,14 +1255,6 @@ public class TaskServiceImpl implements TaskService {
           InvalidOwnerException,
           NotAuthorizedOnWorkbasketException,
           InvalidTaskStateException {
-    String userId = taskanaEngine.getEngine().getCurrentUserContext().getUserid();
-    String userLongName = null;
-    if (taskanaEngine.getEngine().getConfiguration().isAddAdditionalUserInfo()) {
-      User user = userMapper.findById(userId);
-      if (user != null) {
-        userLongName = user.getLongName();
-      }
-    }
     TaskImpl task;
     try {
       taskanaEngine.openConnection();
@@ -1272,6 +1264,16 @@ public class TaskServiceImpl implements TaskService {
       Instant now = Instant.now();
 
       checkPreconditionsForClaimTask(task, forceClaim);
+
+      String userId = taskanaEngine.getEngine().getCurrentUserContext().getUserid();
+      String userLongName = null;
+      if (taskanaEngine.getEngine().getConfiguration().isAddAdditionalUserInfo()) {
+        User user = userMapper.findById(userId);
+        if (user != null) {
+          userLongName = user.getLongName();
+        }
+      }
+
       claimActionsOnTask(task, userId, userLongName, now);
       taskMapper.update(task);
       if (LOGGER.isDebugEnabled()) {


### PR DESCRIPTION
https://sonarcloud.io/summary/new_code?id=ryzheboka_taskana&branch=TSK-2184
<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
