### PR TITLE
Closes #2348 - adds feature to request the current user via /users?currentUser

### DIFF
--- a/rest/taskana-rest-spring/src/docs/asciidoc/rest-api.adoc
+++ b/rest/taskana-rest-spring/src/docs/asciidoc/rest-api.adoc
@@ -11,6 +11,9 @@ Whenever a parameter is a complex type, the attributes of the value-object can b
 For example, a complex parameter with the name "complex-query-param" and attributes "attribute1" and "attribute2" would be specified in the following way: +
 complex-query-param={"attribute1":"value1","attribute2":"value2"}
 
+Whenever a parameter is a value-less type (e.g owner-is-null and current-user) it is expected to be defined without a value,
+i.e., it should be specified as ?parameter and not ?parameter= or ?parameter=someValue
+
 === Hypermedia Support
 
 NOTE: HATEOAS support is still in development.

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/util/QueryParamsValidator.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/util/QueryParamsValidator.java
@@ -38,7 +38,7 @@ public class QueryParamsValidator {
     checkExactParam(request, "owner-is-null");
   }
 
-  private static void checkExactParam(HttpServletRequest request, String queryParameter) {
+  public static void checkExactParam(HttpServletRequest request, String queryParameter) {
     String queryString = request.getQueryString();
     boolean containParam = queryString != null && queryString.contains(queryParameter);
     if (containParam) {

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/user/rest/UserControllerIntTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/user/rest/UserControllerIntTest.java
@@ -64,6 +64,94 @@ class UserControllerIntTest {
   }
 
   @Test
+  void should_ReturnCurrentUser() {
+    String url = restHelper.toUrl(RestEndpoints.URL_USERS) + "?current-user";
+    HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ResponseEntity<UserCollectionRepresentationModel> response =
+            TEMPLATE.exchange(
+                    url,
+                    HttpMethod.GET,
+                    auth,
+                    ParameterizedTypeReference.forType(UserCollectionRepresentationModel.class));
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getContent()).hasSize(1);
+    assertThat(response.getBody().getContent()).extracting("userId").containsExactly("teamlead-1");
+  }
+
+  @Test
+  void should_ReturnExceptionCurrentUserWithBadValue() {
+    String url = restHelper.toUrl(RestEndpoints.URL_USERS) + "?current-user=asd";
+    HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ThrowingCallable httpCall =
+            () -> TEMPLATE.exchange(
+                    url,
+                    HttpMethod.GET,
+                    auth,
+                    ParameterizedTypeReference.forType(UserCollectionRepresentationModel.class));
+    assertThatThrownBy(httpCall)
+            .isInstanceOf(HttpStatusCodeException.class)
+            .extracting(HttpStatusCodeException.class::cast)
+            .extracting(HttpStatusCodeException::getStatusCode)
+            .isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  void should_ReturnExceptionCurrentUserWithEmptyValue() {
+    String url = restHelper.toUrl(RestEndpoints.URL_USERS) + "?current-user=";
+    HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ThrowingCallable httpCall =
+            () -> TEMPLATE.exchange(
+                    url,
+                    HttpMethod.GET,
+                    auth,
+                    ParameterizedTypeReference.forType(UserCollectionRepresentationModel.class));
+    assertThatThrownBy(httpCall)
+            .isInstanceOf(HttpStatusCodeException.class)
+            .extracting(HttpStatusCodeException.class::cast)
+            .extracting(HttpStatusCodeException::getStatusCode)
+            .isEqualTo(HttpStatus.BAD_REQUEST);
+  }
+
+  @Test
+  void should_ReturnOnlyCurrentUserWhileUsingUserIds() {
+    String url = restHelper.toUrl(RestEndpoints.URL_USERS) + "?current-user&user-id=teamlead-1";
+    HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ResponseEntity<UserCollectionRepresentationModel> response =
+            TEMPLATE.exchange(
+                    url,
+                    HttpMethod.GET,
+                    auth,
+                    ParameterizedTypeReference.forType(UserCollectionRepresentationModel.class));
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getContent()).hasSize(1);
+    assertThat(response.getBody().getContent()).extracting("userId").containsExactly("teamlead-1");
+  }
+
+  @Test
+  void should_ReturnExistingUsersAndCurrentUser() throws Exception {
+    String url = restHelper.toUrl(RestEndpoints.URL_USERS)
+            + "?user-id=user-1-1&user-id=USER-1-2&current-user";
+    HttpEntity<?> auth = new HttpEntity<>(RestHelper.generateHeadersForUser("teamlead-1"));
+
+    ResponseEntity<UserCollectionRepresentationModel> responseEntity =
+            TEMPLATE.exchange(
+                    url,
+                    HttpMethod.GET,
+                    auth,
+                    ParameterizedTypeReference.forType(UserCollectionRepresentationModel.class));
+    UserCollectionRepresentationModel response = responseEntity.getBody();
+    assertThat(response).isNotNull();
+    assertThat(response.getContent()).hasSize(3);
+    assertThat(response.getContent())
+            .extracting("userId")
+            .containsExactlyInAnyOrder("user-1-1", "user-1-2", "teamlead-1");
+  }
+
+  @Test
   void should_ReturnExistingUsers_When_ParameterContainsDuplicateAndInvalidIds() throws Exception {
     // also testing different query parameter format
     String url =


### PR DESCRIPTION
See issue [#2348](https://github.com/Taskana/taskana/issues/2348), [sonar](https://sonarcloud.io/summary/new_code?id=nyuuyn_taskana&branch=TSK-2348)
---
Release Notes:
<!-- Please write your release notes between ```-->
```
Enables fetching the current user data via HTTP GET on /users?currentUser
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [x] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #<Issue Number>: Your commit message. i.e. Closes #2271: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
