### PR TITLE
Close #2200 - fix the exception text for wrong classification categories

### DIFF
--- a/lib/taskana-core-test/src/test/java/acceptance/TaskanaConfigurationTest.java
+++ b/lib/taskana-core-test/src/test/java/acceptance/TaskanaConfigurationTest.java
@@ -958,10 +958,12 @@ class TaskanaConfigurationTest {
       assertThatThrownBy(call)
           .isInstanceOf(InvalidArgumentException.class)
           .hasMessageContaining(
-              "Parameter classificationCategoriesByType "
-                  + "(taskana.classification.categories.<KEY>) "
-                  + "contains invalid Classification Types."
-                  + " configured: [VALID] detected: [DOES_NOT_EXIST]");
+              "Parameter classificationCategoriesByType"
+                  + " (taskana.classification.categories.<KEY>) is configured incorrectly. Please"
+                  + " check whether all specified Classification Types exist. Additionally, check"
+                  + " whether the correct separator is used in the property"
+                  + " taskana.classification.types ."
+          );
     }
 
     @Test

--- a/lib/taskana-core/src/main/java/pro/taskana/TaskanaConfiguration.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/TaskanaConfiguration.java
@@ -1055,7 +1055,6 @@ public class TaskanaConfiguration {
       this.enforceServiceLevel = enforceServiceLevel;
       return this;
     }
-
     // endregion
 
     // region authentication configuration
@@ -1447,12 +1446,11 @@ public class TaskanaConfiguration {
       if (!new HashSet<>(classificationTypes)
           .containsAll(classificationCategoriesByType.keySet())) {
         throw new InvalidArgumentException(
-            String.format(
                 "Parameter classificationCategoriesByType (taskana.classification.categories.<KEY>)"
-                    + " contains invalid Classification Types. "
-                    + "configured: %s "
-                    + "detected: %s",
-                classificationTypes, classificationCategoriesByType.keySet()));
+                    + " is configured incorrectly. Please check whether all specified"
+                    + " Classification Types exist. Additionally, check whether the correct"
+                    + " separator is used in the property taskana.classification.types ."
+                );
       }
 
       if (!classificationCategoriesByType.keySet().containsAll(classificationTypes)) {


### PR DESCRIPTION
The exception now uses the default delimiter |. It would be possible to use the configured delimeter. However, it would require adding new property to the configuration. We can discuss what would be better! 
Example:
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [pro.taskana.TaskanaConfiguration]: Factory method 'taskanaConfiguration' threw exception with message: Parameter classificationCategoriesByType (taskana.classification.categories.<KEY>) is configured incorrectly. Please check whether all specified Classification Types exist. Additionally, check if the correct separator is used in the property taskana.classification.types .



<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [ ] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [x] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [ ] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #&lt;Issue Number&gt;: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
