### PR TITLE
Closes #2227 : ClassificationCategories are ordered as defined in properties

### DIFF
--- a/lib/taskana-core-test/src/test/java/acceptance/TaskanaConfigurationTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/TaskanaConfigurationTest.java
@@ -175,8 +175,8 @@ class TaskanaConfigurationTest {
       assertThat(configuration.getClassificationCategoriesByType())
           .isEqualTo(
               Map.ofEntries(
-                  Map.entry("TASK", Set.of("EXTERNAL", "MANUAL", "AUTOMATIC", "PROCESS")),
-                  Map.entry("DOCUMENT", Set.of("EXTERNAL"))));
+                  Map.entry("TASK", List.of("EXTERNAL", "MANUAL", "AUTOMATIC", "PROCESS")),
+                  Map.entry("DOCUMENT", List.of("EXTERNAL"))));
       // working time configuration
       //
       // assertThat(configuration.getWorkingTimeSchedule()).isEqualTo(defaultWorkingTimeSchedule);
@@ -248,8 +248,8 @@ class TaskanaConfigurationTest {
               Map.entry(TaskanaRole.TASK_ROUTER, Set.of("task_router")));
       // classification configuration
       List<String> expectedClassificationTypes = List.of("TYPE_A", "TYPE_B");
-      Map<String, Set<String>> expectedClassificationCategories =
-          Map.of("TYPE_A", Set.of("CATEGORY_A"), "TYPE_B", Set.of("CATEGORY_B"));
+      Map<String, List<String>> expectedClassificationCategories =
+          Map.of("TYPE_A", List.of("CATEGORY_A"), "TYPE_B", List.of("CATEGORY_B"));
       // working time configuration
       Map<DayOfWeek, Set<LocalTimeInterval>> expectedWorkingTimeSchedule =
           Map.of(DayOfWeek.MONDAY, Set.of(new LocalTimeInterval(LocalTime.MIN, LocalTime.NOON)));
@@ -437,7 +437,7 @@ class TaskanaConfigurationTest {
               // classification configuration
               .classificationTypes(List.of("typeA", "typeB"))
               .classificationCategoriesByType(
-                  Map.of("typeA", Set.of("categoryA"), "typeB", Set.of("categoryB")))
+                  Map.of("typeA", List.of("categoryA"), "typeB", List.of("categoryB")))
               // working time configuration
               .workingTimeSchedule(
                   Map.of(
@@ -920,7 +920,7 @@ class TaskanaConfigurationTest {
           new TaskanaConfiguration.Builder(
                   TestContainerExtension.createDataSourceForH2(), false, "TASKANA")
               .classificationTypes(List.of("valid"))
-              .classificationCategoriesByType(Map.of("does_not_exist", Set.of("a", "b")));
+              .classificationCategoriesByType(Map.of("does_not_exist", List.of("a", "b")));
 
       ThrowingCallable call = builder::build;
 
@@ -939,7 +939,7 @@ class TaskanaConfigurationTest {
           new TaskanaConfiguration.Builder(
                   TestContainerExtension.createDataSourceForH2(), false, "TASKANA")
               .classificationTypes(List.of("type1", "type2"))
-              .classificationCategoriesByType(Map.of("type1", Set.of("a", "b")));
+              .classificationCategoriesByType(Map.of("type1", List.of("a", "b")));
 
       ThrowingCallable call = builder::build;
 
@@ -990,7 +990,7 @@ class TaskanaConfigurationTest {
           new Builder(TestContainerExtension.createDataSourceForH2(), false, "TASKANA")
               .classificationTypes(List.of("a", "b"))
               .classificationCategoriesByType(
-                  Map.ofEntries(Map.entry("a", Set.of()), Map.entry("b", Set.of())))
+                  Map.ofEntries(Map.entry("a", List.of()), Map.entry("b", List.of())))
               .build();
 
       assertThat(configuration.getClassificationTypes()).containsExactlyInAnyOrder("A", "B");
@@ -1003,13 +1003,14 @@ class TaskanaConfigurationTest {
               .classificationTypes(List.of("type_a", "type_b"))
               .classificationCategoriesByType(
                   Map.ofEntries(
-                      Map.entry("type_a", Set.of("a", "b")), Map.entry("type_b", Set.of("c", "d"))))
+                      Map.entry("type_a", List.of("a", "b")),
+                      Map.entry("type_b", List.of("c", "d"))))
               .build();
 
       assertThat(configuration.getClassificationCategoriesByType())
           .containsExactlyInAnyOrderEntriesOf(
               Map.ofEntries(
-                  Map.entry("TYPE_A", Set.of("A", "B")), Map.entry("TYPE_B", Set.of("C", "D"))));
+                  Map.entry("TYPE_A", List.of("A", "B")), Map.entry("TYPE_B", List.of("C", "D"))));
     }
 
     @Test

--- a/lib/taskana-core/src/main/java/pro/taskana/TaskanaConfiguration.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/TaskanaConfiguration.java
@@ -69,7 +69,7 @@ public class TaskanaConfiguration {
   // region classification configuration
   private final List<String> classificationTypes;
 
-  private final Map<String, Set<String>> classificationCategoriesByType;
+  private final Map<String, List<String>> classificationCategoriesByType;
   // endregion
 
   // region working time configuration
@@ -147,7 +147,7 @@ public class TaskanaConfiguration {
         builder.classificationCategoriesByType.entrySet().stream()
             .collect(
                 Collectors.toUnmodifiableMap(
-                    Entry::getKey, e -> Collections.unmodifiableSet(e.getValue())));
+                    Entry::getKey, e -> Collections.unmodifiableList(e.getValue())));
     // working time configuration
     this.workingTimeSchedule =
         builder.workingTimeSchedule.entrySet().stream()
@@ -208,17 +208,17 @@ public class TaskanaConfiguration {
     return true;
   }
 
-  public Set<String> getAllClassificationCategories() {
+  public List<String> getAllClassificationCategories() {
     return this.classificationCategoriesByType.values().stream()
         .flatMap(Collection::stream)
-        .collect(Collectors.toSet());
+        .collect(Collectors.toList());
   }
 
-  public Set<String> getClassificationCategoriesByType(String type) {
-    return classificationCategoriesByType.getOrDefault(type, Collections.emptySet());
+  public List<String> getClassificationCategoriesByType(String type) {
+    return classificationCategoriesByType.getOrDefault(type, Collections.emptyList());
   }
 
-  public Map<String, Set<String>> getClassificationCategoriesByType() {
+  public Map<String, List<String>> getClassificationCategoriesByType() {
     return this.classificationCategoriesByType;
   }
 
@@ -632,7 +632,7 @@ public class TaskanaConfiguration {
     private List<String> classificationTypes = new ArrayList<>();
 
     @TaskanaProperty("taskana.classification.categories")
-    private Map<String, Set<String>> classificationCategoriesByType = new HashMap<>();
+    private Map<String, List<String>> classificationCategoriesByType = new HashMap<>();
     // endregion
 
     // region working time configuration
@@ -934,7 +934,7 @@ public class TaskanaConfiguration {
     }
 
     public Builder classificationCategoriesByType(
-        Map<String, Set<String>> classificationCategoriesByType) {
+        Map<String, List<String>> classificationCategoriesByType) {
       this.classificationCategoriesByType = classificationCategoriesByType;
       return this;
     }
@@ -1180,7 +1180,7 @@ public class TaskanaConfiguration {
                           e.getKey().toUpperCase(),
                           e.getValue().stream()
                               .map(String::toUpperCase)
-                              .collect(Collectors.toSet())))
+                              .collect(Collectors.toList())))
               .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
       roleMap =
           Arrays.stream(TaskanaRole.values())

--- a/lib/taskana-core/src/test/java/acceptance/config/TaskanaConfigAccTest.java
+++ b/lib/taskana-core/src/test/java/acceptance/config/TaskanaConfigAccTest.java
@@ -8,7 +8,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,8 +72,8 @@ class TaskanaConfigAccTest {
     assertThat(taskanaConfiguration.getClassificationCategoriesByType())
         .containsExactlyInAnyOrderEntriesOf(
             Map.ofEntries(
-                Map.entry("TASK", Set.of("EXTERNAL", "MANUAL", "AUTOMATIC", "PROCESS")),
-                Map.entry("DOCUMENT", Set.of("EXTERNAL"))));
+                Map.entry("TASK", List.of("EXTERNAL", "MANUAL", "AUTOMATIC", "PROCESS")),
+                Map.entry("DOCUMENT", List.of("EXTERNAL"))));
   }
 
   private String createNewConfigFile(

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/TaskanaEngineController.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/TaskanaEngineController.java
@@ -2,7 +2,6 @@ package pro.taskana.common.rest;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.hateoas.config.EnableHypermediaSupport;
 import org.springframework.http.ResponseEntity;
@@ -63,7 +62,7 @@ public class TaskanaEngineController {
    */
   @GetMapping(path = RestEndpoints.URL_CLASSIFICATION_CATEGORIES)
   @Transactional(readOnly = true, rollbackFor = Exception.class)
-  public ResponseEntity<Set<String>> getClassificationCategories(
+  public ResponseEntity<List<String>> getClassificationCategories(
       @RequestParam(required = false) String type) {
     if (type != null) {
       return ResponseEntity.ok(taskanaConfiguration.getClassificationCategoriesByType(type));
@@ -90,7 +89,7 @@ public class TaskanaEngineController {
    */
   @GetMapping(path = RestEndpoints.URL_CLASSIFICATION_CATEGORIES_BY_TYPES)
   @Transactional(readOnly = true, rollbackFor = Exception.class)
-  public ResponseEntity<Map<String, Set<String>>> getClassificationCategoriesByTypeMap() {
+  public ResponseEntity<Map<String, List<String>>> getClassificationCategoriesByTypeMap() {
     return ResponseEntity.ok(taskanaConfiguration.getClassificationCategoriesByType());
   }
 

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/TaskanaEngineControllerIntTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/common/rest/TaskanaEngineControllerIntTest.java
@@ -52,7 +52,7 @@ class TaskanaEngineControllerIntTest {
   }
 
   @Test
-  void testClassificationCategories() {
+  void should_ReturnAllClassifications_When_GetClassificationCategories_isCalledWithoutType() {
     String url = restHelper.toUrl(RestEndpoints.URL_CLASSIFICATION_CATEGORIES);
     HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
 
@@ -60,7 +60,29 @@ class TaskanaEngineControllerIntTest {
         TEMPLATE.exchange(
             url, HttpMethod.GET, auth, ParameterizedTypeReference.forType(List.class));
     assertThat(response.getBody())
-        .containsExactlyInAnyOrder("MANUAL", "EXTERNAL", "AUTOMATIC", "PROCESS");
+        .containsExactlyInAnyOrder("EXTERNAL", "MANUAL", "AUTOMATIC", "PROCESS", "EXTERNAL");
+  }
+
+  @Test
+  void should_ReturnOnlyClassificationsForTypeTask_When_GetClassificationCategories_isCalled() {
+    String url = restHelper.toUrl(RestEndpoints.URL_CLASSIFICATION_CATEGORIES) + "?type=TASK";
+    HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ResponseEntity<List<String>> response =
+        TEMPLATE.exchange(
+            url, HttpMethod.GET, auth, ParameterizedTypeReference.forType(List.class));
+    assertThat(response.getBody()).containsExactly("EXTERNAL", "MANUAL", "AUTOMATIC", "PROCESS");
+  }
+
+  @Test
+  void should_ReturnOnlyClassificationsForTypeDocument_When_GetClassificationCategories_isCalled() {
+    String url = restHelper.toUrl(RestEndpoints.URL_CLASSIFICATION_CATEGORIES) + "?type=DOCUMENT";
+    HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ResponseEntity<List<String>> response =
+        TEMPLATE.exchange(
+            url, HttpMethod.GET, auth, ParameterizedTypeReference.forType(List.class));
+    assertThat(response.getBody()).containsExactly("EXTERNAL");
   }
 
   @Test


### PR DESCRIPTION
[SonarCloud](https://sonarcloud.io/summary/new_code?id=arolfes_taskana&branch=2227-classifiation-categories-as-list)


---
Release Notes:
<!-- Please write your release notes between ```-->
```
#2227 Categories of Classifications should have the same order as defined in taskana.properties
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [x] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
