### PR TITLE
Closes #2188 - adds checking whether attachment has a proper taskId set when updating a task.

### DIFF
--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskController.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/TaskController.java
@@ -5,6 +5,7 @@ import static java.util.function.Predicate.not;
 import java.beans.ConstructorProperties;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -105,6 +106,15 @@ public class TaskController {
           AttachmentPersistenceException,
           ObjectReferencePersistenceException,
           NotAuthorizedOnWorkbasketException {
+
+    if (!taskRepresentationModel.getAttachments().stream()
+            .filter(att -> Objects.nonNull(att.getTaskId()))
+            .filter(att -> !att.getTaskId().equals(taskRepresentationModel.getTaskId()))
+            .collect(Collectors.toList()).isEmpty()) {
+      throw new InvalidArgumentException(
+              "An attachments' taskId must be empty or equal to the id of the task it belongs to");
+    }
+
     Task fromResource = taskRepresentationModelAssembler.toEntityModel(taskRepresentationModel);
     Task createdTask = taskService.createTask(fromResource);
 
@@ -580,6 +590,15 @@ public class TaskController {
                   + "object in the payload which should be updated. ID=('%s')",
               taskId, taskRepresentationModel.getTaskId()));
     }
+
+    if (!taskRepresentationModel.getAttachments().stream()
+            .filter(att -> Objects.nonNull(att.getTaskId()))
+            .filter(att -> !att.getTaskId().equals(taskRepresentationModel.getTaskId()))
+            .collect(Collectors.toList()).isEmpty()) {
+      throw new InvalidArgumentException(
+              "An attachments' taskId must be empty or equal to the id of the task it belongs to");
+    }
+
     Task task = taskRepresentationModelAssembler.toEntityModel(taskRepresentationModel);
     task = taskService.updateTask(task);
     return ResponseEntity.ok(taskRepresentationModelAssembler.toModel(task));


### PR DESCRIPTION
Closes issue #2188 
---
Release Notes:
<!-- Please write your release notes between ```-->
```
If attachments are set a wrong Task Id the API will respond with a BadRequest
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #<Issue Number>: Your commit message. i.e. Closes #2271: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
