### PR TITLE
Closes #2299 - remove lock from the query when unnecessary

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQuerySqlProvider.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskQuerySqlProvider.java
@@ -70,9 +70,11 @@ public class TaskQuerySqlProvider {
         + "ORDER BY <foreach item='item' collection='orderByOuter' separator=',' >${item}</foreach>"
         + "</if> "
         + "<if test='selectAndClaim == true'> "
-        + "FETCH FIRST ROW ONLY FOR UPDATE"
+        + "FETCH FIRST ROW ONLY FOR UPDATE "
         + "</if>"
-        + "<if test=\"_databaseId == 'db2'\">WITH RS USE AND KEEP UPDATE LOCKS </if>"
+        + "<if test=\"_databaseId == 'db2' and selectAndClaim \">WITH RS USE "
+        + "AND KEEP UPDATE LOCKS </if>"
+        + "<if test=\"_databaseId == 'db2' and !selectAndClaim \">WITH UR </if>"
         + CLOSING_SCRIPT_TAG;
   }
 
@@ -429,9 +431,7 @@ public class TaskQuerySqlProvider {
   }
 
   private static String openOuterClauseForGroupByPorOrSor() {
-    return "<if test=\"groupByPor or groupBySor != null\"> "
-        + "SELECT * FROM ("
-        + "</if> ";
+    return "<if test=\"groupByPor or groupBySor != null\"> " + "SELECT * FROM (" + "</if> ";
   }
 
   private static String closeOuterClauseForGroupByPor() {


### PR DESCRIPTION
https://sonarcloud.io/summary/new_code?id=ryzheboka_taskana&branch=TSK-2299
<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [X] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [X] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #<Issue Number>: Your commit message. i.e. Closes #2271: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
