### PR TITLE
Closes #2366 - add TaskEndstatePreprocessor

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/common/internal/InternalTaskanaEngine.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/common/internal/InternalTaskanaEngine.java
@@ -12,6 +12,7 @@ import pro.taskana.spi.task.internal.BeforeRequestChangesManager;
 import pro.taskana.spi.task.internal.BeforeRequestReviewManager;
 import pro.taskana.spi.task.internal.CreateTaskPreprocessorManager;
 import pro.taskana.spi.task.internal.ReviewRequiredManager;
+import pro.taskana.spi.task.internal.TaskEndstatePreprocessorManager;
 
 /**
  * FOR INTERNAL USE ONLY.
@@ -144,4 +145,11 @@ public interface InternalTaskanaEngine {
    * @return the {@linkplain AfterRequestChangesManager} instance
    */
   AfterRequestChangesManager getAfterRequestChangesManager();
+
+  /**
+   * Retrieves the {@linkplain pro.taskana.spi.task.internal.TaskEndstatePreprocessorManager}.
+   *
+   * @return the {@linkplain pro.taskana.spi.task.internal.TaskEndstatePreprocessorManager} instance
+   */
+  TaskEndstatePreprocessorManager getTaskEndstatePreprocessorManager();
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/common/internal/TaskanaEngineImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/common/internal/TaskanaEngineImpl.java
@@ -65,6 +65,7 @@ import pro.taskana.spi.task.internal.BeforeRequestChangesManager;
 import pro.taskana.spi.task.internal.BeforeRequestReviewManager;
 import pro.taskana.spi.task.internal.CreateTaskPreprocessorManager;
 import pro.taskana.spi.task.internal.ReviewRequiredManager;
+import pro.taskana.spi.task.internal.TaskEndstatePreprocessorManager;
 import pro.taskana.task.api.TaskService;
 import pro.taskana.task.internal.AttachmentMapper;
 import pro.taskana.task.internal.ObjectReferenceMapper;
@@ -98,6 +99,8 @@ public class TaskanaEngineImpl implements TaskanaEngine {
   private final AfterRequestReviewManager afterRequestReviewManager;
   private final BeforeRequestChangesManager beforeRequestChangesManager;
   private final AfterRequestChangesManager afterRequestChangesManager;
+  private final TaskEndstatePreprocessorManager taskEndstatePreprocessorManager;
+
   private final InternalTaskanaEngineImpl internalTaskanaEngineImpl;
   private final WorkingTimeCalculator workingTimeCalculator;
   private final HistoryEventManager historyEventManager;
@@ -176,6 +179,7 @@ public class TaskanaEngineImpl implements TaskanaEngine {
     afterRequestReviewManager = new AfterRequestReviewManager(this);
     beforeRequestChangesManager = new BeforeRequestChangesManager(this);
     afterRequestChangesManager = new AfterRequestChangesManager(this);
+    taskEndstatePreprocessorManager = new TaskEndstatePreprocessorManager();
 
     // don't remove, to reset possible explicit mode
     this.mode = connectionManagementMode;
@@ -623,6 +627,11 @@ public class TaskanaEngineImpl implements TaskanaEngine {
     @Override
     public AfterRequestChangesManager getAfterRequestChangesManager() {
       return afterRequestChangesManager;
+    }
+
+    @Override
+    public TaskEndstatePreprocessorManager getTaskEndstatePreprocessorManager() {
+      return taskEndstatePreprocessorManager;
     }
   }
 }

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/TaskEndstatePreprocessor.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/api/TaskEndstatePreprocessor.java
@@ -1,0 +1,34 @@
+package pro.taskana.spi.task.api;
+
+import pro.taskana.task.api.models.Task;
+
+/**
+ * The TaskEndstatePreprocessor allows to implement customized behaviour before the given
+ * {@linkplain Task} goes into an {@linkplain pro.taskana.task.api.TaskState#END_STATES end state}
+ * (cancelled, terminated or completed).
+ */
+public interface TaskEndstatePreprocessor {
+
+  /**
+   * Perform any action before a {@linkplain Task} goes into an {@linkplain
+   * pro.taskana.task.api.TaskState#END_STATES end state}. A {@linkplain Task} goes into an end
+   * state at the end of the following methods: {@linkplain
+   * pro.taskana.task.api.TaskService#completeTask(String)}, {@linkplain
+   * pro.taskana.task.api.TaskService#cancelTask(String)}, {@linkplain
+   * pro.taskana.task.api.TaskService#terminateTask(String)}.
+   *
+   * <p>This SPI is executed within the same transaction staple as {@linkplain
+   * pro.taskana.task.api.TaskService#completeTask(String)}, {@linkplain
+   * pro.taskana.task.api.TaskService#cancelTask(String)}, {@linkplain
+   * pro.taskana.task.api.TaskService#terminateTask(String)}.
+   *
+   * <p>This SPI is executed with the same {@linkplain
+   * pro.taskana.common.api.security.UserPrincipal} and {@linkplain
+   * pro.taskana.common.api.security.GroupPrincipal} as in the methods mentioned above.
+   *
+   * @param taskToProcess the {@linkplain Task} to preprocess
+   * @return the modified {@linkplain Task}. <b>IMPORTANT:</b> persistent changes to the {@linkplain
+   *     Task} have to be managed by the service provider
+   */
+  Task processTaskBeforeEndstate(Task taskToProcess);
+}

--- a/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/TaskEndstatePreprocessorManager.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/spi/task/internal/TaskEndstatePreprocessorManager.java
@@ -1,0 +1,39 @@
+package pro.taskana.spi.task.internal;
+
+import static pro.taskana.common.internal.util.CheckedConsumer.wrap;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import pro.taskana.common.internal.util.SpiLoader;
+import pro.taskana.spi.task.api.TaskEndstatePreprocessor;
+import pro.taskana.task.api.models.Task;
+
+public class TaskEndstatePreprocessorManager {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(TaskEndstatePreprocessorManager.class);
+  private final List<TaskEndstatePreprocessor> taskEndstatePreprocessors;
+
+  public TaskEndstatePreprocessorManager() {
+    taskEndstatePreprocessors = SpiLoader.load(TaskEndstatePreprocessor.class);
+    for (TaskEndstatePreprocessor preprocessor : taskEndstatePreprocessors) {
+      LOGGER.info(
+          "Registered TaskEndstatePreprocessor provider: {}", preprocessor.getClass().getName());
+    }
+    if (taskEndstatePreprocessors.isEmpty()) {
+      LOGGER.info("No TaskEndstatePreprocessor found. Running without TaskEndstatePreprocessor.");
+    }
+  }
+
+  public Task processTaskBeforeEndstate(Task taskToProcess) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Sending task to TaskEndstatePreprocessor providers: {}", taskToProcess);
+    }
+    taskEndstatePreprocessors.forEach(
+        wrap(
+            taskEndstatePreprocessor ->
+                taskEndstatePreprocessor.processTaskBeforeEndstate(taskToProcess)));
+    return taskToProcess;
+  }
+}

--- a/lib/taskana-test-api/src/main/java/pro/taskana/testapi/util/ServiceProviderExtractor.java
+++ b/lib/taskana-test-api/src/main/java/pro/taskana/testapi/util/ServiceProviderExtractor.java
@@ -20,6 +20,7 @@ import pro.taskana.spi.task.api.BeforeRequestChangesProvider;
 import pro.taskana.spi.task.api.BeforeRequestReviewProvider;
 import pro.taskana.spi.task.api.CreateTaskPreprocessor;
 import pro.taskana.spi.task.api.ReviewRequiredProvider;
+import pro.taskana.spi.task.api.TaskEndstatePreprocessor;
 import pro.taskana.testapi.WithServiceProvider;
 
 public class ServiceProviderExtractor {
@@ -34,7 +35,8 @@ public class ServiceProviderExtractor {
           BeforeRequestReviewProvider.class,
           AfterRequestReviewProvider.class,
           BeforeRequestChangesProvider.class,
-          AfterRequestChangesProvider.class);
+          AfterRequestChangesProvider.class,
+          TaskEndstatePreprocessor.class);
 
   private ServiceProviderExtractor() {
     throw new IllegalStateException("utility class");


### PR DESCRIPTION
https://sonarcloud.io/summary/new_code?id=ryzheboka_taskana&branch=TSK-2366
<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```
Add an SPI that is activated before a Task changes into an endstate. The affected methods are "complete", "cancel" and "terminate"
```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #<Issue Number>: Your commit message. i.e. Closes #2271: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
