### PR TITLE
Closes #2246 - add grouping by sors and pors

### DIFF
--- a/lib/taskana-core-test/src/test/java/acceptance/TaskanaConfigurationTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/TaskanaConfigurationTest.java
@@ -289,6 +289,8 @@ class TaskanaConfigurationTest {
       boolean expectedAddAdditionalUserInfo = true;
       Set<WorkbasketPermission> expectedMinimalPermissionsToAssignDomains =
           Set.of(WorkbasketPermission.CUSTOM_2);
+      // database configuration
+      boolean expectedUseSpecificDb2Taskquery = false;
 
       // when
       TaskanaConfiguration configuration =
@@ -346,6 +348,7 @@ class TaskanaConfigurationTest {
               // user configuration
               .addAdditionalUserInfo(expectedAddAdditionalUserInfo)
               .minimalPermissionsToAssignDomains(expectedMinimalPermissionsToAssignDomains)
+              .useSpecificDb2Taskquery(expectedUseSpecificDb2Taskquery)
               .build();
 
       // then
@@ -478,6 +481,8 @@ class TaskanaConfigurationTest {
               // user configuration
               .addAdditionalUserInfo(true)
               .minimalPermissionsToAssignDomains(Set.of(WorkbasketPermission.CUSTOM_2))
+              //database configuration
+              .useSpecificDb2Taskquery(false)
               .build();
 
       TaskanaConfiguration copyConfiguration = new Builder(configuration).build();

--- a/lib/taskana-core-test/src/test/java/acceptance/task/get/GetTaskAccTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/task/get/GetTaskAccTest.java
@@ -179,7 +179,8 @@ class GetTaskAccTest {
     assertThat(readTask.getCustomField(TaskCustomField.CUSTOM_16)).isEqualTo("custom16");
     assertThatCode(() -> readTask.getCustomAttributeMap().put("X", "Y")).doesNotThrowAnyException();
     assertThatCode(() -> readTask.getCallbackInfo().put("X", "Y")).doesNotThrowAnyException();
-    assertThat(readTask).hasNoNullFieldsOrPropertiesExcept("ownerLongName", "completed");
+    assertThat(readTask)
+        .hasNoNullFieldsOrPropertiesExcept("ownerLongName", "completed", "groupByCount");
   }
 
   @WithAccessId(user = "user-1-1")

--- a/lib/taskana-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/task/query/TaskQueryImplAccTest.java
@@ -249,7 +249,7 @@ class TaskQueryImplAccTest {
       List<TaskSummary> list = taskService.createTaskQuery().workbasketIdIn(wb.getId()).list();
 
       assertThat(list).containsExactlyInAnyOrder(taskSummary1, taskSummary2);
-      assertThat(taskSummary1).hasNoNullFieldsOrPropertiesExcept("ownerLongName");
+      assertThat(taskSummary1).hasNoNullFieldsOrPropertiesExcept("ownerLongName", "groupByCount");
     }
 
     @WithAccessId(user = "user-1-1")
@@ -697,6 +697,9 @@ class TaskQueryImplAccTest {
             taskInWorkbasket(wb)
                 .completed(Instant.parse("2020-02-01T00:00:00Z"))
                 .buildAndStoreAsSummary(taskService);
+        taskInWorkbasket(wb)
+                .completed(null)
+                .buildAndStoreAsSummary(taskService);
       }
 
       @WithAccessId(user = "user-1-1")
@@ -871,6 +874,7 @@ class TaskQueryImplAccTest {
         taskSummary1 = taskInWorkbasket(wb).note("Note1").buildAndStoreAsSummary(taskService);
         taskSummary2 = taskInWorkbasket(wb).note("Note2").buildAndStoreAsSummary(taskService);
         taskSummary3 = taskInWorkbasket(wb).note("Lorem ipsum").buildAndStoreAsSummary(taskService);
+        taskInWorkbasket(wb).note(null).buildAndStoreAsSummary(taskService);
       }
 
       @WithAccessId(user = "user-1-1")
@@ -1772,8 +1776,16 @@ class TaskQueryImplAccTest {
         wb = createWorkbasketWithPermission();
         por1 = defaultTestObjectReference().company("15").build();
         ObjectReference por2 = defaultTestObjectReference().build();
-        taskSummary1 = taskInWorkbasket(wb).primaryObjRef(por1).buildAndStoreAsSummary(taskService);
-        taskSummary2 = taskInWorkbasket(wb).primaryObjRef(por2).buildAndStoreAsSummary(taskService);
+        taskSummary1 =
+            taskInWorkbasket(wb)
+                .primaryObjRef(por1)
+                .due(Instant.parse("2022-11-15T09:42:00.000Z"))
+                .buildAndStoreAsSummary(taskService);
+        taskSummary2 =
+            taskInWorkbasket(wb)
+                .primaryObjRef(por2)
+                .due(Instant.parse("2022-11-15T09:45:00.000Z"))
+                .buildAndStoreAsSummary(taskService);
       }
 
       @WithAccessId(user = "user-1-1")
@@ -3066,13 +3078,17 @@ class TaskQueryImplAccTest {
                 .type("SecondType")
                 .build();
         taskSummary2 =
-            taskInWorkbasket(wb).objectReferences(sor2).buildAndStoreAsSummary(taskService);
+            taskInWorkbasket(wb)
+                .objectReferences(sor2)
+                .due(Instant.parse("2022-11-15T09:42:00.000Z"))
+                .buildAndStoreAsSummary(taskService);
 
         ObjectReference sor2copy = sor2.copy();
         ObjectReference sor1copy = sor1.copy();
         taskSummary3 =
             taskInWorkbasket(wb)
                 .objectReferences(sor2copy, sor1copy)
+                .due(Instant.parse("2022-11-15T09:45:00.000Z"))
                 .buildAndStoreAsSummary(taskService);
 
         ObjectReference sor3 =

--- a/lib/taskana-core-test/src/test/java/acceptance/task/query/TaskQueryImplGroupByAccTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/task/query/TaskQueryImplGroupByAccTest.java
@@ -1,0 +1,334 @@
+package acceptance.task.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static pro.taskana.testapi.DefaultTestEntities.defaultTestClassification;
+import static pro.taskana.testapi.DefaultTestEntities.defaultTestObjectReference;
+import static pro.taskana.testapi.DefaultTestEntities.defaultTestWorkbasket;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import pro.taskana.TaskanaConfiguration;
+import pro.taskana.classification.api.ClassificationService;
+import pro.taskana.classification.api.models.ClassificationSummary;
+import pro.taskana.common.api.BaseQuery.SortDirection;
+import pro.taskana.common.api.security.CurrentUserContext;
+import pro.taskana.task.api.TaskService;
+import pro.taskana.task.api.models.ObjectReference;
+import pro.taskana.task.api.models.TaskSummary;
+import pro.taskana.testapi.TaskanaConfigurationModifier;
+import pro.taskana.testapi.TaskanaInject;
+import pro.taskana.testapi.TaskanaIntegrationTest;
+import pro.taskana.testapi.builder.ObjectReferenceBuilder;
+import pro.taskana.testapi.builder.TaskAttachmentBuilder;
+import pro.taskana.testapi.builder.TaskBuilder;
+import pro.taskana.testapi.builder.UserBuilder;
+import pro.taskana.testapi.builder.WorkbasketAccessItemBuilder;
+import pro.taskana.testapi.security.WithAccessId;
+import pro.taskana.user.api.UserService;
+import pro.taskana.workbasket.api.WorkbasketPermission;
+import pro.taskana.workbasket.api.WorkbasketService;
+import pro.taskana.workbasket.api.models.WorkbasketSummary;
+
+@TaskanaIntegrationTest
+@DisabledIfEnvironmentVariable(named = "DB", matches = "ORACLE")
+class TaskQueryImplGroupByAccTest implements TaskanaConfigurationModifier {
+  @TaskanaInject TaskService taskService;
+  @TaskanaInject WorkbasketService workbasketService;
+  @TaskanaInject CurrentUserContext currentUserContext;
+  @TaskanaInject ClassificationService classificationService;
+  @TaskanaInject UserService userService;
+
+  ClassificationSummary defaultClassificationSummary;
+  WorkbasketSummary defaultWorkbasket;
+  TaskSummary taskSummary1;
+  TaskSummary taskSummary2;
+  TaskSummary taskSummary3;
+
+  @Override
+  public TaskanaConfiguration.Builder modify(TaskanaConfiguration.Builder builder) {
+    return builder.addAdditionalUserInfo(true).useSpecificDb2Taskquery(false);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @BeforeAll
+  void setup() throws Exception {
+    UserBuilder.newUser()
+        .id("user-1-1")
+        .longName("Mustermann, Max - (user-1-1)")
+        .firstName("Max")
+        .lastName("Mustermann")
+        .buildAndStore(userService, "businessadmin");
+    defaultClassificationSummary =
+        defaultTestClassification().buildAndStoreAsSummary(classificationService, "businessadmin");
+    defaultWorkbasket = createWorkbasketWithPermission();
+    ObjectReference sor2 =
+        ObjectReferenceBuilder.newObjectReference()
+            .company("FirstCompany")
+            .value("FirstValue")
+            .type("SecondType")
+            .build();
+    ObjectReference por2 = defaultTestObjectReference().build();
+    taskSummary2 =
+        taskInWorkbasket(defaultWorkbasket)
+            .owner("user-1-1")
+            .primaryObjRef(por2)
+            .objectReferences(sor2)
+            .due(Instant.parse("2022-11-10T09:45:00.000Z"))
+            .name("Name2")
+            .attachments(
+                TaskAttachmentBuilder.newAttachment()
+                    .channel("A")
+                    .classificationSummary(defaultClassificationSummary)
+                    .objectReference(por2)
+                    .build())
+            .buildAndStore(taskService)
+            .asSummary();
+    ObjectReference por1 = defaultTestObjectReference().company("15").build();
+    ObjectReference sor1 =
+        ObjectReferenceBuilder.newObjectReference()
+            .company("FirstCompany")
+            .value("FirstValue")
+            .type("FirstType")
+            .build();
+    taskSummary1 =
+        taskInWorkbasket(defaultWorkbasket)
+            .owner("user-1-1")
+            .primaryObjRef(por1)
+            .objectReferences(sor1)
+            .due(Instant.parse("2022-11-09T09:42:00.000Z"))
+            .name("Name3")
+            .attachments(
+                TaskAttachmentBuilder.newAttachment()
+                    .channel("B")
+                    .classificationSummary(defaultClassificationSummary)
+                    .objectReference(por1)
+                    .build())
+            .buildAndStoreAsSummary(taskService);
+    ObjectReference sor2copy = sor2.copy();
+    ObjectReference sor1copy = sor1.copy();
+    taskSummary3 =
+        taskInWorkbasket(defaultWorkbasket)
+            .owner("user-1-1")
+            .objectReferences(sor2copy, sor1copy)
+            .due(Instant.parse("2022-11-15T09:45:00.000Z"))
+            .name("Name1")
+            .attachments(
+                TaskAttachmentBuilder.newAttachment()
+                    .channel("C")
+                    .classificationSummary(defaultClassificationSummary)
+                    .objectReference(por1)
+                    .build())
+            .buildAndStoreAsSummary(taskService);
+    taskInWorkbasket(createWorkbasketWithPermission()).buildAndStore(taskService);
+  }
+
+  private TaskBuilder taskInWorkbasket(WorkbasketSummary wb) {
+    return TaskBuilder.newTask()
+        .classificationSummary(defaultClassificationSummary)
+        .primaryObjRef(defaultTestObjectReference().build())
+        .workbasketSummary(wb);
+  }
+
+  private WorkbasketSummary createWorkbasketWithPermission() throws Exception {
+    WorkbasketSummary workbasketSummary =
+        defaultTestWorkbasket().buildAndStoreAsSummary(workbasketService, "businessadmin");
+    persistPermission(workbasketSummary);
+    return workbasketSummary;
+  }
+
+  private void persistPermission(WorkbasketSummary workbasketSummary) throws Exception {
+    WorkbasketAccessItemBuilder.newWorkbasketAccessItem()
+        .workbasketId(workbasketSummary.getId())
+        .accessId(currentUserContext.getUserid())
+        .permission(WorkbasketPermission.OPEN)
+        .permission(WorkbasketPermission.READ)
+        .permission(WorkbasketPermission.APPEND)
+        .buildAndStore(workbasketService, "businessadmin");
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_GroupByPor_When_OrderingByName() {
+    List<TaskSummary> list =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupByPor()
+            .orderByName(SortDirection.ASCENDING)
+            .list();
+    assertThat(list)
+        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("groupByCount")
+        .containsExactly(taskSummary3)
+        .extracting("groupByCount")
+        .containsExactly(3);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_GroupByPor_When_JoiningWithAllTablesAndPaging() {
+    List<TaskSummary> list =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupByPor()
+            .ownerLongNameNotIn("Unexisting")
+            .attachmentChannelNotLike("Unexisting")
+            .sorTypeLike("%Type%")
+            .orderByOwnerLongName(SortDirection.ASCENDING)
+            .orderByAttachmentChannel(SortDirection.ASCENDING)
+            .orderByClassificationName(SortDirection.ASCENDING)
+            .listPage(1, 1);
+    assertThat(list)
+        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("groupByCount")
+        .containsExactly(taskSummary2)
+        .extracting("groupByCount")
+        .containsExactly(3);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_GroupBySor_When_JoiningWithAllTablesAndPaging() {
+    List<TaskSummary> list =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupBySor("SecondType")
+            .ownerLongNameNotIn("Unexisting")
+            .attachmentChannelNotLike("Unexisting")
+            .sorTypeLike("%Type%")
+            .orderByOwnerLongName(SortDirection.ASCENDING)
+            .orderByAttachmentChannel(SortDirection.ASCENDING)
+            .orderByClassificationName(SortDirection.ASCENDING)
+            .listPage(1, 1);
+    assertThat(list)
+        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("groupByCount")
+        .containsExactly(taskSummary2)
+        .extracting("groupByCount")
+        .containsExactly(2);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_GroupByPorWithOrderingByDue_When_OrderingByPorValue() {
+    List<TaskSummary> list =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupByPor()
+            .orderByPrimaryObjectReferenceValue(SortDirection.ASCENDING)
+            .list();
+    assertThat(list).hasSize(1);
+    assertThat(list)
+        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("groupByCount")
+        .containsExactly(taskSummary1)
+        .extracting("groupByCount")
+        .containsExactly(3);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_GroupByPorWithOrderingByDue_When_NotOrdering() {
+    List<TaskSummary> list =
+        taskService.createTaskQuery().workbasketIdIn(defaultWorkbasket.getId()).groupByPor().list();
+    assertThat(list).hasSize(1);
+    assertThat(list)
+        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("groupByCount")
+        .containsExactly(taskSummary1)
+        .extracting("groupByCount")
+        .containsExactly(3);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_UseSingleCorrectly_When_GroupingByPor() {
+    TaskSummary result =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupByPor()
+            .single();
+    assertThat(result)
+        .usingRecursiveComparison()
+        .ignoringFields("groupByCount")
+        .isEqualTo(taskSummary1);
+    assertThat(result.getGroupByCount()).isEqualTo(3);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_UseSingleCorrectly_When_GroupingBySor() {
+    TaskSummary result =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupBySor("SecondType")
+            .single();
+    assertThat(result)
+        .usingRecursiveComparison()
+        .ignoringFields("groupByCount")
+        .isEqualTo(taskSummary2);
+    assertThat(result.getGroupByCount()).isEqualTo(2);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_Count_When_GroupingByPor() {
+    Long numberOfTasks =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupByPor()
+            .count();
+    assertThat(numberOfTasks).isEqualTo(1);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_GroupBySor_When_OrderingByName() {
+    List<TaskSummary> list =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupBySor("SecondType")
+            .orderByName(SortDirection.ASCENDING)
+            .list();
+    assertThat(list).hasSize(1);
+    assertThat(list)
+        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("groupByCount")
+        .containsExactly(taskSummary3)
+        .extracting("groupByCount")
+        .containsExactly(2);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_GroupBySorWithOrderingByDue_When_NotOrdering() {
+    List<TaskSummary> list =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupBySor("SecondType")
+            .list();
+    assertThat(list).hasSize(1);
+    assertThat(list)
+        .usingRecursiveFieldByFieldElementComparatorIgnoringFields("groupByCount")
+        .containsExactly(taskSummary2)
+        .extracting("groupByCount")
+        .containsExactly(2);
+  }
+
+  @WithAccessId(user = "user-1-1")
+  @Test
+  void should_Count_When_GroupingBySor() {
+    Long numberOfTasks =
+        taskService
+            .createTaskQuery()
+            .workbasketIdIn(defaultWorkbasket.getId())
+            .groupBySor("SecondType")
+            .count();
+    assertThat(numberOfTasks).isEqualTo(1);
+  }
+}

--- a/lib/taskana-core-test/src/test/resources/fullTaskana.properties
+++ b/lib/taskana-core-test/src/test/resources/fullTaskana.properties
@@ -53,6 +53,8 @@ taskana.jobs.customJobs=A | B | C
 # user configuration
 taskana.user.addAdditionalUserInfo=true
 taskana.user.minimalPermissionsToAssignDomains=READ | OPEN
+# database configuration
+taskana.feature.useSpecificDb2Taskquery=false
 # custom configuration
 my_custom_property1=my_custom_value1
 my_custom_property2=my_custom_value2

--- a/lib/taskana-core/src/main/java/pro/taskana/TaskanaConfiguration.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/TaskanaConfiguration.java
@@ -123,6 +123,10 @@ public class TaskanaConfiguration {
   private final Set<WorkbasketPermission> minimalPermissionsToAssignDomains;
   // endregion
 
+  // region database configuration
+  private final boolean useSpecificDb2Taskquery;
+  // endregion
+
   // region custom configuration
   private final Map<String, String> properties;
   // endregion
@@ -194,6 +198,8 @@ public class TaskanaConfiguration {
     this.addAdditionalUserInfo = builder.addAdditionalUserInfo;
     this.minimalPermissionsToAssignDomains =
         Collections.unmodifiableSet(builder.minimalPermissionsToAssignDomains);
+    // database configuration
+    this.useSpecificDb2Taskquery = builder.useSpecificDb2Taskquery;
     // custom configuration
     this.properties = Map.copyOf(builder.properties);
   }
@@ -388,6 +394,10 @@ public class TaskanaConfiguration {
     return minimalPermissionsToAssignDomains;
   }
 
+  public boolean isUseSpecificDb2Taskquery() {
+    return useSpecificDb2Taskquery;
+  }
+
   /**
    * return all properties loaded from taskana properties file. Per Design the normal Properties are
    * not immutable, so we return here an ImmutableMap, because we don't want direct changes in the
@@ -447,6 +457,7 @@ public class TaskanaConfiguration {
         customJobs,
         addAdditionalUserInfo,
         minimalPermissionsToAssignDomains,
+        useSpecificDb2Taskquery,
         properties);
   }
 
@@ -481,6 +492,7 @@ public class TaskanaConfiguration {
         && simpleHistoryCleanupJobAllCompletedSameParentBusiness
             == other.simpleHistoryCleanupJobAllCompletedSameParentBusiness
         && taskUpdatePriorityJobEnabled == other.taskUpdatePriorityJobEnabled
+        && useSpecificDb2Taskquery == other.useSpecificDb2Taskquery
         && taskUpdatePriorityJobBatchSize == other.taskUpdatePriorityJobBatchSize
         && userInfoRefreshJobEnabled == other.userInfoRefreshJobEnabled
         && addAdditionalUserInfo == other.addAdditionalUserInfo
@@ -596,6 +608,8 @@ public class TaskanaConfiguration {
         + addAdditionalUserInfo
         + ", minimalPermissionsToAssignDomains="
         + minimalPermissionsToAssignDomains
+        + ", useSpecificDb2Taskquery="
+        + useSpecificDb2Taskquery
         + ", properties="
         + properties
         + "]";
@@ -743,6 +757,11 @@ public class TaskanaConfiguration {
     private Set<WorkbasketPermission> minimalPermissionsToAssignDomains = new HashSet<>();
     // endregion
 
+    // region database configuration
+    @TaskanaProperty("taskana.feature.useSpecificDb2Taskquery")
+    private boolean useSpecificDb2Taskquery = true;
+    // endregion
+
     // region custom configuration
     private Map<String, String> properties = Collections.emptyMap();
     // endregion
@@ -845,6 +864,8 @@ public class TaskanaConfiguration {
       // user configuration
       this.addAdditionalUserInfo = conf.addAdditionalUserInfo;
       this.minimalPermissionsToAssignDomains = conf.minimalPermissionsToAssignDomains;
+      // database configuration
+      this.useSpecificDb2Taskquery = conf.useSpecificDb2Taskquery;
       // custom configuration
       this.properties = conf.properties;
     }
@@ -1128,6 +1149,11 @@ public class TaskanaConfiguration {
     }
 
     // endregion
+    // region database configuration
+    public Builder useSpecificDb2Taskquery(boolean useSpecificDb2Taskquery) {
+      this.useSpecificDb2Taskquery = useSpecificDb2Taskquery;
+      return this;
+    }
 
     public TaskanaConfiguration build() {
       adjustConfiguration();

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskQuery.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskQuery.java
@@ -1218,6 +1218,29 @@ public interface TaskQuery extends BaseQuery<TaskSummary, TaskQueryColumnName> {
   TaskQuery orderByPrimaryObjectReferenceValue(SortDirection sortDirection);
 
   // endregion
+  // region groupBy
+
+  /**
+   * Group the {@linkplain Task Tasks} that will be returned by this query according to the value of
+   * their {@linkplain Task#getPrimaryObjRef() primary ObjectReference}. Only one Task will be
+   * returned for all Tasks with the same value.
+   *
+   * @return the query
+   */
+  TaskQuery groupByPor();
+
+  /**
+   * Group the {@linkplain Task Tasks} that will be returned by this query according to the value of
+   * their {@linkplain Task#getSecondaryObjectReferences() secondary ObjectReference} with the
+   * specified type. Only one Task will be returned for all Tasks with the same value.
+   *
+   * @param type the type of the relevant {@linkplain Task#getSecondaryObjectReferences() secondary
+   *     ObjectReference}
+   * @return the query
+   */
+  TaskQuery groupBySor(String type);
+
+  // endregion
   // region read
 
   /**

--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/models/TaskSummary.java
@@ -81,6 +81,16 @@ public interface TaskSummary {
   Instant getReceived();
 
   /**
+   * Returns the number of {@linkplain Task Tasks} that are grouped together with this {@linkplain
+   * Task} by a {@linkplain pro.taskana.task.api.TaskQuery}. It's only not NULL when using
+   * {@linkplain pro.taskana.task.api.TaskQuery#groupByPor()} or {@linkplain
+   * pro.taskana.task.api.TaskQuery#groupBySor(String)}.
+   *
+   * @return the number of {@linkplain Task Tasks} grouped toghether with this {@linkplain Task}
+   */
+  Integer getGroupByCount();
+
+  /**
    * Returns the time when the {@linkplain Task} is due.
    *
    * <p>This instant denotes the last point in the allowed work time has ended or in short it is

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQueryMapper.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQueryMapper.java
@@ -43,6 +43,7 @@ public interface TaskQueryMapper {
   @Result(property = "primaryObjRefImpl.value", column = "POR_VALUE")
   @Result(property = "isRead", column = "IS_READ")
   @Result(property = "isTransferred", column = "IS_TRANSFERRED")
+  @Result(property = "groupByCount", column = "R_COUNT")
   @Result(property = "custom1", column = "CUSTOM_1")
   @Result(property = "custom2", column = "CUSTOM_2")
   @Result(property = "custom3", column = "CUSTOM_3")

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskImpl.java
@@ -33,6 +33,7 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
     callbackInfo = new HashMap<>(copyFrom.callbackInfo);
     callbackState = copyFrom.callbackState;
     attachments = copyFrom.attachments.stream().map(Attachment::copy).collect(Collectors.toList());
+    groupByCount = copyFrom.groupByCount;
   }
 
   public Map<String, String> getCustomAttributes() {
@@ -280,6 +281,7 @@ public class TaskImpl extends TaskSummaryImpl implements Task {
     taskSummary.setNote(note);
     taskSummary.setDescription(description);
     taskSummary.setOwner(owner);
+    taskSummary.setOwnerLongName(ownerLongName);
     taskSummary.setParentBusinessProcessId(parentBusinessProcessId);
     taskSummary.setPlanned(planned);
     taskSummary.setReceived(received);

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/models/TaskSummaryImpl.java
@@ -38,6 +38,7 @@ public class TaskSummaryImpl implements TaskSummary {
   protected int manualPriority = DEFAULT_MANUAL_PRIORITY;
   protected TaskState state;
   protected ClassificationSummary classificationSummary;
+  protected Integer groupByCount;
   protected WorkbasketSummary workbasketSummary;
   protected String businessProcessId;
   protected String parentBusinessProcessId;
@@ -105,6 +106,7 @@ public class TaskSummaryImpl implements TaskSummary {
         copyFrom.secondaryObjectReferences.stream()
             .map(ObjectReference::copy)
             .collect(Collectors.toList());
+    groupByCount = copyFrom.groupByCount;
     custom1 = copyFrom.custom1;
     custom2 = copyFrom.custom2;
     custom3 = copyFrom.custom3;
@@ -210,6 +212,11 @@ public class TaskSummaryImpl implements TaskSummary {
 
   public void setReceived(Instant received) {
     this.received = received != null ? received.truncatedTo(ChronoUnit.MILLIS) : null;
+  }
+
+  @Override
+  public Integer getGroupByCount() {
+    return this.groupByCount;
   }
 
   @Override
@@ -484,6 +491,10 @@ public class TaskSummaryImpl implements TaskSummary {
   // auxiliary method to allow mybatis access to workbasketSummary
   public void setWorkbasketSummaryImpl(WorkbasketSummaryImpl workbasketSummary) {
     setWorkbasketSummary(workbasketSummary);
+  }
+
+  public void setGroupByCount(Integer n) {
+    groupByCount = n;
   }
 
   public void addAttachmentSummary(AttachmentSummary attachmentSummary) {
@@ -797,6 +808,7 @@ public class TaskSummaryImpl implements TaskSummary {
         primaryObjRef,
         isRead,
         isTransferred,
+        groupByCount,
         attachmentSummaries,
         secondaryObjectReferences,
         custom1,
@@ -864,6 +876,7 @@ public class TaskSummaryImpl implements TaskSummary {
         && Objects.equals(primaryObjRef, other.primaryObjRef)
         && Objects.equals(attachmentSummaries, other.attachmentSummaries)
         && Objects.equals(secondaryObjectReferences, other.secondaryObjectReferences)
+        && Objects.equals(groupByCount, other.groupByCount)
         && Objects.equals(custom1, other.custom1)
         && Objects.equals(custom2, other.custom2)
         && Objects.equals(custom3, other.custom3)
@@ -942,6 +955,8 @@ public class TaskSummaryImpl implements TaskSummary {
         + isRead
         + ", isTransferred="
         + isTransferred
+        + ", groupByCount="
+        + groupByCount
         + ", attachmentSummaries="
         + attachmentSummaries
         + ", objectReferences="

--- a/lib/taskana-test-api/src/main/java/pro/taskana/testapi/builder/TaskBuilder.java
+++ b/lib/taskana-test-api/src/main/java/pro/taskana/testapi/builder/TaskBuilder.java
@@ -132,6 +132,11 @@ public class TaskBuilder implements SummaryEntityBuilder<TaskSummary, Task, Task
     return this;
   }
 
+  public TaskBuilder ownerLongName(String ownerLongName) {
+    testTask.setOwnerLongName(ownerLongName);
+    return this;
+  }
+
   public TaskBuilder primaryObjRef(ObjectReference primaryObjRef) {
     testTask.setPrimaryObjRef(primaryObjRef);
     return this;
@@ -158,6 +163,11 @@ public class TaskBuilder implements SummaryEntityBuilder<TaskSummary, Task, Task
     } else {
       testTask.unfreezeTransferred();
     }
+    return this;
+  }
+
+  public TaskBuilder groupByCount(Integer count) {
+    testTask.setGroupByCount(count);
     return this;
   }
 

--- a/lib/taskana-test-api/src/test/java/pro/taskana/testapi/builder/TaskBuilderTest.java
+++ b/lib/taskana-test-api/src/test/java/pro/taskana/testapi/builder/TaskBuilderTest.java
@@ -212,7 +212,7 @@ class TaskBuilderTest {
     expectedTask.setCallbackState(CallbackState.CALLBACK_PROCESSING_COMPLETED);
 
     assertThat(task)
-        .hasNoNullFieldsOrPropertiesExcept("ownerLongName")
+        .hasNoNullFieldsOrPropertiesExcept("ownerLongName", "groupByCount")
         .usingRecursiveComparison()
         .ignoringFields("id")
         .isEqualTo(expectedTask);

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskController.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskController.java
@@ -123,7 +123,8 @@ public class TaskController {
    * @param request the HTTP request
    * @param filterParameter the filter parameters
    * @param filterCustomFields the filter parameters regarding TaskCustomFields
-   * @param filterCustomIntFields the filter parameters regarding TaskCustomIntFields
+   * @param filterCustomIntFields the filter parameters regarding TaskCustomIntFields * @param
+   * @param groupByParameter the group by parameters
    * @param sortParameter the sort parameters
    * @param pagingParameter the paging parameters
    * @return the Tasks with the given filter, sort and paging options.
@@ -135,6 +136,7 @@ public class TaskController {
       TaskQueryFilterParameter filterParameter,
       TaskQueryFilterCustomFields filterCustomFields,
       TaskQueryFilterCustomIntFields filterCustomIntFields,
+      TaskQueryGroupByParameter groupByParameter,
       TaskQuerySortParameter sortParameter,
       QueryPagingParameter<TaskSummary, TaskQuery> pagingParameter) {
     QueryParamsValidator.validateParams(
@@ -142,6 +144,7 @@ public class TaskController {
         TaskQueryFilterParameter.class,
         TaskQueryFilterCustomFields.class,
         TaskQueryFilterCustomIntFields.class,
+        TaskQueryGroupByParameter.class,
         QuerySortParameter.class,
         QueryPagingParameter.class);
     TaskQuery query = taskService.createTaskQuery();
@@ -149,6 +152,7 @@ public class TaskController {
     filterParameter.apply(query);
     filterCustomFields.apply(query);
     filterCustomIntFields.apply(query);
+    groupByParameter.apply(query);
     sortParameter.apply(query);
 
     List<TaskSummary> taskSummaries = pagingParameter.apply(query);

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskQueryGroupByParameter.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskQueryGroupByParameter.java
@@ -1,0 +1,61 @@
+package pro.taskana.task.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.beans.ConstructorProperties;
+import java.util.Optional;
+import java.util.function.Consumer;
+import pro.taskana.common.api.exceptions.InvalidArgumentException;
+import pro.taskana.common.rest.QueryParameter;
+import pro.taskana.task.api.TaskQuery;
+
+public class TaskQueryGroupByParameter implements QueryParameter<TaskQuery, Void> {
+  public enum TaskQueryGroupBy {
+    POR_VALUE(TaskQuery::groupByPor);
+    private final Consumer<TaskQuery> consumer;
+
+    TaskQueryGroupBy(Consumer<TaskQuery> consumer) {
+      this.consumer = consumer;
+    }
+
+    public void applyGroupByForQuery(TaskQuery query) {
+      consumer.accept(query);
+    }
+  }
+
+  // region groupBy
+  @JsonProperty("group-by")
+  private final TaskQueryGroupBy groupByPor;
+
+  @JsonProperty("group-by-sor")
+  private final String groupBySor;
+  // endregion
+
+  // region constructor
+
+  @ConstructorProperties({"group-by", "group-by-sor"})
+  public TaskQueryGroupByParameter(TaskQueryGroupBy groupBy, String groupBySor)
+      throws InvalidArgumentException {
+    this.groupByPor = groupBy;
+    this.groupBySor = groupBySor;
+    validateGroupByParameters();
+  }
+
+  // endregion
+
+  @Override
+  public Void apply(TaskQuery query) {
+
+    Optional.ofNullable(groupBySor).ifPresent(query::groupBySor);
+    Optional.ofNullable(groupByPor)
+        .ifPresent(taskQueryGroupBy -> taskQueryGroupBy.applyGroupByForQuery(query));
+
+    return null;
+  }
+
+  private void validateGroupByParameters() throws InvalidArgumentException {
+    if (groupByPor != null && groupBySor != null) {
+      throw new InvalidArgumentException(
+          "Only one of the following can be provided: Either group-by or group-by-sor");
+    }
+  }
+}

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/assembler/TaskRepresentationModelAssembler.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/assembler/TaskRepresentationModelAssembler.java
@@ -82,6 +82,7 @@ public class TaskRepresentationModelAssembler
             .collect(Collectors.toList()));
     repModel.setRead(task.isRead());
     repModel.setTransferred(task.isTransferred());
+    repModel.setGroupByCount(task.getGroupByCount());
     repModel.setAttachments(
         task.getAttachments().stream()
             .map(attachmentAssembler::toModel)
@@ -159,6 +160,7 @@ public class TaskRepresentationModelAssembler
     task.setPrimaryObjRef(objectReferenceAssembler.toEntity(repModel.getPrimaryObjRef()));
     task.setRead(repModel.isRead());
     task.setTransferred(repModel.isTransferred());
+    task.setGroupByCount(repModel.getGroupByCount());
     task.setCustomField(TaskCustomField.CUSTOM_1, repModel.getCustom1());
     task.setCustomField(TaskCustomField.CUSTOM_2, repModel.getCustom2());
     task.setCustomField(TaskCustomField.CUSTOM_3, repModel.getCustom3());

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/assembler/TaskSummaryRepresentationModelAssembler.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/assembler/TaskSummaryRepresentationModelAssembler.java
@@ -82,6 +82,7 @@ public class TaskSummaryRepresentationModelAssembler
             .collect(Collectors.toList()));
     repModel.setRead(taskSummary.isRead());
     repModel.setTransferred(taskSummary.isTransferred());
+    repModel.setGroupByCount(taskSummary.getGroupByCount());
     repModel.setAttachmentSummaries(
         taskSummary.getAttachmentSummaries().stream()
             .map(attachmentAssembler::toModel)
@@ -148,6 +149,7 @@ public class TaskSummaryRepresentationModelAssembler
             .collect(Collectors.toList()));
     taskSummary.setRead(repModel.isRead());
     taskSummary.setTransferred(repModel.isTransferred());
+    taskSummary.setGroupByCount(repModel.getGroupByCount());
     taskSummary.setAttachmentSummaries(
         repModel.getAttachmentSummaries().stream()
             .map(attachmentAssembler::toEntityModel)

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/models/TaskSummaryRepresentationModel.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/models/TaskSummaryRepresentationModel.java
@@ -79,6 +79,8 @@ public class TaskSummaryRepresentationModel
   protected boolean isRead;
   /** Indicator if the task has been transferred. */
   protected boolean isTransferred;
+  /** Number of Tasks that are grouped together with this Task during a groupBy. */
+  protected Integer groupByCount;
   /** A custom property with name "1". */
   protected String custom1;
   /** A custom property with name "2". */
@@ -349,6 +351,14 @@ public class TaskSummaryRepresentationModel
   public void setAttachmentSummaries(
       List<AttachmentSummaryRepresentationModel> attachmentSummaries) {
     this.attachmentSummaries = attachmentSummaries;
+  }
+
+  public Integer getGroupByCount() {
+    return groupByCount;
+  }
+
+  public void setGroupByCount(Integer groupByCount) {
+    this.groupByCount = groupByCount;
   }
 
   public String getCustom1() {

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/task/rest/assembler/TaskRepresentationModelAssemblerTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/task/rest/assembler/TaskRepresentationModelAssemblerTest.java
@@ -96,6 +96,7 @@ class TaskRepresentationModelAssemblerTest {
     repModel.setCustomAttributes(List.of(TaskRepresentationModel.CustomAttribute.of("abc", "def")));
     repModel.setCallbackInfo(List.of(TaskRepresentationModel.CustomAttribute.of("ghi", "jkl")));
     repModel.setAttachments(List.of(attachment));
+    repModel.setGroupByCount(0);
     repModel.setCustom1("custom1");
     repModel.setCustom2("custom2");
     repModel.setCustom3("custom3");
@@ -195,6 +196,7 @@ class TaskRepresentationModelAssemblerTest {
     task.setPrimaryObjRef(primaryObjRef);
     task.setRead(true);
     task.setTransferred(true);
+    task.setGroupByCount(0);
     task.setCustomAttributeMap(Map.of("abc", "def"));
     task.setCallbackInfo(Map.of("ghi", "jkl"));
     task.setAttachments(List.of(attachment));
@@ -268,6 +270,7 @@ class TaskRepresentationModelAssemblerTest {
     task.setPrimaryObjRef(primaryObjRef);
     task.setRead(true);
     task.setTransferred(true);
+    task.setGroupByCount(0);
     task.setCustomAttributeMap(Map.of("abc", "def"));
     task.setCallbackInfo(Map.of("ghi", "jkl"));
     task.setAttachments(List.of(attachment));

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/task/rest/assembler/TaskSummaryRepresentationModelAssemblerTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/task/rest/assembler/TaskSummaryRepresentationModelAssemblerTest.java
@@ -104,6 +104,7 @@ class TaskSummaryRepresentationModelAssemblerTest {
     task.setPrimaryObjRef(primaryObjRef);
     task.setRead(true);
     task.setTransferred(true);
+    task.setGroupByCount(0);
     task.setCustom1("custom1");
     task.setCustom2("custom2");
     task.setCustom3("custom3");
@@ -178,6 +179,7 @@ class TaskSummaryRepresentationModelAssemblerTest {
     repModel.setOwnerLongName("ownerLongName");
     repModel.setRead(true);
     repModel.setTransferred(true);
+    repModel.setGroupByCount(0);
     repModel.setCustom1("custom1");
     repModel.setCustom2("custom2");
     repModel.setCustom3("custom3");
@@ -276,6 +278,7 @@ class TaskSummaryRepresentationModelAssemblerTest {
     task.setPrimaryObjRef(primaryObjRef);
     task.setRead(true);
     task.setTransferred(true);
+    task.setGroupByCount(0);
     task.setCustom1("custom1");
     task.setCustom2("custom2");
     task.setCustom3("custom3");
@@ -340,6 +343,7 @@ class TaskSummaryRepresentationModelAssemblerTest {
         taskSummary.getPrimaryObjRef(), repModel.getPrimaryObjRef());
     assertThat(taskSummary.isRead()).isEqualTo(repModel.isRead());
     assertThat(taskSummary.isTransferred()).isEqualTo(repModel.isTransferred());
+    assertThat(taskSummary.getGroupByCount()).isEqualTo(repModel.getGroupByCount());
     assertThat(taskSummary.getCustomField(CUSTOM_1)).isEqualTo(repModel.getCustom1());
     assertThat(taskSummary.getCustomField(CUSTOM_2)).isEqualTo(repModel.getCustom2());
     assertThat(taskSummary.getCustomField(CUSTOM_3)).isEqualTo(repModel.getCustom3());


### PR DESCRIPTION
https://sonarcloud.io/summary/new_code?id=ryzheboka_taskana&branch=TSK-2246
<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```
Add grouping by the same por or sor value. In case of sor values, a type needs to be specified. 
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → TSK-XXX: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
