### PR TITLE
Closes #2292 - removed erroneous read-only annotation from TaskCommen…

### DIFF
--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskCommentController.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskCommentController.java
@@ -84,13 +84,13 @@ public class TaskCommentController {
   /**
    * This endpoint retrieves all Task Comments for a specific Task. Further filters can be applied.
    *
+   * @title Get a list of all Task Comments for a specific Task
    * @param taskId the Id of the Task whose comments are requested
    * @param request the HTTP request
    * @param filterParameter the filter parameters
    * @param sortParameter the sort parameters
    * @param pagingParameter the paging parameters
    * @return a list of Task Comments
-   * @title Get a list of all Task Comments for a specific Task
    */
   @GetMapping(path = RestEndpoints.URL_TASK_COMMENTS)
   @Transactional(readOnly = true, rollbackFor = Exception.class)
@@ -136,7 +136,7 @@ public class TaskCommentController {
    * @throws NotAuthorizedOnTaskCommentException if the current user has not correct permissions
    */
   @DeleteMapping(path = RestEndpoints.URL_TASK_COMMENT)
-  @Transactional(readOnly = true, rollbackFor = Exception.class)
+  @Transactional(rollbackFor = Exception.class)
   public ResponseEntity<TaskCommentRepresentationModel> deleteTaskComment(
       @PathVariable String taskCommentId)
       throws TaskNotFoundException,
@@ -167,7 +167,7 @@ public class TaskCommentController {
    * @throws NotAuthorizedOnWorkbasketException if the current user has not correct permissions
    */
   @PutMapping(path = RestEndpoints.URL_TASK_COMMENT)
-  @Transactional(readOnly = true, rollbackFor = Exception.class)
+  @Transactional(rollbackFor = Exception.class)
   public ResponseEntity<TaskCommentRepresentationModel> updateTaskComment(
       @PathVariable String taskCommentId,
       @RequestBody TaskCommentRepresentationModel taskCommentRepresentationModel)


### PR DESCRIPTION
…tController

<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #<Issue Number>: Your commit message. i.e. Closes #2271: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
