### PR TITLE
Closes #2328 - fix smoketest - wait longer

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -414,7 +414,7 @@ jobs:
   deploy_to_azure:
     runs-on: ubuntu-20.04
     name: Deploy demo app to Microsoft Azure
-    if: github.repository == 'Taskana/taskana' && github.ref == 'refs/heads/master' && github.head_ref == ''
+    if: github.repository == 'Taskana/taskana' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/smoketest-fix')  && github.head_ref == ''
     needs: [ test_frontend, test_e2e, test_backend ]
     steps:
       - name: Git checkout
@@ -459,10 +459,10 @@ jobs:
         with:
           app-name: taskana
           package: rest/taskana-rest-spring-example-boot/target/taskana-rest-spring-example-boot.jar
-      - name: Wait for Azure for 15 seconds
+      - name: Wait for Azure for 60 seconds
         uses: jakejarvis/wait-action@master
         with:
-          time: '15s'
+          time: '60s'
       - name: Smoke test documentation
         run: ci/verify_docs_alive.sh
       - name: Cancel workflow


### PR DESCRIPTION
Wait 60s before performing the smoketest. Need to merge in order too see if this works. Changed pipeline so that azure deployment also happens on smoketest-fix branch

<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #<Issue Number>: Your commit message. i.e. Closes #2271: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
