### PR TITLE
Closes #2496 : Set Owner of Tasks when Transferring

### DIFF
--- a/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskService.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/api/TaskService.java
@@ -640,6 +640,100 @@ public interface TaskService {
           NotAuthorizedOnWorkbasketException;
 
   /**
+   * Transfers a List of {@linkplain Task Tasks} to another {@linkplain Workbasket} and set owner to
+   * {@param owner} while always setting {@linkplain Task#isTransferred isTransferred} to true.
+   *
+   * @see #transferTasksWithOwner(String, List, String, boolean)
+   */
+  @SuppressWarnings("checkstyle:JavadocMethod")
+  default BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      String destinationWorkbasketId, List<String> taskIds, String owner)
+      throws InvalidArgumentException,
+          WorkbasketNotFoundException,
+          NotAuthorizedOnWorkbasketException {
+    return transferTasksWithOwner(destinationWorkbasketId, taskIds, owner, true);
+  }
+
+  /**
+   * Transfers a List of {@linkplain Task Tasks} to another {@linkplain Workbasket} and set the
+   * owner.
+   *
+   * <p>The transfer resets {@linkplain Task#isRead() isRead} and sets {@linkplain
+   * Task#isTransferred() isTransferred} if setTransferFlag is true. Exceptions will be thrown if
+   * the caller got no {@linkplain WorkbasketPermission} on the target or if the target {@linkplain
+   * Workbasket} doesn't exist. Other Exceptions will be stored and returned in the end.
+   *
+   * @param destinationWorkbasketId {@linkplain Workbasket#getId() id} of the target {@linkplain
+   *     Workbasket}
+   * @param taskIds List of source {@linkplain Task Tasks} which will be moved
+   * @param owner the new owner of the transferred tasks
+   * @param setTransferFlag controls whether to set {@linkplain Task#isTransferred() isTransferred}
+   *     or not
+   * @return Bulkresult with {@linkplain Task#getId() ids} and Error for each failed transactions
+   * @throws NotAuthorizedOnWorkbasketException if the current user has no {@linkplain
+   *     WorkbasketPermission#READ} for the source {@linkplain Workbasket} or no {@linkplain
+   *     WorkbasketPermission#TRANSFER} for the target {@linkplain Workbasket}
+   * @throws InvalidArgumentException if the method parameters are empty or NULL
+   * @throws WorkbasketNotFoundException if the target {@linkplain Workbasket} can't be found
+   */
+  BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      String destinationWorkbasketId, List<String> taskIds, String owner, boolean setTransferFlag)
+      throws InvalidArgumentException,
+          WorkbasketNotFoundException,
+          NotAuthorizedOnWorkbasketException;
+
+  /**
+   * Transfers a List of {@linkplain Task Tasks} to another {@linkplain Workbasket} and set owner
+   * while always setting {@linkplain Task#isTransferred() isTransferred} to true.
+   *
+   * @see #transferTasksWithOwner(String, String, List, String, boolean)
+   */
+  @SuppressWarnings("checkstyle:JavadocMethod")
+  default BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      String destinationWorkbasketKey,
+      String destinationWorkbasketDomain,
+      List<String> taskIds,
+      String owner)
+      throws InvalidArgumentException,
+          WorkbasketNotFoundException,
+          NotAuthorizedOnWorkbasketException {
+    return transferTasksWithOwner(
+        destinationWorkbasketKey, destinationWorkbasketDomain, taskIds, owner, true);
+  }
+
+  /**
+   * Transfers a List of {@linkplain Task Tasks} to another {@linkplain Workbasket} and set owner.
+   *
+   * <p>The transfer resets {@linkplain Task#isRead() isRead} and sets {@linkplain
+   * Task#isTransferred() isTransferred} if setTransferFlag is true. Exceptions will be thrown if
+   * the caller got no {@linkplain WorkbasketPermission} on the target {@linkplain Workbasket} or if
+   * it doesn't exist. Other Exceptions will be stored and returned in the end.
+   *
+   * @param destinationWorkbasketKey target {@linkplain Workbasket#getKey() key}
+   * @param destinationWorkbasketDomain target {@linkplain Workbasket#getDomain() domain}
+   * @param taskIds List of {@linkplain Task#getId() ids} of source {@linkplain Task Tasks} which
+   *     will be moved
+   * @param owner the new owner of the transferred tasks
+   * @param setTransferFlag controls whether to set {@linkplain Task#isTransferred() isTransferred}
+   *     or not
+   * @return BulkResult with {@linkplain Task#getId() ids} and Error for each failed transactions
+   * @throws NotAuthorizedOnWorkbasketException if the current user has no {@linkplain
+   *     WorkbasketPermission#READ} for the source {@linkplain Workbasket} or no {@linkplain
+   *     WorkbasketPermission#TRANSFER} for the target {@linkplain Workbasket}
+   * @throws InvalidArgumentException if the method parameters are empty or NULL
+   * @throws WorkbasketNotFoundException if the target {@linkplain Workbasket} can't be found
+   */
+  BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      String destinationWorkbasketKey,
+      String destinationWorkbasketDomain,
+      List<String> taskIds,
+      String owner,
+      boolean setTransferFlag)
+      throws InvalidArgumentException,
+          WorkbasketNotFoundException,
+          NotAuthorizedOnWorkbasketException;
+
+  /**
    * Update a {@linkplain Task}.
    *
    * @param task the {@linkplain Task} to be updated

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskServiceImpl.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskServiceImpl.java
@@ -632,6 +632,30 @@ public class TaskServiceImpl implements TaskService {
   }
 
   @Override
+  public BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      String destinationWorkbasketId, List<String> taskIds, String owner, boolean setTransferFlag)
+      throws InvalidArgumentException,
+          WorkbasketNotFoundException,
+          NotAuthorizedOnWorkbasketException {
+    return taskTransferrer.transferTasksWithOwner(
+        taskIds, destinationWorkbasketId, owner, setTransferFlag);
+  }
+
+  @Override
+  public BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      String destinationWorkbasketKey,
+      String destinationWorkbasketDomain,
+      List<String> taskIds,
+      String owner,
+      boolean setTransferFlag)
+      throws InvalidArgumentException,
+          WorkbasketNotFoundException,
+          NotAuthorizedOnWorkbasketException {
+    return taskTransferrer.transferTasksWithOwner(
+        taskIds, destinationWorkbasketKey, destinationWorkbasketDomain, owner, setTransferFlag);
+  }
+
+  @Override
   public void deleteTask(String taskId)
       throws TaskNotFoundException,
           NotAuthorizedException,

--- a/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskTransferrer.java
+++ b/lib/taskana-core/src/main/java/pro/taskana/task/internal/TaskTransferrer.java
@@ -86,7 +86,7 @@ final class TaskTransferrer {
         workbasketService.getWorkbasket(destinationWorkbasketId).asSummary();
     checkDestinationWorkbasket(destinationWorkbasket);
 
-    return transferMultipleTasks(taskIds, destinationWorkbasket, setTransferFlag);
+    return transferMultipleTasks(taskIds, destinationWorkbasket, null, setTransferFlag);
   }
 
   BulkOperationResults<String, TaskanaException> transfer(
@@ -101,7 +101,35 @@ final class TaskTransferrer {
         workbasketService.getWorkbasket(destinationWorkbasketKey, destinationDomain).asSummary();
     checkDestinationWorkbasket(destinationWorkbasket);
 
-    return transferMultipleTasks(taskIds, destinationWorkbasket, setTransferFlag);
+    return transferMultipleTasks(taskIds, destinationWorkbasket, null, setTransferFlag);
+  }
+
+  BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      List<String> taskIds, String destinationWorkbasketId, String owner, boolean setTransferFlag)
+      throws WorkbasketNotFoundException,
+          InvalidArgumentException,
+          NotAuthorizedOnWorkbasketException {
+    WorkbasketSummary destinationWorkbasket =
+        workbasketService.getWorkbasket(destinationWorkbasketId).asSummary();
+    checkDestinationWorkbasket(destinationWorkbasket);
+
+    return transferMultipleTasks(taskIds, destinationWorkbasket, owner, setTransferFlag);
+  }
+
+  BulkOperationResults<String, TaskanaException> transferTasksWithOwner(
+      List<String> taskIds,
+      String destinationWorkbasketKey,
+      String destinationDomain,
+      String owner,
+      boolean setTransferFlag)
+      throws WorkbasketNotFoundException,
+          InvalidArgumentException,
+          NotAuthorizedOnWorkbasketException {
+    WorkbasketSummary destinationWorkbasket =
+        workbasketService.getWorkbasket(destinationWorkbasketKey, destinationDomain).asSummary();
+    checkDestinationWorkbasket(destinationWorkbasket);
+
+    return transferMultipleTasks(taskIds, destinationWorkbasket, owner, setTransferFlag);
   }
 
   private Task transferSingleTask(
@@ -120,7 +148,7 @@ final class TaskTransferrer {
       WorkbasketSummary originWorkbasket = task.getWorkbasketSummary();
       checkPreconditionsForTransferTask(task, destinationWorkbasket, originWorkbasket);
 
-      applyTransferValuesForTask(task, destinationWorkbasket, setTransferFlag);
+      applyTransferValuesForTask(task, destinationWorkbasket, null, setTransferFlag);
       taskMapper.update(task);
       if (historyEventManager.isEnabled()) {
         createTransferredEvent(
@@ -136,6 +164,7 @@ final class TaskTransferrer {
   private BulkOperationResults<String, TaskanaException> transferMultipleTasks(
       List<String> taskToBeTransferred,
       WorkbasketSummary destinationWorkbasket,
+      String owner,
       boolean setTransferFlag)
       throws InvalidArgumentException {
     if (taskToBeTransferred == null || taskToBeTransferred.isEmpty()) {
@@ -154,7 +183,7 @@ final class TaskTransferrer {
                   () -> taskService.createTaskQuery().idIn(taskIds.toArray(new String[0])).list());
       taskSummaries =
           filterOutTasksWhichDoNotMatchTransferCriteria(taskIds, taskSummaries, bulkLog);
-      updateTransferableTasks(taskSummaries, destinationWorkbasket, setTransferFlag);
+      updateTransferableTasks(taskSummaries, destinationWorkbasket, owner, setTransferFlag);
 
       return bulkLog;
     } finally {
@@ -254,6 +283,7 @@ final class TaskTransferrer {
   private void updateTransferableTasks(
       List<TaskSummary> taskSummaries,
       WorkbasketSummary destinationWorkbasket,
+      String owner,
       boolean setTransferFlag) {
     Map<TaskState, List<TaskSummary>> summariesByState = groupTasksByState(taskSummaries);
     for (Map.Entry<TaskState, List<TaskSummary>> entry : summariesByState.entrySet()) {
@@ -262,7 +292,7 @@ final class TaskTransferrer {
       if (!taskSummariesWithSameGoalState.isEmpty()) {
         TaskImpl updateObject = new TaskImpl();
         updateObject.setState(goalState);
-        applyTransferValuesForTask(updateObject, destinationWorkbasket, setTransferFlag);
+        applyTransferValuesForTask(updateObject, destinationWorkbasket, owner, setTransferFlag);
         taskMapper.updateTransfered(
             taskSummariesWithSameGoalState.stream()
                 .map(TaskSummary::getId)
@@ -275,7 +305,8 @@ final class TaskTransferrer {
                 TaskSummaryImpl newSummary = (TaskSummaryImpl) oldSummary.copy();
                 newSummary.setId(oldSummary.getId());
                 newSummary.setExternalId(oldSummary.getExternalId());
-                applyTransferValuesForTask(newSummary, destinationWorkbasket, setTransferFlag);
+                applyTransferValuesForTask(
+                    newSummary, destinationWorkbasket, owner, setTransferFlag);
 
                 createTransferredEvent(
                     oldSummary,
@@ -289,11 +320,11 @@ final class TaskTransferrer {
   }
 
   private void applyTransferValuesForTask(
-      TaskSummaryImpl task, WorkbasketSummary workbasket, boolean setTransferFlag) {
+      TaskSummaryImpl task, WorkbasketSummary workbasket, String owner, boolean setTransferFlag) {
     task.setRead(false);
     task.setTransferred(setTransferFlag);
     task.setState(getStateAfterTransfer(task));
-    task.setOwner(null);
+    task.setOwner(owner);
     task.setWorkbasketSummary(workbasket);
     task.setDomain(workbasket.getDomain());
     task.setModified(Instant.now());

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/RestEndpoints.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/common/rest/RestEndpoints.java
@@ -60,6 +60,7 @@ public final class RestEndpoints {
   public static final String URL_TASKS_ID_TERMINATE = API_V1 + "tasks/{taskId}/terminate";
   public static final String URL_TASKS_ID_TRANSFER_WORKBASKET_ID =
       API_V1 + "tasks/{taskId}/transfer/{workbasketId}";
+  public static final String URL_TRANSFER_WORKBASKET_ID = API_V1 + "tasks/transfer/{workbasketId}";
   public static final String URL_TASKS_ID_SET_READ = API_V1 + "tasks/{taskId}/set-read";
 
   // task comment endpoints

--- a/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/models/TransferTaskRepresentationModel.java
+++ b/rest/taskana-rest-spring/src/main/java/pro/taskana/task/rest/models/TransferTaskRepresentationModel.java
@@ -1,0 +1,40 @@
+package pro.taskana.task.rest.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+public class TransferTaskRepresentationModel {
+
+  /** The value to set the Task property owner. */
+  @JsonProperty("owner")
+  private final String owner;
+
+  /** The value to set the Task property setTransferFlag. */
+  @JsonProperty("setTransferFlag")
+  private final Boolean setTransferFlag;
+
+  /** The value to set the Task property taskIds. */
+  @JsonProperty("taskIds")
+  private final List<String> taskIds;
+
+  @ConstructorProperties({"setTransferFlag", "owner", "taskIds"})
+  public TransferTaskRepresentationModel(
+      Boolean setTransferFlag, String owner, List<String> taskIds) {
+    this.setTransferFlag = setTransferFlag == null || setTransferFlag;
+    this.owner = owner;
+    this.taskIds = taskIds;
+  }
+
+  public Boolean getSetTransferFlag() {
+    return setTransferFlag;
+  }
+
+  public String getOwner() {
+    return owner;
+  }
+
+  public List<String> getTaskIds() {
+    return taskIds;
+  }
+}

--- a/rest/taskana-rest-spring/src/test/java/pro/taskana/task/rest/TaskControllerRestDocTest.java
+++ b/rest/taskana-rest-spring/src/test/java/pro/taskana/task/rest/TaskControllerRestDocTest.java
@@ -5,6 +5,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,7 @@ import pro.taskana.task.internal.models.ObjectReferenceImpl;
 import pro.taskana.task.rest.assembler.TaskRepresentationModelAssembler;
 import pro.taskana.task.rest.models.IsReadRepresentationModel;
 import pro.taskana.task.rest.models.TaskRepresentationModel;
+import pro.taskana.task.rest.models.TransferTaskRepresentationModel;
 import pro.taskana.testapi.security.JaasExtension;
 import pro.taskana.testapi.security.WithAccessId;
 
@@ -242,6 +244,22 @@ class TaskControllerRestDocTest extends BaseRestDocTest {
         .perform(
             put(RestEndpoints.URL_TASKS_ID, task.getId())
                 .content(objectMapper.writeValueAsString(repModel)))
+        .andExpect(MockMvcResultMatchers.status().isOk());
+  }
+
+  @Test
+  void transferTasksDocTest() throws Exception {
+    List<String> taskIds =
+        List.of(
+            "TKI:000000000000000000000000000000000000", "TKI:000000000000000000000000000000000001");
+    TransferTaskRepresentationModel transferTaskRepresentationModel =
+        new TransferTaskRepresentationModel(true, "user-1-1", taskIds);
+    mockMvc
+        .perform(
+            post(
+                    RestEndpoints.URL_TRANSFER_WORKBASKET_ID,
+                    "WBI:100000000000000000000000000000000001")
+                .content(objectMapper.writeValueAsString(transferTaskRepresentationModel)))
         .andExpect(MockMvcResultMatchers.status().isOk());
   }
 }


### PR DESCRIPTION
https://sonarcloud.io/summary/new_code?id=jamesrdi_taskana&branch=TSK-2496
<!-- if needed please write above the given line -->
---
Release Notes:
<!-- Please write your release notes between ```-->
```

```
<!-- please don't delete/modify the checklist --> 
### For the submitter:
- [x] I updated the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) and will supply links to the specific files
- [ ] I did not update the [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview)
- [x] I included a link to the [SonarCloud branch analysis](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1019969636/SonarCloud+Integration)
- [ ] After integration of the PR, I added a description of changes on the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [x] I did not update the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana)
- [ ] I put the ticket in review
- [ ] After integration of the pull request, I verified our [bluemix test environment](http://taskana.mybluemix.net/taskana) is not broken

### Verified by the reviewer:
- [ ] Commit message format → (Closes) #&lt;Issue Number&gt;: Your commit message.
- [ ] Submitter's update to [documentation](https://taskana.atlassian.net/wiki/spaces/TAS/overview) is sufficient
- [ ] SonarCloud analysis meets our standards
- [ ] Update of the [current release notes](https://taskana.atlassian.net/wiki/spaces/TAS/pages/1281392672/Current+Release+Notes+Taskana) reflects changes
- [ ] PR fulfills the ticket
- [ ] Edge cases and unwanted side effects are tested
- [ ] Readability
